### PR TITLE
fix(kubernetes): add substituteFrom for penpot SECRET_DOMAIN

### DIFF
--- a/kubernetes/apps/utils/penpot/ks.yaml
+++ b/kubernetes/apps/utils/penpot/ks.yaml
@@ -25,6 +25,9 @@ spec:
     substitute:
       APP: *app
       VOLSYNC_CAPACITY: 20Gi
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
Add cluster-secrets substitution to resolve ${SECRET_DOMAIN} variable in ingress host configuration.

https://claude.ai/code/session_01KQFLv71NB5uQhtkdTwaVau