### PR TITLE
fix(kubevirt): use classic chpasswd list format for password

### DIFF
--- a/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
@@ -65,11 +65,9 @@ spec:
               manage_etc_hosts: true
               ssh_pwauth: true
               chpasswd:
+                list: |
+                  admin:123456aA
                 expire: false
-                users:
-                  - name: admin
-                    password: "123456aA"
-                    type: text
               users:
                 - name: admin
                   groups: [adm, sudo]


### PR DESCRIPTION
The newer chpasswd.users format may not work on all cloud-init versions. Using the classic list format (user:password) which is more reliable.

https://claude.ai/code/session_01CKc1uoauvzTWpifTKuJJaR