### PR TITLE
feat(network): add macvtap-cni for KubeVirt VM networking

### DIFF
--- a/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
@@ -13,9 +13,8 @@ spec:
         kubevirt.io/allow-pod-bridge-network-live-migration: "true"
         k8s.v1.cni.cncf.io/networks: |-
           [{
-            "name": "vm",
+            "name": "vm-macvtap",
             "namespace": "network",
-            "ips": ["192.168.57.10/24"],
             "mac": "52:54:00:57:00:10"
           }]
     spec:
@@ -40,7 +39,7 @@ spec:
       networks:
         - name: lan
           multus:
-            networkName: network/vm
+            networkName: network/vm-macvtap
       volumes:
         - name: rootdisk
           dataVolume:

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -13,5 +13,6 @@ resources:
   - ./cloudflare-tunnel/ks.yaml
   - ./envoy-gateway/ks.yaml
   - ./k8s-gateway/ks.yaml
+  - ./macvtap-cni/ks.yaml
   - ./multus/ks.yaml
   - ./unifi-dns/ks.yaml

--- a/kubernetes/apps/network/macvtap-cni/app/configmap.yaml
+++ b/kubernetes/apps/network/macvtap-cni/app/configmap.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: macvtap-deviceplugin-config
+data:
+  DP_MACVTAP_CONF: '[{"name":"vm","lowerDevice":"bond0.57","mode":"bridge","capacity":10}]'

--- a/kubernetes/apps/network/macvtap-cni/app/kustomization.yaml
+++ b/kubernetes/apps/network/macvtap-cni/app/kustomization.yaml
@@ -4,12 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://raw.githubusercontent.com/kubevirt/macvtap-cni/main/manifests/macvtap.yaml
+  - ./configmap.yaml
   - ./networkattachmentdefinition.yaml
-patches:
-  - patch: |-
-      - op: replace
-        path: /spec/template/spec/containers/0/env/0/value
-        value: '[{"name":"vm","lowerDevice":"bond0.57","mode":"bridge","capacity":10}]'
-    target:
-      kind: DaemonSet
-      name: macvtap-cni

--- a/kubernetes/apps/network/macvtap-cni/app/kustomization.yaml
+++ b/kubernetes/apps/network/macvtap-cni/app/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/kubevirt/macvtap-cni/main/manifests/macvtap.yaml
+  - ./networkattachmentdefinition.yaml
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/env/0/value
+        value: '[{"name":"vm","lowerDevice":"bond0.57","mode":"bridge","capacity":10}]'
+    target:
+      kind: DaemonSet
+      name: macvtap-cni

--- a/kubernetes/apps/network/macvtap-cni/app/networkattachmentdefinition.yaml
+++ b/kubernetes/apps/network/macvtap-cni/app/networkattachmentdefinition.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vm-macvtap
+  namespace: network
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: macvtap.network.kubevirt.io/vm
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "vm-macvtap",
+      "type": "macvtap",
+      "mtu": 1500
+    }

--- a/kubernetes/apps/network/macvtap-cni/ks.yaml
+++ b/kubernetes/apps/network/macvtap-cni/ks.yaml
@@ -3,23 +3,15 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: ubuntu-server
+  name: macvtap-cni
 spec:
   dependsOn:
-    - name: kubevirt
-    - name: cdi
-    - name: macvtap-cni
-      namespace: network
+    - name: multus
   interval: 1h
-  path: ./kubernetes/apps/kubevirt/ubuntu-server/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
+  path: ./kubernetes/apps/network/macvtap-cni/app
   prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: kubevirt
-  wait: false
+  wait: true


### PR DESCRIPTION
macvlan CNI doesn't work with KubeVirt bridge interfaces because it moves the MAC address. macvtap-cni is the KubeVirt-recommended solution for connecting VMs to external networks.

- Add macvtap-cni DaemonSet configured for bond0.57 (VLAN57)
- Create vm-macvtap NetworkAttachmentDefinition
- Update ubuntu-server VM to use macvtap instead of macvlan
- Add macvtap-cni dependency to ubuntu-server Kustomization

https://claude.ai/code/session_01CKc1uoauvzTWpifTKuJJaR