### PR TITLE
fix: remove external-secrets from CRDs helmfile

### DIFF
--- a/bootstrap/helmfile.d/00-crds.yaml
+++ b/bootstrap/helmfile.d/00-crds.yaml
@@ -13,11 +13,6 @@ helmDefaults:
     - yq eval-all --exit-status 'select(.kind == "CustomResourceDefinition")'
 
 releases:
-  - name: external-secrets
-    namespace: external-secrets
-    chart: oci://ghcr.io/external-secrets/charts/external-secrets
-    version: 1.2.1
-
   - name: cloudflare-dns
     namespace: network
     chart: oci://ghcr.io/home-operations/charts-mirror/external-dns


### PR DESCRIPTION
Remove external-secrets from the CRDs helmfile to avoid Helm ownership conflicts. The external-secrets Helm chart will install its own CRDs with proper Helm metadata when deployed in the apps helmfile.

The issue was:
- Step 3 (apply_crds) installed CRDs via kubectl apply (no Helm metadata)
- Step 4 (sync_helm_releases) tried to install external-secrets chart
- Helm couldn't adopt existing CRDs without proper labels/annotations

Solution:
- Remove external-secrets from 00-crds.yaml
- Let external-secrets chart install its own CRDs in 01-apps.yaml
- CRDs will have proper Helm ownership metadata from the start