### PR TITLE
Add CloudNative-PG and Dragonfly database operators

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/helmrelease.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cloudnative-pg
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: cloudnative-pg
+  interval: 1h
+  values:
+    crds:
+      create: true
+    monitoring:
+      podMonitorEnabled: true

--- a/kubernetes/apps/database/cloudnative-pg/app/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/database/cloudnative-pg/app/ocirepository.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.27.0
+  url: oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/database/cloudnative-pg/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  wait: false

--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dragonfly-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: dragonfly-operator
+  interval: 1h
+  values:
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi

--- a/kubernetes/apps/database/dragonfly/app/kustomization.yaml
+++ b/kubernetes/apps/database/dragonfly/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/database/dragonfly/app/ocirepository.yaml
+++ b/kubernetes/apps/database/dragonfly/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dragonfly-operator
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v1.1.10
+  url: oci://ghcr.io/dragonflydb/dragonfly-operator/helm/dragonfly-operator

--- a/kubernetes/apps/database/dragonfly/ks.yaml
+++ b/kubernetes/apps/database/dragonfly/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dragonfly
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/database/dragonfly/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  wait: false

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: database
+
+components:
+  - ../../components/alerts
+  - ../../components/sops
+
+resources:
+  - ./namespace.yaml
+  - ./cloudnative-pg/ks.yaml
+  - ./dragonfly/ks.yaml

--- a/kubernetes/apps/database/namespace.yaml
+++ b/kubernetes/apps/database/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: database
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled


### PR DESCRIPTION
## Summary
This PR introduces two new database operators to the Kubernetes cluster: CloudNative-PG (PostgreSQL operator) and Dragonfly (in-memory datastore operator). Both are deployed via Flux CD using Helm charts from OCI repositories.

## Key Changes
- **CloudNative-PG Operator**: Added Helm release configuration for CloudNative-PG v0.27.0 with CRD creation and Prometheus monitoring enabled
- **Dragonfly Operator**: Added Helm release configuration for Dragonfly Operator v1.1.10 with resource requests/limits configured
- **Database Namespace**: Created new `database` namespace with Flux pruning disabled to prevent accidental deletion
- **Flux Integration**: Added Kustomization resources for both operators to be managed by Flux CD with 1-hour sync intervals
- **OCI Repository Sources**: Configured OCIRepository resources for both operators pulling from GHCR with 15-minute refresh intervals
- **Components**: Integrated alerts and SOPS encryption components into the database namespace

## Implementation Details
- Both operators use Flux CD v2 HelmRelease API with OCIRepository chart sources
- CloudNative-PG enables pod monitoring for Prometheus integration
- Dragonfly operator has conservative resource limits (256Mi memory max) suitable for operator workloads
- All resources target the `database` namespace with pruning enabled at the Kustomization level
- YAML schema validation configured for IDE support via language server directives

https://claude.ai/code/session_01KQFLv71NB5uQhtkdTwaVau