### PR TITLE
chore(observability): disable buddy heartbeat monitor and alerts

### DIFF
--- a/kubernetes/apps/observability/gatus/app/resources/buddy.yaml
+++ b/kubernetes/apps/observability/gatus/app/resources/buddy.yaml
@@ -24,13 +24,13 @@ endpoints:
     alerts:
       - type: discord
 
-# External endpoint for Alertmanager heartbeat
+# External endpoint for Alertmanager heartbeat - DISABLED
 # Alertmanager pushes Watchdog alerts here every 2 minutes
-external-endpoints:
-  - name: buddy_heartbeat
-    group: buddy
-    token: ${BUDDY_HEARTBEAT_TOKEN}
-    heartbeat:
-      interval: 5m  # Alert if no heartbeat received in 5 minutes
-    alerts:
-      - type: discord
+#external-endpoints:
+#  - name: buddy_heartbeat
+#    group: buddy
+#    token: ${BUDDY_HEARTBEAT_TOKEN}
+#    heartbeat:
+#      interval: 5m  # Alert if no heartbeat received in 5 minutes
+#    alerts:
+#      - type: discord

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -14,14 +14,6 @@ spec:
           - name: alertname
             value: InfoInhibitor
             matchType: =
-      - receiver: buddy-heartbeat
-        groupInterval: 2m
-        groupWait: 0s
-        repeatInterval: 2m30s
-        matchers:
-          - name: alertname
-            value: Watchdog
-            matchType: =
       - receiver: discord
         matchers:
           - name: severity
@@ -49,15 +41,6 @@ spec:
 
   receivers:
     - name: blackhole
-    - name: buddy-heartbeat
-      webhookConfigs:
-        - httpConfig:
-            bearerTokenSecret:
-              name: alertmanager-secret
-              key: BUDDY_HEARTBEAT_TOKEN
-          urlSecret:
-            name: alertmanager-secret
-            key: BUDDY_HEARTBEAT_URL
     - name: discord
       webhookConfigs:
         - urlSecret:


### PR DESCRIPTION
Disable the buddy heartbeat monitoring system by:
- Commenting out external-endpoints section in Gatus buddy configuration
- Removing buddy-heartbeat route for Watchdog alerts in AlertmanagerConfig
- Removing buddy-heartbeat receiver webhook configuration

This removes the Alertmanager -> Gatus heartbeat integration that monitored the monitoring system itself via Watchdog alert pushes.