### PR TITLE
Use external-dns target annotation instead of EndpointSlice

### DIFF
--- a/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/service.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/service.yaml
@@ -8,23 +8,9 @@ metadata:
   name: ubuntu-server
   annotations:
     external-dns.alpha.kubernetes.io/hostname: ubuntu-server.00o.sh
+    external-dns.alpha.kubernetes.io/target: 192.168.57.10
 spec:
   clusterIP: None
   ports:
     - name: placeholder
       port: 1
----
-apiVersion: discovery.k8s.io/v1
-kind: EndpointSlice
-metadata:
-  name: ubuntu-server
-  labels:
-    kubernetes.io/service-name: ubuntu-server
-addressType: IPv4
-ports:
-  - name: placeholder
-    port: 1
-    protocol: TCP
-endpoints:
-  - addresses:
-      - 192.168.57.10

--- a/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/ks.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/ks.yaml
@@ -11,7 +11,7 @@ spec:
     - name: macvtap-cni
       namespace: network
   interval: 1h
-  path: ./kubernetes/apps/kubevirt/ubuntu-server/app
+  path: ./kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app
   postBuild:
     substituteFrom:
       - name: cluster-secrets


### PR DESCRIPTION
## Summary
Simplified the ubuntu-server service configuration by replacing the manual EndpointSlice resource with the `external-dns.alpha.kubernetes.io/target` annotation. This allows external-dns to manage DNS records more cleanly without requiring a separate EndpointSlice resource.

## Changes
- Added `external-dns.alpha.kubernetes.io/target: 192.168.57.10` annotation to the Service
- Removed the manual EndpointSlice resource for ubuntu-server
- Service continues to use headless mode (clusterIP: None) with placeholder port configuration

## Implementation Details
The external-dns controller will now use the target annotation to create/update the DNS record for `ubuntu-server.00o.sh` pointing to `192.168.57.10`, eliminating the need to maintain a separate EndpointSlice resource. This reduces configuration complexity and makes the DNS target explicit in the Service definition.

https://claude.ai/code/session_01Rc4C7p5EJQ3tQui1dwkyQc