### PR TITLE
fix(kubevirt): add healthChecks to wait for operators to be ready

### DIFF
--- a/kubernetes/apps/kubevirt/cdi/ks.yaml
+++ b/kubernetes/apps/kubevirt/cdi/ks.yaml
@@ -15,3 +15,8 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: true
+  healthChecks:
+    - apiVersion: cdi.kubevirt.io/v1beta1
+      kind: CDI
+      name: cdi
+      namespace: cdi

--- a/kubernetes/apps/kubevirt/kubevirt/ks.yaml
+++ b/kubernetes/apps/kubevirt/kubevirt/ks.yaml
@@ -17,3 +17,8 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: true
+  healthChecks:
+    - apiVersion: kubevirt.io/v1
+      kind: KubeVirt
+      name: kubevirt
+      namespace: kubevirt


### PR DESCRIPTION
- KubeVirt: wait for KubeVirt CR to be healthy (CRDs registered)
- CDI: wait for CDI CR to be healthy (DataVolume CRD registered)

Ensures ubuntu-server doesn't deploy until VirtualMachine/DataVolume CRDs are available

https://claude.ai/code/session_01CKc1uoauvzTWpifTKuJJaR