### PR TITLE
Fix restore timing issues with concurrent backups

### DIFF
--- a/kubernetes/components/volsync/replicationsource.yaml
+++ b/kubernetes/components/volsync/replicationsource.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   sourcePVC: ${APP}
   trigger:
-    schedule: "*/5 * * * *"
+    schedule: "0 2 * * *"
   kopia:
     accessModes:
       - ${VOLSYNC_SNAP_ACCESSMODES:=ReadWriteOnce}


### PR DESCRIPTION
… 2 AM

Fixes race condition where backups could capture incomplete data during application initialization after restores. By reducing backup frequency from every 5 minutes to once daily at 2 AM, we eliminate the risk of backups running while applications like qui are still initializing their database and configuration after a restore operation.

This prevents the scenario where:
1. Restore completes and app starts
2. App is still initializing (creating user setup pages, reading DB)
3. Scheduled backup fires within 5 minutes
4. Backup captures the incomplete/empty state
5. Good restored data is overwritten

With daily backups at 2 AM, applications have ample time to fully initialize after restores, and the backup schedule aligns with low-activity periods.