### PR TITLE
fix(kubevirt): use correct chpasswd users dict format

### DIFF
--- a/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
@@ -65,9 +65,9 @@ spec:
               manage_etc_hosts: true
               ssh_pwauth: true
               chpasswd:
-                list: |
-                  admin:123456aA
                 expire: false
+                users:
+                  - {name: admin, password: 123456aA, type: text}
               users:
                 - name: admin
                   groups: [adm, sudo]


### PR DESCRIPTION
Use the documented format: {name: user, password: pass, type: text}

https://claude.ai/code/session_01CKc1uoauvzTWpifTKuJJaR