### PR TITLE
feat: add Discord notifications for Flux alerts

### DIFF
--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 namespace: flux-system
 
 components:
+  - ../../components/alerts
   - ../../components/sops
 
 resources:

--- a/kubernetes/components/alerts/discord/alert.yaml
+++ b/kubernetes/components/alerts/discord/alert.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/notification.toolkit.fluxcd.io/alert_v1beta3.json
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: discord
+spec:
+  providerRef:
+    name: discord
+  eventSeverity: error
+  eventSources:
+    - kind: FluxInstance
+      name: "*"
+    - kind: GitRepository
+      name: "*"
+    - kind: HelmRelease
+      name: "*"
+    - kind: HelmRepository
+      name: "*"
+    - kind: Kustomization
+      name: "*"
+    - kind: OCIRepository
+      name: "*"
+  exclusionList:
+    - error.*lookup.*github
+    - dial.*tcp.*timeout
+    - waiting.*socket
+  suspend: false

--- a/kubernetes/components/alerts/discord/externalsecret.yaml
+++ b/kubernetes/components/alerts/discord/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: discord-webhook
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: discord-webhook-secret
+    template:
+      data:
+        address: "{{ .DISCORD_WEBHOOK_URL }}"
+  dataFrom:
+    - extract:
+        key: flux

--- a/kubernetes/components/alerts/discord/kustomization.yaml
+++ b/kubernetes/components/alerts/discord/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./alert.yaml
+  - ./externalsecret.yaml
+  - ./provider.yaml

--- a/kubernetes/components/alerts/discord/provider.yaml
+++ b/kubernetes/components/alerts/discord/provider.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/notification.toolkit.fluxcd.io/provider_v1beta3.json
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: discord
+spec:
+  type: discord
+  channel: flux-notifications
+  secretRef:
+    name: discord-webhook-secret

--- a/kubernetes/components/alerts/kustomization.yaml
+++ b/kubernetes/components/alerts/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
 resources:
   - ./alertmanager
+  - ./discord
   - ./github-status


### PR DESCRIPTION
Implements Discord notification integration for Kubernetes/Flux alerts:
- Add Discord provider with webhook secret reference
- Configure alert resource to monitor all Flux resources (GitRepository, HelmRelease, Kustomization, etc.)
- Set up ExternalSecret to pull Discord webhook from 1Password
- Enable alerts component in flux-system namespace
- Filter common false positives (GitHub DNS lookups, TCP timeouts)

The Discord webhook URL must be added to 1Password under the 'flux' key as 'DISCORD_WEBHOOK_URL'.