### PR TITLE
Add PENPOT_SECRET_KEY environment variable from Kubernetes secret

### DIFF
--- a/kubernetes/apps/utils/penpot/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/penpot/app/helmrelease.yaml
@@ -117,6 +117,11 @@ spec:
             env:
               PENPOT_PUBLIC_URI: https://penpot.00o.sh
               PENPOT_REDIS_URI: redis://penpot-valkey:6379/0
+              PENPOT_SECRET_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: penpot-secret
+                    key: PENPOT_SECRET_KEY
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
## Summary
Configure the Penpot application to retrieve its secret key from a Kubernetes secret instead of hardcoding it in the HelmRelease manifest.

## Changes
- Added `PENPOT_SECRET_KEY` environment variable to the Penpot container configuration
- Configured the variable to pull its value from a Kubernetes secret named `penpot-secret` with the key `PENPOT_SECRET_KEY`
- Uses `valueFrom.secretKeyRef` to securely reference the secret rather than storing sensitive data in the manifest

## Implementation Details
- The secret must be pre-created in the cluster with the name `penpot-secret` containing the key `PENPOT_SECRET_KEY`
- This follows Kubernetes best practices for handling sensitive configuration data
- The secret reference will be resolved at pod creation time

https://claude.ai/code/session_01224qFGQTdB5nRVafqz8UbN