### PR TITLE
feat: add external-secrets CRDs to bootstrap

### DIFF
--- a/bootstrap/helmfile.d/00-crds.yaml
+++ b/bootstrap/helmfile.d/00-crds.yaml
@@ -13,6 +13,11 @@ helmDefaults:
     - yq eval-all --exit-status 'select(.kind == "CustomResourceDefinition")'
 
 releases:
+  - name: external-secrets
+    namespace: external-secrets
+    chart: oci://ghcr.io/external-secrets/charts/external-secrets
+    version: 1.2.1
+
   - name: cloudflare-dns
     namespace: network
     chart: oci://ghcr.io/home-operations/charts-mirror/external-dns


### PR DESCRIPTION
Add external-secrets CRDs to the bootstrap helmfile to ensure the ExternalSecret CRDs are available before Flux reconciles cluster-apps.

This prevents dry-run failures when components (alerts, volsync) include ExternalSecret resources. The CRDs will be installed during bootstrap, while the external-secrets operator and onepassword ClusterSecretStore will be managed by Flux with proper dependency ordering.

Bootstrap order:
1. Bootstrap installs external-secrets CRDs (this change)
2. Flux reconciles external-secrets namespace -> external-secrets operator
3. Flux reconciles onepassword app -> ClusterSecretStore created
4. Flux reconciles ExternalSecrets in various namespaces

This allows components to safely include ExternalSecret resources without causing "no matches for kind ExternalSecret" errors during dry-run.