### PR TITLE
fix(multus): enable ips capability for static IPAM runtime config

### DIFF
--- a/kubernetes/apps/network/multus/networks/vm.yaml
+++ b/kubernetes/apps/network/multus/networks/vm.yaml
@@ -14,6 +14,7 @@ spec:
           "type": "macvlan",
           "master": "bond0.57",
           "mode": "bridge",
+          "capabilities": {"ips": true},
           "ipam": {
             "type": "static",
             "routes": [


### PR DESCRIPTION
The static IPAM plugin needs the 'ips' capability enabled to accept IP addresses from pod annotations at runtime.

https://claude.ai/code/session_01CKc1uoauvzTWpifTKuJJaR