### PR TITLE
feat(cert-manager): implement short-lived Let's Encrypt certificates

### DIFF
--- a/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml
@@ -5,6 +5,7 @@ metadata:
   name: letsencrypt-production
 spec:
   acme:
+    profile: shortlived
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: letsencrypt-production

--- a/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml
@@ -5,10 +5,10 @@ metadata:
   name: letsencrypt-production
 spec:
   acme:
-    profile: shortlived
-    server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: letsencrypt-production
+    profile: shortlived
+    server: https://acme-v02.api.letsencrypt.org/directory
     solvers:
       - dns01:
           cloudflare:

--- a/kubernetes/apps/network/envoy-gateway/app/certificate.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/certificate.yaml
@@ -4,14 +4,15 @@ kind: Certificate
 metadata:
   name: "${SECRET_DOMAIN/./-}-production"
 spec:
-  secretName: "${SECRET_DOMAIN/./-}-production-tls"
+  dnsNames:
+    - "${SECRET_DOMAIN}"
+    - "*.${SECRET_DOMAIN}"
+  duration: 160h
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: "${SECRET_DOMAIN}"
-  dnsNames: ["${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"]
-  duration: 160h
   privateKey:
     algorithm: ECDSA
+  secretName: "${SECRET_DOMAIN/./-}-production-tls"
   usages:
     - digital signature

--- a/kubernetes/apps/network/envoy-gateway/app/certificate.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/certificate.yaml
@@ -10,3 +10,8 @@ spec:
     kind: ClusterIssuer
   commonName: "${SECRET_DOMAIN}"
   dnsNames: ["${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"]
+  duration: 160h
+  privateKey:
+    algorithm: ECDSA
+  usages:
+    - digital signature

--- a/templates/config/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml.j2
+++ b/templates/config/kubernetes/apps/cert-manager/cert-manager/app/clusterissuer.yaml.j2
@@ -5,6 +5,7 @@ metadata:
   name: letsencrypt-production
 spec:
   acme:
+    profile: shortlived
     server: https://acme-v02.api.letsencrypt.org/directory
     privateKeySecretRef:
       name: letsencrypt-production

--- a/templates/config/kubernetes/apps/network/envoy-gateway/app/certificate.yaml.j2
+++ b/templates/config/kubernetes/apps/network/envoy-gateway/app/certificate.yaml.j2
@@ -4,14 +4,15 @@ kind: Certificate
 metadata:
   name: "${SECRET_DOMAIN/./-}-production"
 spec:
-  secretName: "${SECRET_DOMAIN/./-}-production-tls"
+  dnsNames:
+    - "${SECRET_DOMAIN}"
+    - "*.${SECRET_DOMAIN}"
+  duration: 160h
   issuerRef:
     name: letsencrypt-production
     kind: ClusterIssuer
-  commonName: "${SECRET_DOMAIN}"
-  dnsNames: ["${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"]
-  duration: 160h
   privateKey:
     algorithm: ECDSA
+  secretName: "${SECRET_DOMAIN/./-}-production-tls"
   usages:
     - digital signature

--- a/templates/config/kubernetes/apps/network/envoy-gateway/app/certificate.yaml.j2
+++ b/templates/config/kubernetes/apps/network/envoy-gateway/app/certificate.yaml.j2
@@ -10,3 +10,8 @@ spec:
     kind: ClusterIssuer
   commonName: "${SECRET_DOMAIN}"
   dnsNames: ["${SECRET_DOMAIN}", "*.${SECRET_DOMAIN}"]
+  duration: 160h
+  privateKey:
+    algorithm: ECDSA
+  usages:
+    - digital signature


### PR DESCRIPTION
- Add profile: shortlived to ClusterIssuer for 6-day certificates
- Update certificate duration to 160h (6.67 days)
- Configure ECDSA private key algorithm
- Set digital signature usage for certificate

https://claude.ai/code/session_012GKm5sry7AgS5g2dPMMVPT