### PR TITLE
Fix Prometheus DNS lookup error in observability

### DIFF
--- a/kubernetes/apps/media/qbittorrent/ks.yaml
+++ b/kubernetes/apps/media/qbittorrent/ks.yaml
@@ -9,6 +9,8 @@ spec:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
   dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
     - name: multus-networks
       namespace: network
     - name: volsync

--- a/kubernetes/apps/media/qui/ks.yaml
+++ b/kubernetes/apps/media/qui/ks.yaml
@@ -9,6 +9,8 @@ spec:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
   dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
     - name: multus-networks
       namespace: network
     - name: volsync

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -9,6 +9,8 @@ spec:
     - ../../../../components/nfs-scaler
     - ../../../../components/volsync
   dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
     - name: volsync
       namespace: volsync-system
   interval: 1h

--- a/kubernetes/apps/volsync-system/kopia/ks.yaml
+++ b/kubernetes/apps/volsync-system/kopia/ks.yaml
@@ -9,6 +9,8 @@ spec:
   components:
     - ../../../../components/nfs-scaler
   dependsOn:
+    - name: kube-prometheus-stack
+      namespace: observability
     - name: volsync
   interval: 1h
   path: ./kubernetes/apps/volsync-system/kopia/app


### PR DESCRIPTION
…apps

Applications using the nfs-scaler component were experiencing DNS lookup failures when KEDA tried to query prometheus-operated.observability.svc.cluster.local. This occurred because there was no dependency ensuring Prometheus was deployed before KEDA attempted to scale based on Prometheus metrics.

Added dependsOn clause for kube-prometheus-stack to all Kustomizations using the nfs-scaler component:
- gatus (observability)
- qbittorrent (media)
- qui (media)
- kopia (volsync-system)

This ensures the prometheus-operated service exists before KEDA queries it.