### PR TITLE
fix(kubevirt): correct stimer field in Windows VM hyperv features

### DIFF
--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
@@ -46,8 +46,7 @@ spec:
             vpindex: {}
             runtime: {}
             synic: {}
-            stimer:
-              direct: {}
+            stimer: {}
             reset: {}
             frequencies: {}
             reenlightenment: {}


### PR DESCRIPTION
Remove invalid 'direct' sub-field from stimer - use empty object like other hyperv features.

https://claude.ai/code/session_01B8SGs6frQS9NJZ2dhotNdy