### PR TITLE
fix(kubevirt): use passwd hash directly in user definition

### DIFF
--- a/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
@@ -66,14 +66,13 @@ spec:
               ssh_pwauth: true
               chpasswd:
                 expire: false
-                users:
-                  - {name: admin, password: 123456aA, type: text}
               users:
                 - name: admin
                   groups: [adm, sudo]
                   shell: /bin/bash
                   sudo: ALL=(ALL) NOPASSWD:ALL
                   lock_passwd: false
+                  passwd: $6$5qqFFER4w2zN2qTy$yg36q1ceQTlxTJsyJfDVpMl8sWdD.95XYo1XXL7znFntex4gs5VJGNRAf5nzh4.8frSxtwoJlZsbRgZaXj9pq1
                   ssh_authorized_keys:
                     - "${SECRET_SSH_PUBLIC_KEY}"
               package_update: true


### PR DESCRIPTION
Consolidated to single users section with SHA512 hashed password. Removed duplicate users sections that may have caused conflicts.

https://claude.ai/code/session_01CKc1uoauvzTWpifTKuJJaR