### PR TITLE
fix(kubevirt): use fully qualified NAD reference network/vm

### DIFF
--- a/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
@@ -40,7 +40,7 @@ spec:
       networks:
         - name: lan
           multus:
-            networkName: vm
+            networkName: network/vm
       volumes:
         - name: rootdisk
           dataVolume:


### PR DESCRIPTION
The NetworkAttachmentDefinition 'vm' is in the 'network' namespace, so the networkName must be 'network/vm' for KubeVirt to find it.

https://claude.ai/code/session_01CKc1uoauvzTWpifTKuJJaR