### PR TITLE
Fix missing Discord webhook secret for notifications

### DIFF
--- a/kubernetes/components/alerts/discord/kustomization.yaml
+++ b/kubernetes/components/alerts/discord/kustomization.yaml
@@ -4,4 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./alert.yaml
+  - ./externalsecret.yaml
   - ./provider.yaml


### PR DESCRIPTION
The discord-webhook-secret was missing in namespaces using the alerts component because the externalsecret.yaml was not included in the discord kustomization resources. This caused gatus and other services to fail notification dispatch with "secrets 'discord-webhook-secret' not found".