### PR TITLE
Manual testing guide for Buddy Heart

### DIFF
--- a/kubernetes/apps/observability/gatus/app/resources/buddy.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/buddy.yaml
@@ -27,7 +27,7 @@ endpoints:
 # External endpoint for Alertmanager heartbeat
 # Alertmanager pushes Watchdog alerts here every 2 minutes
 external-endpoints:
-  - name: Alertmanager Heartbeat
+  - name: buddy_heartbeat
     group: buddy
     token: ${BUDDY_HEARTBEAT_TOKEN}
     heartbeat:


### PR DESCRIPTION
Changed external endpoint name from "Alertmanager Heartbeat" to "buddy_heartbeat" to match the URL configured in alertmanager externalsecret.

This fixes the 404 error when Alertmanager tries to send heartbeat webhooks.