### PR TITLE
feat(kubernetes): add PostgreSQL cluster and Penpot application

### DIFF
--- a/.taskfiles/bootstrap/Taskfile.yaml
+++ b/.taskfiles/bootstrap/Taskfile.yaml
@@ -28,3 +28,18 @@ tasks:
       - test -f {{.ROOT_DIR}}/.sops.yaml
       - test -f {{.SCRIPTS_DIR}}/bootstrap-apps.sh
       - test -f {{.SOPS_AGE_KEY_FILE}}
+
+  postgres-recovery:
+    desc: Restore PostgreSQL from Garage S3 backup (run after bootstrap:apps, before Flux deploys postgres16-cluster)
+    cmds:
+      - kubectl create namespace database --dry-run=client -o yaml | kubectl apply -f -
+      - echo "Waiting for onepassword ClusterSecretStore..."
+      - until kubectl get clustersecretstore onepassword -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep -q "True"; do sleep 5; done
+      - echo "Applying PostgreSQL recovery manifest..."
+      - kubectl apply -k {{.KUBERNETES_DIR}}/apps/database/cloudnative-pg/recovery/
+      - echo "Waiting for PostgreSQL cluster to be ready..."
+      - until kubectl -n database get cluster postgres16 -o jsonpath='{.status.phase}' 2>/dev/null | grep -q "Cluster in healthy state"; do sleep 10; done
+      - echo "PostgreSQL restored successfully. Flux will now manage the cluster."
+    preconditions:
+      - test -f {{.KUBECONFIG}}
+      - test -d {{.KUBERNETES_DIR}}/apps/database/cloudnative-pg/recovery

--- a/.taskfiles/bootstrap/Taskfile.yaml
+++ b/.taskfiles/bootstrap/Taskfile.yaml
@@ -30,7 +30,7 @@ tasks:
       - test -f {{.SOPS_AGE_KEY_FILE}}
 
   postgres-recovery:
-    desc: Restore PostgreSQL from Garage S3 backup (run after bootstrap:apps, before Flux deploys postgres17-cluster)
+    desc: Restore PostgreSQL from Garage S3 backup (run after bootstrap:apps, before Flux deploys postgres-cluster)
     cmds:
       - kubectl create namespace database --dry-run=client -o yaml | kubectl apply -f -
       - echo "Waiting for onepassword ClusterSecretStore..."
@@ -38,7 +38,7 @@ tasks:
       - echo "Applying PostgreSQL recovery manifest..."
       - kubectl apply -k {{.KUBERNETES_DIR}}/apps/database/cloudnative-pg/recovery/
       - echo "Waiting for PostgreSQL cluster to be ready..."
-      - until kubectl -n database get cluster postgres17 -o jsonpath='{.status.phase}' 2>/dev/null | grep -q "Cluster in healthy state"; do sleep 10; done
+      - until kubectl -n database get cluster postgres -o jsonpath='{.status.phase}' 2>/dev/null | grep -q "Cluster in healthy state"; do sleep 10; done
       - echo "PostgreSQL restored successfully. Flux will now manage the cluster."
     preconditions:
       - test -f {{.KUBECONFIG}}

--- a/.taskfiles/bootstrap/Taskfile.yaml
+++ b/.taskfiles/bootstrap/Taskfile.yaml
@@ -30,7 +30,7 @@ tasks:
       - test -f {{.SOPS_AGE_KEY_FILE}}
 
   postgres-recovery:
-    desc: Restore PostgreSQL from Garage S3 backup (run after bootstrap:apps, before Flux deploys postgres16-cluster)
+    desc: Restore PostgreSQL from Garage S3 backup (run after bootstrap:apps, before Flux deploys postgres17-cluster)
     cmds:
       - kubectl create namespace database --dry-run=client -o yaml | kubectl apply -f -
       - echo "Waiting for onepassword ClusterSecretStore..."
@@ -38,7 +38,7 @@ tasks:
       - echo "Applying PostgreSQL recovery manifest..."
       - kubectl apply -k {{.KUBERNETES_DIR}}/apps/database/cloudnative-pg/recovery/
       - echo "Waiting for PostgreSQL cluster to be ready..."
-      - until kubectl -n database get cluster postgres16 -o jsonpath='{.status.phase}' 2>/dev/null | grep -q "Cluster in healthy state"; do sleep 10; done
+      - until kubectl -n database get cluster postgres17 -o jsonpath='{.status.phase}' 2>/dev/null | grep -q "Cluster in healthy state"; do sleep 10; done
       - echo "PostgreSQL restored successfully. Flux will now manage the cluster."
     preconditions:
       - test -f {{.KUBECONFIG}}

--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -3,7 +3,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgres17
+  name: postgres
 spec:
   instances: 2
   imageName: ghcr.io/cloudnative-pg/postgresql:17.7-202601260808-system-bullseye

--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/cluster_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres16
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.6-1
+  primaryUpdateStrategy: unsupervised
+
+  storage:
+    size: 20Gi
+    storageClass: openebs-hostpath
+
+  superuserSecret:
+    name: cloudnative-pg-secret
+
+  enableSuperuserAccess: true
+
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: 256MB
+      effective_cache_size: 512MB
+      maintenance_work_mem: 128MB
+      checkpoint_completion_target: "0.9"
+      wal_buffers: 16MB
+      default_statistics_target: "100"
+      random_page_cost: "1.1"
+      effective_io_concurrency: "200"
+      work_mem: 4MB
+      huge_pages: "off"
+      min_wal_size: 1GB
+      max_wal_size: 4GB
+
+  monitoring:
+    enablePodMonitor: true
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 2Gi
+
+  backup:
+    retentionPolicy: 30d
+    barmanObjectStore:
+      destinationPath: s3://cnpg/
+      endpointURL: http://garage.volsync-system.svc.cluster.local:3900
+      s3Credentials:
+        accessKeyId:
+          name: cloudnative-pg-secret
+          key: AWS_ACCESS_KEY_ID
+        secretAccessKey:
+          name: cloudnative-pg-secret
+          key: AWS_SECRET_ACCESS_KEY
+      wal:
+        compression: bzip2
+        maxParallel: 2
+      data:
+        compression: bzip2

--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -3,10 +3,10 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgres16
+  name: postgres17
 spec:
   instances: 2
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.6-1
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.7-202601260808-system-bullseye
   primaryUpdateStrategy: unsupervised
 
   storage:

--- a/kubernetes/apps/database/cloudnative-pg/cluster/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/externalsecret.yaml
@@ -15,10 +15,8 @@ spec:
       data:
         username: postgres
         password: "{{ .POSTGRES_SUPER_PASS }}"
-        AWS_ACCESS_KEY_ID: "{{ .GARAGE_ACCESS_KEY_ID }}"
-        AWS_SECRET_ACCESS_KEY: "{{ .GARAGE_SECRET_ACCESS_KEY }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
   dataFrom:
     - extract:
         key: cloudnative-pg
-    - extract:
-        key: garage

--- a/kubernetes/apps/database/cloudnative-pg/cluster/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: cloudnative-pg
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: cloudnative-pg-secret
+    template:
+      engineVersion: v2
+      data:
+        username: postgres
+        password: "{{ .POSTGRES_SUPER_PASS }}"
+        AWS_ACCESS_KEY_ID: "{{ .GARAGE_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .GARAGE_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: cloudnative-pg
+    - extract:
+        key: garage

--- a/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
@@ -2,12 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: utils
-
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  - ./penpot/ks.yaml
-  - ./smtp-relay/ks.yaml
+  - ./cluster.yaml
+  - ./externalsecret.yaml
+  - ./scheduledbackup.yaml

--- a/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -3,10 +3,10 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: postgres16-backup
+  name: postgres17-backup
 spec:
   schedule: "0 2 * * *"
   backupOwnerReference: self
   cluster:
-    name: postgres16
+    name: postgres17
   immediate: true

--- a/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/scheduledbackup_v1.json
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: postgres16-backup
+spec:
+  schedule: "0 2 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: postgres16
+  immediate: true

--- a/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -3,10 +3,10 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup
 metadata:
-  name: postgres17-backup
+  name: postgres-backup
 spec:
   schedule: "0 2 * * *"
   backupOwnerReference: self
   cluster:
-    name: postgres17
+    name: postgres
   immediate: true

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -19,7 +19,7 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: postgres17-cluster
+  name: postgres-cluster
 spec:
   dependsOn:
     - name: cloudnative-pg

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -19,7 +19,7 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: postgres16-cluster
+  name: postgres17-cluster
 spec:
   dependsOn:
     - name: cloudnative-pg

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -13,4 +13,26 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: database
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: postgres16-cluster
+spec:
+  dependsOn:
+    - name: cloudnative-pg
+    - name: onepassword
+      namespace: external-secrets
+    - name: garage
+      namespace: volsync-system
+  interval: 1h
+  path: ./kubernetes/apps/database/cloudnative-pg/cluster
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
   wait: false

--- a/kubernetes/apps/database/cloudnative-pg/recovery/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/recovery/cluster.yaml
@@ -5,7 +5,7 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgres17
+  name: postgres
   namespace: database
 spec:
   instances: 2
@@ -24,10 +24,10 @@ spec:
   # RECOVERY: Bootstrap from existing Garage S3 backup
   bootstrap:
     recovery:
-      source: postgres17-backup
+      source: postgres-backup
 
   externalClusters:
-    - name: postgres17-backup
+    - name: postgres-backup
       barmanObjectStore:
         destinationPath: s3://cnpg/
         endpointURL: http://garage.volsync-system.svc.cluster.local:3900

--- a/kubernetes/apps/database/cloudnative-pg/recovery/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/recovery/cluster.yaml
@@ -1,0 +1,87 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/postgresql.cnpg.io/cluster_v1.json
+# DISASTER RECOVERY: Apply this during bootstrap to restore from Garage S3 backup
+# Usage: kubectl apply -k kubernetes/apps/database/cloudnative-pg/recovery/
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres16
+  namespace: database
+spec:
+  instances: 2
+  imageName: ghcr.io/cloudnative-pg/postgresql:16.6-1
+  primaryUpdateStrategy: unsupervised
+
+  storage:
+    size: 20Gi
+    storageClass: openebs-hostpath
+
+  superuserSecret:
+    name: cloudnative-pg-secret
+
+  enableSuperuserAccess: true
+
+  # RECOVERY: Bootstrap from existing Garage S3 backup
+  bootstrap:
+    recovery:
+      source: postgres16-backup
+
+  externalClusters:
+    - name: postgres16-backup
+      barmanObjectStore:
+        destinationPath: s3://cnpg/
+        endpointURL: http://garage.volsync-system.svc.cluster.local:3900
+        s3Credentials:
+          accessKeyId:
+            name: cloudnative-pg-secret
+            key: AWS_ACCESS_KEY_ID
+          secretAccessKey:
+            name: cloudnative-pg-secret
+            key: AWS_SECRET_ACCESS_KEY
+        wal:
+          maxParallel: 2
+
+  postgresql:
+    parameters:
+      max_connections: "200"
+      shared_buffers: 256MB
+      effective_cache_size: 512MB
+      maintenance_work_mem: 128MB
+      checkpoint_completion_target: "0.9"
+      wal_buffers: 16MB
+      default_statistics_target: "100"
+      random_page_cost: "1.1"
+      effective_io_concurrency: "200"
+      work_mem: 4MB
+      huge_pages: "off"
+      min_wal_size: 1GB
+      max_wal_size: 4GB
+
+  monitoring:
+    enablePodMonitor: true
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 2Gi
+
+  # Resume backups after recovery
+  backup:
+    retentionPolicy: 30d
+    barmanObjectStore:
+      destinationPath: s3://cnpg/
+      endpointURL: http://garage.volsync-system.svc.cluster.local:3900
+      s3Credentials:
+        accessKeyId:
+          name: cloudnative-pg-secret
+          key: AWS_ACCESS_KEY_ID
+        secretAccessKey:
+          name: cloudnative-pg-secret
+          key: AWS_SECRET_ACCESS_KEY
+      wal:
+        compression: bzip2
+        maxParallel: 2
+      data:
+        compression: bzip2

--- a/kubernetes/apps/database/cloudnative-pg/recovery/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/recovery/cluster.yaml
@@ -5,11 +5,11 @@
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
-  name: postgres16
+  name: postgres17
   namespace: database
 spec:
   instances: 2
-  imageName: ghcr.io/cloudnative-pg/postgresql:16.6-1
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.7-202601260808-system-bullseye
   primaryUpdateStrategy: unsupervised
 
   storage:
@@ -24,10 +24,10 @@ spec:
   # RECOVERY: Bootstrap from existing Garage S3 backup
   bootstrap:
     recovery:
-      source: postgres16-backup
+      source: postgres17-backup
 
   externalClusters:
-    - name: postgres16-backup
+    - name: postgres17-backup
       barmanObjectStore:
         destinationPath: s3://cnpg/
         endpointURL: http://garage.volsync-system.svc.cluster.local:3900

--- a/kubernetes/apps/database/cloudnative-pg/recovery/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/recovery/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+# DISASTER RECOVERY: Not managed by Flux - apply manually during bootstrap
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../cluster/externalsecret.yaml
+  - ./cluster.yaml

--- a/kubernetes/apps/utils/penpot/app/externalsecret.yaml
+++ b/kubernetes/apps/utils/penpot/app/externalsecret.yaml
@@ -14,9 +14,9 @@ spec:
       engineVersion: v2
       data:
         PENPOT_SECRET_KEY: "{{ .PENPOT_SECRET_KEY }}"
-        PENPOT_DATABASE_URI: "postgresql://postgres16-rw.database.svc.cluster.local:5432/{{ .PENPOT_POSTGRES_DB }}"
+        PENPOT_DATABASE_URI: "postgresql://postgres17-rw.database.svc.cluster.local:5432/{{ .PENPOT_POSTGRES_DB }}"
         INIT_POSTGRES_DBNAME: "{{ .PENPOT_POSTGRES_DB }}"
-        INIT_POSTGRES_HOST: postgres16-rw.database.svc.cluster.local
+        INIT_POSTGRES_HOST: postgres17-rw.database.svc.cluster.local
         INIT_POSTGRES_PORT: "5432"
         INIT_POSTGRES_USER: "{{ .PENPOT_POSTGRES_USER }}"
         INIT_POSTGRES_PASS: "{{ .PENPOT_POSTGRES_PASSWORD }}"

--- a/kubernetes/apps/utils/penpot/app/externalsecret.yaml
+++ b/kubernetes/apps/utils/penpot/app/externalsecret.yaml
@@ -14,9 +14,9 @@ spec:
       engineVersion: v2
       data:
         PENPOT_SECRET_KEY: "{{ .PENPOT_SECRET_KEY }}"
-        PENPOT_DATABASE_URI: "postgresql://postgres17-rw.database.svc.cluster.local:5432/{{ .PENPOT_POSTGRES_DB }}"
+        PENPOT_DATABASE_URI: "postgresql://postgres-rw.database.svc.cluster.local:5432/{{ .PENPOT_POSTGRES_DB }}"
         INIT_POSTGRES_DBNAME: "{{ .PENPOT_POSTGRES_DB }}"
-        INIT_POSTGRES_HOST: postgres17-rw.database.svc.cluster.local
+        INIT_POSTGRES_HOST: postgres-rw.database.svc.cluster.local
         INIT_POSTGRES_PORT: "5432"
         INIT_POSTGRES_USER: "{{ .PENPOT_POSTGRES_USER }}"
         INIT_POSTGRES_PASS: "{{ .PENPOT_POSTGRES_PASSWORD }}"

--- a/kubernetes/apps/utils/penpot/app/externalsecret.yaml
+++ b/kubernetes/apps/utils/penpot/app/externalsecret.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: penpot
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: penpot-secret
+    template:
+      engineVersion: v2
+      data:
+        PENPOT_SECRET_KEY: "{{ .PENPOT_SECRET_KEY }}"
+        PENPOT_DATABASE_URI: "postgresql://postgres16-rw.database.svc.cluster.local:5432/{{ .PENPOT_POSTGRES_DB }}"
+        INIT_POSTGRES_DBNAME: "{{ .PENPOT_POSTGRES_DB }}"
+        INIT_POSTGRES_HOST: postgres16-rw.database.svc.cluster.local
+        INIT_POSTGRES_PORT: "5432"
+        INIT_POSTGRES_USER: "{{ .PENPOT_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .PENPOT_POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: penpot
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/utils/penpot/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/penpot/app/helmrelease.yaml
@@ -1,0 +1,78 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: penpot
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: penpot
+      version: 0.6.0
+      sourceRef:
+        kind: HelmRepository
+        name: penpot
+        namespace: flux-system
+  values:
+    global:
+      postgresqlEnabled: false
+      redisEnabled: false
+      valkeyEnabled: true
+
+    config:
+      publicUri: "https://penpot.${SECRET_DOMAIN}"
+      flags: "enable-registration enable-login-with-password disable-email-verification"
+
+      postgresql:
+        host: postgres16-rw.database.svc.cluster.local
+        port: 5432
+        username: penpot
+        database: penpot
+        existingSecret: penpot-secret
+        secretKeys:
+          usernameKey: INIT_POSTGRES_USER
+          passwordKey: INIT_POSTGRES_PASS
+          postgresqlUriKey: PENPOT_DATABASE_URI
+
+      redis:
+        host: penpot-valkey-primary
+        port: 6379
+        database: "0"
+
+    backend:
+      replicaCount: 1
+      env:
+        - name: PENPOT_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: penpot-secret
+              key: PENPOT_SECRET_KEY
+      initContainers:
+        - name: init-db
+          image: ghcr.io/home-operations/postgres-init:18@sha256:3c54d39f19fdb82ed5b3f286450e4071133cc6025bd0e25856bc2c522f8fc030
+          envFrom:
+            - secretRef:
+                name: penpot-secret
+
+    frontend:
+      replicaCount: 1
+
+    exporter:
+      replicaCount: 1
+
+    persistence:
+      assets:
+        enabled: true
+        existingClaim: penpot
+
+    ingress:
+      enabled: true
+      className: envoy-internal
+      annotations:
+        external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+      hosts:
+        - host: "penpot.${SECRET_DOMAIN}"
+          paths:
+            - path: /
+              pathType: Prefix

--- a/kubernetes/apps/utils/penpot/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/penpot/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
       flags: "enable-registration enable-login-with-password disable-email-verification"
 
       postgresql:
-        host: postgres17-rw.database.svc.cluster.local
+        host: postgres-rw.database.svc.cluster.local
         port: 5432
         username: penpot
         database: penpot

--- a/kubernetes/apps/utils/penpot/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/penpot/app/helmrelease.yaml
@@ -20,7 +20,7 @@ spec:
       flags: "enable-registration enable-login-with-password disable-email-verification"
 
       postgresql:
-        host: postgres16-rw.database.svc.cluster.local
+        host: postgres17-rw.database.svc.cluster.local
         port: 5432
         username: penpot
         database: penpot

--- a/kubernetes/apps/utils/penpot/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/penpot/app/helmrelease.yaml
@@ -13,7 +13,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: penpot
-        namespace: flux-system
   values:
     global:
       postgresqlEnabled: false

--- a/kubernetes/apps/utils/penpot/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/penpot/app/helmrelease.yaml
@@ -6,13 +6,9 @@ metadata:
   name: penpot
 spec:
   interval: 1h
-  chart:
-    spec:
-      chart: penpot
-      version: 0.6.0
-      sourceRef:
-        kind: HelmRepository
-        name: penpot
+  chartRef:
+    kind: OCIRepository
+    name: penpot
   values:
     global:
       postgresqlEnabled: false

--- a/kubernetes/apps/utils/penpot/app/helmrepository.yaml
+++ b/kubernetes/apps/utils/penpot/app/helmrepository.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: penpot
+  namespace: flux-system
+spec:
+  interval: 2h
+  type: oci
+  url: oci://ghcr.io/penpot/helm-charts

--- a/kubernetes/apps/utils/penpot/app/helmrepository.yaml
+++ b/kubernetes/apps/utils/penpot/app/helmrepository.yaml
@@ -4,8 +4,6 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: penpot
-  namespace: flux-system
 spec:
-  interval: 2h
-  type: oci
-  url: oci://ghcr.io/penpot/helm-charts
+  interval: 1h
+  url: https://helm.penpot.app/

--- a/kubernetes/apps/utils/penpot/app/helmrepository.yaml
+++ b/kubernetes/apps/utils/penpot/app/helmrepository.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: penpot
-spec:
-  interval: 1h
-  url: https://helm.penpot.app/

--- a/kubernetes/apps/utils/penpot/app/kustomization.yaml
+++ b/kubernetes/apps/utils/penpot/app/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
-  - ./helmrepository.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/utils/penpot/app/kustomization.yaml
+++ b/kubernetes/apps/utils/penpot/app/kustomization.yaml
@@ -2,12 +2,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: utils
-
-components:
-  - ../../components/alerts
-
 resources:
-  - ./namespace.yaml
-  - ./penpot/ks.yaml
-  - ./smtp-relay/ks.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./helmrepository.yaml

--- a/kubernetes/apps/utils/penpot/app/ocirepository.yaml
+++ b/kubernetes/apps/utils/penpot/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: penpot
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.32.0
+  url: oci://ghcr.io/penpot/penpot-helm/penpot

--- a/kubernetes/apps/utils/penpot/ks.yaml
+++ b/kubernetes/apps/utils/penpot/ks.yaml
@@ -15,7 +15,7 @@ spec:
   dependsOn:
     - name: volsync
       namespace: volsync-system
-    - name: postgres17-cluster
+    - name: postgres-cluster
       namespace: database
     - name: onepassword
       namespace: external-secrets

--- a/kubernetes/apps/utils/penpot/ks.yaml
+++ b/kubernetes/apps/utils/penpot/ks.yaml
@@ -15,7 +15,7 @@ spec:
   dependsOn:
     - name: volsync
       namespace: volsync-system
-    - name: postgres16-cluster
+    - name: postgres17-cluster
       namespace: database
     - name: onepassword
       namespace: external-secrets

--- a/kubernetes/apps/utils/penpot/ks.yaml
+++ b/kubernetes/apps/utils/penpot/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app penpot
+  namespace: flux-system
+spec:
+  targetNamespace: utils
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: postgres16-cluster
+      namespace: database
+    - name: onepassword
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/utils/penpot/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 20Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
- Add postgres17 cluster CR for CloudNativePG with:
  - 2 replicas, 20Gi storage, PostgreSQL 16.6
  - Scheduled backups to Garage S3 at 2 AM daily
  - External secret for superuser and S3 credentials
  - Pod monitoring enabled

- Add Penpot design platform with:
  - Fixed configuration to match repo patterns
  - HelmRepository for penpot chart (OCI)
  - Valkey for Redis, external PostgreSQL
  - Volsync for asset persistence (20Gi)
  - Internal ingress via envoy

Dependency chain: cloudnative-pg -> postgres17-cluster -> penpot

https://claude.ai/code/session_01KQFLv71NB5uQhtkdTwaVau