### PR TITLE
chore(github): add missing namespace labels

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -56,10 +56,25 @@ area/templates:
           - makejinja.toml
 
 # Area Labels - Kubernetes Namespaces
+area/actions-runner-system:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/apps/actions-runner-system/**/*
+
 area/cert-manager:
   - changed-files:
       - any-glob-to-any-file:
           - kubernetes/apps/cert-manager/**/*
+
+area/database:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/apps/database/**/*
+
+area/default:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/apps/default/**/*
 
 area/external-secrets:
   - changed-files:
@@ -76,6 +91,11 @@ area/kube-system:
   - changed-files:
       - any-glob-to-any-file:
           - kubernetes/apps/kube-system/**/*
+
+area/kubevirt:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/apps/kubevirt/**/*
 
 area/media:
   - changed-files:
@@ -98,6 +118,16 @@ area/storage:
           - kubernetes/apps/volsync-system/**/*
           - kubernetes/apps/openebs-system/**/*
           - kubernetes/components/volsync/**/*
+
+area/system-upgrade:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/apps/system-upgrade/**/*
+
+area/utils:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/apps/utils/**/*
 
 # Component Labels
 component/cilium:

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -188,6 +188,17 @@ component/volsync:
           - kubernetes/apps/volsync-system/volsync/**/*
           - kubernetes/components/volsync/**/*
 
+component/kubevirt:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/apps/kubevirt/kubevirt/**/*
+          - kubernetes/apps/kubevirt/cdi/**/*
+
+component/kubevirt-vms:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/apps/kubevirt/ubuntu-server/**/*
+
 # Type Labels - Based on file patterns and commit messages
 type/ci:
   - changed-files:

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -32,9 +32,18 @@
   description: "Task automation definitions"
 
 # Area Labels - Kubernetes Namespaces
+- name: area/actions-runner-system
+  color: "1d76db"
+  description: "GitHub Actions self-hosted runners"
 - name: area/cert-manager
   color: "1d76db"
   description: "Certificate management"
+- name: area/database
+  color: "1d76db"
+  description: "Database infrastructure"
+- name: area/default
+  color: "1d76db"
+  description: "Default namespace applications"
 - name: area/external-secrets
   color: "1d76db"
   description: "External secrets integration"
@@ -44,6 +53,9 @@
 - name: area/kube-system
   color: "1d76db"
   description: "Core Kubernetes system components"
+- name: area/kubevirt
+  color: "1d76db"
+  description: "KubeVirt virtualization"
 - name: area/media
   color: "1d76db"
   description: "Media applications"
@@ -56,6 +68,12 @@
 - name: area/storage
   color: "1d76db"
   description: "Storage and backup systems"
+- name: area/system-upgrade
+  color: "1d76db"
+  description: "System upgrade automation"
+- name: area/utils
+  color: "1d76db"
+  description: "Utility services"
 
 # Component Labels
 - name: component/cilium

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -106,6 +106,12 @@
 - name: component/volsync
   color: "5319e7"
   description: "Volsync backup system"
+- name: component/kubevirt
+  color: "5319e7"
+  description: "KubeVirt core and CDI"
+- name: component/kubevirt-vms
+  color: "5319e7"
+  description: "KubeVirt virtual machines"
 
 # Type Labels - Development
 - name: type/bug


### PR DESCRIPTION
Add label definitions and path mappings for namespaces that were
missing from the label configuration:
- actions-runner-system
- database
- default
- kubevirt
- system-upgrade
- utils

https://claude.ai/code/session_019HWHDGSihujY1ejmUeipPA