### PR TITLE
fix(kubevirt): fix cloud-init user creation failure

### DIFF
--- a/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
@@ -64,7 +64,9 @@ spec:
               hostname: ubuntu-server
               manage_etc_hosts: true
               users:
+                - default
                 - name: admin
+                  gecos: Admin User
                   groups: [adm, sudo]
                   shell: /bin/bash
                   sudo: ALL=(ALL) NOPASSWD:ALL


### PR DESCRIPTION
- Add 'default' to users list to preserve default cloud-init user config
- Add 'gecos' field for admin user
- Without 'default', the users_groups module fails to create users properly

https://claude.ai/code/session_012v5pkEz7uSTaYx4DTtabeU