### PR TITLE
fix(volsync): guard CEL expression against missing metadata.name

### DIFF
--- a/kubernetes/apps/volsync-system/volsync/maintenance/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/volsync-system/volsync/maintenance/mutatingadmissionpolicy.yaml
@@ -27,7 +27,7 @@ spec:
   matchConditions:
     - name: has-kopia-maint-job-name-prefix
       expression: >
-        object.metadata.name.startsWith("kopia-maint-")
+        has(object.metadata.name) && object.metadata.name.startsWith("kopia-maint-")
     - name: repository-volume-does-not-exist
       expression: >
         !has(object.spec.template.spec.volumes) ||


### PR DESCRIPTION
The kopia-maintenance-nfs MutatingAdmissionPolicy matchCondition was failing with "no such key: name" on resources that don't have metadata.name during admission evaluation. This was blocking KubeVirt operator from creating resources.

https://claude.ai/code/session_01CKc1uoauvzTWpifTKuJJaR