### PR TITLE
fix(kubevirt): hardcode SSH keys instead of ssh_import_id

### DIFF
--- a/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
@@ -69,8 +69,10 @@ spec:
                   groups: [adm, sudo]
                   shell: /bin/bash
                   sudo: ALL=(ALL) NOPASSWD:ALL
-                  ssh_import_id:
-                    - gh:00o-sh
+                  ssh_authorized_keys:
+                    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKTGSd9Ukp/CKEWssokvlEop1wrACYVS75fdKy5gNo37
+                    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAqkeDwM1SWrSy7w+tR0oyVzLIcAU5yz5doTgI8u/eaw
+                    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKRG6pXx4rXDOY8X5xamGwrZCb/OLTXgv963EsqI0HJp
               package_update: true
               packages:
                 - qemu-guest-agent


### PR DESCRIPTION
ssh_import_id requires internet access during cloud-init which VLAN57 may not have. Hardcode the GitHub public keys directly.

https://claude.ai/code/session_01CKc1uoauvzTWpifTKuJJaR