### PR TITLE
Check Flux Git source status

### DIFF
--- a/kubernetes/apps/external-secrets/discord-webhook/app/externalsecret.yaml
+++ b/kubernetes/apps/external-secrets/discord-webhook/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: discord-webhook
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: discord-webhook-secret
+    template:
+      data:
+        address: "{{ .DISCORD_WEBHOOK_URL }}"
+  dataFrom:
+    - extract:
+        key: flux

--- a/kubernetes/apps/external-secrets/discord-webhook/app/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/discord-webhook/app/kustomization.yaml
@@ -2,6 +2,6 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: default
 resources:
-  - ./alert.yaml
-  - ./provider.yaml
+  - ./externalsecret.yaml

--- a/kubernetes/apps/external-secrets/discord-webhook/ks.yaml
+++ b/kubernetes/apps/external-secrets/discord-webhook/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: discord-webhook
+spec:
+  dependsOn:
+    - name: onepassword
+  interval: 1h
+  path: ./kubernetes/apps/external-secrets/discord-webhook/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: true

--- a/kubernetes/apps/external-secrets/kustomization.yaml
+++ b/kubernetes/apps/external-secrets/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./namespace.yaml
   - ./external-secrets/ks.yaml
   - ./onepassword/ks.yaml
+  - ./discord-webhook/ks.yaml


### PR DESCRIPTION
Move the discord-webhook ExternalSecret from the alerts component to a dedicated Flux Kustomization that depends on the onepassword ClusterSecretStore.

This fixes the cluster-apps reconciliation error where the ExternalSecret CRD was not available during dry-run because external-secrets operator wasn't installed yet.

Changes:
- Remove externalsecret.yaml from alerts/discord component
- Create new discord-webhook app under external-secrets namespace
- Add Flux Kustomization with dependsOn: onepassword
- Ensures proper ordering: external-secrets -> onepassword -> discord-webhook