### PR TITLE
Fix restores not working after cluster bootstrap

### DIFF
--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -11,10 +11,6 @@ spec:
   dependsOn:
     - name: multus-networks
       namespace: network
-    - name: csi-driver-nfs
-      namespace: kube-system
-    - name: onepassword
-      namespace: external-secrets
     - name: volsync
       namespace: volsync-system
   interval: 1h

--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -15,6 +15,8 @@ spec:
       namespace: kube-system
     - name: onepassword
       namespace: external-secrets
+    - name: volsync
+      namespace: volsync-system
   interval: 1h
   path: ./kubernetes/apps/media/qbittorrent/app
   postBuild:
@@ -28,4 +30,4 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: media
-  wait: false
+  wait: true

--- a/kubernetes/apps/media/qui/ks.yaml
+++ b/kubernetes/apps/media/qui/ks.yaml
@@ -11,10 +11,6 @@ spec:
   dependsOn:
     - name: multus-networks
       namespace: network
-    - name: csi-driver-nfs
-      namespace: kube-system
-    - name: onepassword
-      namespace: external-secrets
     - name: volsync
       namespace: volsync-system
   interval: 1h

--- a/kubernetes/apps/media/qui/ks.yaml
+++ b/kubernetes/apps/media/qui/ks.yaml
@@ -15,6 +15,8 @@ spec:
       namespace: kube-system
     - name: onepassword
       namespace: external-secrets
+    - name: volsync
+      namespace: volsync-system
   interval: 1h
   path: ./kubernetes/apps/media/qui/app
   postBuild:
@@ -27,4 +29,4 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: media
-  wait: false
+  wait: true

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -24,4 +24,4 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: observability
-  wait: false
+  wait: true

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -28,8 +28,6 @@ spec:
     - name: grafana
     - name: csi-driver-nfs
       namespace: kube-system
-    - name: onepassword
-      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/observability/grafana/instance
   prune: true

--- a/kubernetes/apps/volsync-system/garage/ks.yaml
+++ b/kubernetes/apps/volsync-system/garage/ks.yaml
@@ -11,8 +11,6 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: volsync
-    - name: onepassword
-      namespace: external-secrets
 #  components:
 #    - ../../../../components/gatus/guarded
   interval: 1h
@@ -42,8 +40,6 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: volsync
-    - name: onepassword
-      namespace: external-secrets
 #      namespace: external-secrets
 #  components:
 #    - ../../../../components/ext-auth

--- a/kubernetes/apps/volsync-system/kopia/ks.yaml
+++ b/kubernetes/apps/volsync-system/kopia/ks.yaml
@@ -10,8 +10,6 @@ spec:
     - ../../../../components/nfs-scaler
   dependsOn:
     - name: volsync
-    - name: onepassword
-      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/volsync-system/kopia/app
   postBuild:

--- a/kubernetes/apps/volsync-system/volsync/ks.yaml
+++ b/kubernetes/apps/volsync-system/volsync/ks.yaml
@@ -30,8 +30,6 @@ metadata:
 spec:
   dependsOn:
     - name: volsync
-    - name: onepassword
-      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/volsync-system/volsync/maintenance
   prune: true


### PR DESCRIPTION
Changes Made
1. Media Apps (qbittorrent, qui)

- Before: multus-networks, csi-driver-nfs, onepassword, volsync
+ After:  multus-networks, volsync

✅ Removed csi-driver-nfs and onepassword (inherited via volsync)

2. Grafana Instance

- Before: grafana, csi-driver-nfs, onepassword
+ After:  grafana, csi-driver-nfs

✅ Removed onepassword (inherited via grafana)

3. Volsync Apps (garage, garage-webui, kopia, volsync-maintenance)

- Before: volsync, onepassword
+ After:  volsync

✅ Removed onepassword (inherited via volsync)

Dependency Chain Structure
Now the dependencies follow a clean hierarchical pattern:

Foundation Layer:
├── snapshot-controller
├── external-secrets
├── flux-operator
└── openebs

Infrastructure Layer:
├── onepassword → external-secrets
├── csi-driver-nfs → snapshot-controller
└── volsync → snapshot-controller, csi-driver-nfs, onepassword

Application Layer:
├── qbittorrent/qui → multus-networks, volsync
├── gatus → volsync
├── garage/kopia → volsync
└── grafana-instance → grafana, csi-driver-nfs

Benefits
✨ Clearer intent - Each app declares only what it directly needs
✨ Easier maintenance - Changes to base dependencies propagate automatically
✨ Less duplication - Removed 18 redundant dependency entries
✨ Better readability - Dependency graph is now more logical