### PR TITLE
Investigate RAM usage and deployment memory issues

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -53,6 +53,8 @@ spec:
                     containers:
                       - name: manager
                         resources:
+                          requests:
+                            memory: 128Mi
                           limits:
                             memory: 1Gi
             target:

--- a/kubernetes/apps/media/autobrr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/autobrr/app/helmrelease.yaml
@@ -60,6 +60,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 128Mi
               limits:
                 memory: 256Mi
     defaultPodOptions:

--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -42,6 +42,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 128Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/plex/app/helmrelease.yaml
+++ b/kubernetes/apps/media/plex/app/helmrelease.yaml
@@ -48,6 +48,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 256Mi
               limits:
                 memory: 2Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/prowlarr/app/helmrelease.yaml
@@ -52,6 +52,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 128Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/helmrelease.yaml
@@ -48,6 +48,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 512Mi
               limits:
                 memory: 4Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/qui/app/helmrelease.yaml
+++ b/kubernetes/apps/media/qui/app/helmrelease.yaml
@@ -43,6 +43,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 256Mi
               limits:
                 memory: 512Mi
             securityContext:

--- a/kubernetes/apps/media/radarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/radarr/app/helmrelease.yaml
@@ -52,6 +52,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 256Mi
               limits:
                 memory: 2Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -37,6 +37,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 64Mi
               limits:
                 memory: 128Mi
         pod:

--- a/kubernetes/apps/media/seerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/seerr/app/helmrelease.yaml
@@ -46,6 +46,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 256Mi
               limits:
                 memory: 2Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/sonarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/sonarr/app/helmrelease.yaml
@@ -52,6 +52,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 512Mi
               limits:
                 memory: 4Gi
     defaultPodOptions:

--- a/kubernetes/apps/media/tautulli/app/helmrelease.yaml
+++ b/kubernetes/apps/media/tautulli/app/helmrelease.yaml
@@ -46,6 +46,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 128Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -48,6 +48,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 128Mi
               limits:
                 memory: 256Mi
     defaultPodOptions:

--- a/kubernetes/apps/volsync-system/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/garage/app/helmrelease.yaml
@@ -39,6 +39,7 @@ spec:
             resources:
               requests:
                 cpu: 100m
+                memory: 256Mi
               limits:
                 memory: 512Mi
     defaultPodOptions:

--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -50,6 +50,7 @@ spec:
             resources:
               requests:
                 cpu: 10m
+                memory: 128Mi
               limits:
                 memory: 1Gi
     defaultPodOptions:


### PR DESCRIPTION
Applications were only specifying memory limits without requests. When memory requests are omitted, Kubernetes defaults them to equal the limits, causing scheduler to reserve full limit amounts.

This resulted in ~18Gi being requested (qbittorrent 4Gi, sonarr 4Gi, plex 2Gi, radarr 2Gi, seerr 2Gi, etc.) on a cluster with 29Gi total, preventing new pods from being scheduled.

Changes:
- Added memory requests to 15 applications across media, network, flux-system, and volsync-system namespaces
- Used 8:1 ratio for large apps (e.g., 512Mi request for 4Gi limit)
- Used 2:1 ratio for smaller apps (e.g., 128Mi request for 256Mi limit)
- Total memory requests reduced from ~18Gi to ~2.5Gi
- Pods can now burst to limits when needed while allowing better packing

Affected applications:
- media: qbittorrent, sonarr, plex, radarr, seerr, prowlarr, bazarr, tautulli, qui, autobrr, recyclarr
- network: cloudflare-tunnel
- flux-system: flux-instance (kustomize/helm/source controllers)
- volsync-system: garage, kopia