### PR TITLE
fix(kubevirt): use network binding plugin API for macvtap

### DIFF
--- a/kubernetes/apps/kubevirt/kubevirt/app/kubevirt.yaml
+++ b/kubernetes/apps/kubevirt/kubevirt/app/kubevirt.yaml
@@ -22,6 +22,9 @@ spec:
       family: "ccio"
     network:
       permitBridgeInterfaceOnPodNetwork: true
+      binding:
+        macvtap:
+          domainAttachmentType: tap
   workloadUpdateStrategy:
     workloadUpdateMethods:
       - LiveMigrate

--- a/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
@@ -35,7 +35,8 @@ spec:
                 bus: virtio
           interfaces:
             - name: lan
-              macvtap: {}
+              binding:
+                name: macvtap
       networks:
         - name: lan
           multus:


### PR DESCRIPTION
Since KubeVirt v1.3, the core macvtap binding was removed and replaced with network binding plugins. Register the macvtap binding in the KubeVirt CR and update the VM to use the new binding API syntax.

References:
- https://kubevirt.io/user-guide/network/network_binding_plugins/
- https://github.com/kubevirt/kubevirt/blob/main/docs/network/network-binding-plugin.md

https://claude.ai/code/session_01CKc1uoauvzTWpifTKuJJaR