### PR TITLE
Improve Ubuntu VM security and guest agent startup

### DIFF
--- a/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
@@ -68,6 +68,7 @@ spec:
                   groups: [adm, sudo]
                   shell: /bin/bash
                   sudo: ALL=(ALL) NOPASSWD:ALL
+                  lock_passwd: true
                   ssh_authorized_keys:
                     - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKTGSd9Ukp/CKEWssokvlEop1wrACYVS75fdKy5gNo37
                     - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAqkeDwM1SWrSy7w+tR0oyVzLIcAU5yz5doTgI8u/eaw
@@ -76,7 +77,7 @@ spec:
               packages:
                 - qemu-guest-agent
               runcmd:
-                - systemctl enable --now qemu-guest-agent
+                - systemctl start qemu-guest-agent || true
   dataVolumeTemplates:
     - metadata:
         name: ubuntu-server-pvc


### PR DESCRIPTION
## Summary
Enhanced the Ubuntu KubeVirt virtual machine configuration with improved security settings and more robust guest agent initialization.

## Key Changes
- **Security hardening**: Added `lock_passwd: true` to the cloud-init user configuration to lock the password and prevent password-based authentication, enforcing SSH key-only access
- **Guest agent startup**: Changed `systemctl enable --now` to `systemctl start` with error handling (`|| true`) for the qemu-guest-agent service
  - This prevents VM startup failures if the service is already enabled or encounters issues
  - Provides more graceful error handling during initial provisioning

## Implementation Details
The qemu-guest-agent change removes the `enable` flag which attempts to persist the service across reboots. The new approach uses `start` with a fallback to true, making the startup more idempotent and resilient to various system states during VM initialization.

https://claude.ai/code/session_012v5pkEz7uSTaYx4DTtabeU