### PR TITLE
chore(helm): migrate to official cilium OCI chart

### DIFF
--- a/bootstrap/helmfile.d/01-apps.yaml
+++ b/bootstrap/helmfile.d/01-apps.yaml
@@ -8,7 +8,7 @@ helmDefaults:
 releases:
   - name: cilium
     namespace: kube-system
-    chart: oci://ghcr.io/home-operations/charts-mirror/cilium
+    chart: oci://quay.io/cilium/charts/cilium
     version: 1.18.6
     values: ['./templates/values.yaml.gotmpl']
 

--- a/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
@@ -10,4 +10,4 @@ spec:
     operation: copy
   ref:
     tag: 1.18.6
-  url: oci://ghcr.io/home-operations/charts-mirror/cilium
+  url: oci://quay.io/cilium/charts/cilium

--- a/templates/config/bootstrap/helmfile.d/01-apps.yaml.j2
+++ b/templates/config/bootstrap/helmfile.d/01-apps.yaml.j2
@@ -8,7 +8,7 @@ helmDefaults:
 releases:
   - name: cilium
     namespace: kube-system
-    chart: oci://ghcr.io/home-operations/charts-mirror/cilium
+    chart: oci://quay.io/cilium/charts/cilium
     version: 1.18.6
     values: ['./templates/values.yaml.gotmpl']
 

--- a/templates/config/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml.j2
+++ b/templates/config/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml.j2
@@ -10,4 +10,4 @@ spec:
     operation: copy
   ref:
     tag: 1.18.6
-  url: oci://ghcr.io/home-operations/charts-mirror/cilium
+  url: oci://quay.io/cilium/charts/cilium


### PR DESCRIPTION
Migrate Cilium chart from the mirrored repository at ghcr.io/home-operations/charts-mirror/cilium
to the official Cilium OCI chart at quay.io/cilium/charts/cilium.

This change affects both the bootstrap helmfile and the Flux OCI repository configuration.

https://claude.ai/code/session_01VDTu1JYamZFxjWbVWvYfXx