### PR TITLE
fix: remove unsupported event sources from Discord alert

### DIFF
--- a/kubernetes/components/alerts/discord/alert.yaml
+++ b/kubernetes/components/alerts/discord/alert.yaml
@@ -21,12 +21,6 @@ spec:
       name: "*"
     - kind: OCIRepository
       name: "*"
-    - kind: TalosUpgrade
-      name: "*"
-      namespace: system-upgrade
-    - kind: KubernetesUpgrade
-      name: "*"
-      namespace: system-upgrade
   exclusionList:
     - error.*lookup.*github
     - dial.*tcp.*timeout


### PR DESCRIPTION
Remove TalosUpgrade and KubernetesUpgrade from Discord alert event sources as they are not supported by Flux notification controller.

Flux only supports these resource kinds:
- Bucket, GitRepository, Kustomization
- HelmRelease, HelmChart, HelmRepository
- ImageRepository, ImagePolicy, ImageUpdateAutomation
- OCIRepository, FluxInstance
- ResourceSet, ResourceSetInputProvider

The tuppr HelmRelease itself will still be monitored for failures.