### PR TITLE
fix(kubevirt): disable ssh_authkey_fingerprints module

### DIFF
--- a/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/ubuntu-server/app/virtualmachine.yaml
@@ -63,6 +63,7 @@ spec:
               #cloud-config
               hostname: ubuntu-server
               manage_etc_hosts: true
+              no_ssh_fingerprints: true
               users:
                 - default
                 - name: admin


### PR DESCRIPTION
Add no_ssh_fingerprints: true to prevent the ssh_authkey_fingerprints module from running and failing. This module only logs authorized key fingerprints to console - not essential functionality.

https://claude.ai/code/session_012v5pkEz7uSTaYx4DTtabeU