### PR TITLE
feat(kubevirt): deploy kubevirt-manager web UI

### DIFF
--- a/kubernetes/apps/kubevirt/kubevirt-manager/app/helmrelease.yaml
+++ b/kubernetes/apps/kubevirt/kubevirt-manager/app/helmrelease.yaml
@@ -1,0 +1,81 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kubevirt-manager
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: kubevirt-manager
+  interval: 1h
+  values:
+    controllers:
+      kubevirt-manager:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: kubevirtmanager/kubevirt-manager
+              tag: 1.5.3
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 8080
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10000
+            runAsGroup: 30000
+            fsGroup: 30000
+    serviceAccount:
+      kubevirt-manager: {}
+    service:
+      app:
+        controller: kubevirt-manager
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        hostnames:
+          - kubevirt.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      cache:
+        type: emptyDir
+        advancedMounts:
+          kubevirt-manager:
+            app:
+              - path: /var/cache/nginx
+      run:
+        type: emptyDir
+        advancedMounts:
+          kubevirt-manager:
+            app:
+              - path: /var/run

--- a/kubernetes/apps/kubevirt/kubevirt-manager/app/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/kubevirt-manager/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/kubevirt/kubevirt-manager/app/ocirepository.yaml
+++ b/kubernetes/apps/kubevirt/kubevirt-manager/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kubevirt-manager
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # renovate: datasource=docker depName=ghcr.io/bjw-s-labs/helm/app-template
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/kubevirt/kubevirt-manager/app/rbac.yaml
+++ b/kubernetes/apps/kubevirt/kubevirt-manager/app/rbac.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubevirt-manager
+rules:
+  # Core resources
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - namespaces
+      - persistentvolumeclaims
+      - persistentvolumes
+      - pods
+      - pods/exec
+      - services
+      - secrets
+      - configmaps
+      - events
+    verbs: ["*"]
+  # Apps resources
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - replicasets
+    verbs: ["*"]
+  # Storage resources
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+    verbs: ["get", "list", "watch"]
+  # Networking
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - networkpolicies
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["k8s.cni.cncf.io"]
+    resources:
+      - network-attachment-definitions
+    verbs: ["get", "list", "watch"]
+  # KubeVirt resources
+  - apiGroups: ["kubevirt.io"]
+    resources:
+      - virtualmachines
+      - virtualmachines/start
+      - virtualmachines/stop
+      - virtualmachines/restart
+      - virtualmachineinstances
+      - virtualmachineinstances/console
+      - virtualmachineinstances/vnc
+      - virtualmachineinstances/portforward
+      - virtualmachineinstances/freeze
+      - virtualmachineinstances/unfreeze
+      - virtualmachineinstances/softreboot
+      - virtualmachineinstancemigrations
+      - virtualmachineinstancepresets
+      - virtualmachineinstancereplicasets
+      - virtualmachineclones
+    verbs: ["*"]
+  - apiGroups: ["kubevirt.io"]
+    resources:
+      - kubevirts
+    verbs: ["get", "list", "watch"]
+  # Instance types
+  - apiGroups: ["instancetype.kubevirt.io"]
+    resources:
+      - virtualmachineinstancetypes
+      - virtualmachineclusterinstancetypes
+      - virtualmachinepreferences
+      - virtualmachineclusterpreferences
+    verbs: ["*"]
+  # Pool resources
+  - apiGroups: ["pool.kubevirt.io"]
+    resources:
+      - virtualmachinepools
+    verbs: ["*"]
+  # CDI resources
+  - apiGroups: ["cdi.kubevirt.io"]
+    resources:
+      - datavolumes
+      - cdiconfigs
+      - datasources
+      - dataimportcrons
+    verbs: ["*"]
+  - apiGroups: ["upload.cdi.kubevirt.io"]
+    resources:
+      - uploadtokenrequests
+    verbs: ["*"]
+  # Snapshot resources
+  - apiGroups: ["snapshot.kubevirt.io"]
+    resources:
+      - virtualmachinesnapshots
+      - virtualmachinesnapshotcontents
+      - virtualmachinerestores
+    verbs: ["*"]
+  # Export resources
+  - apiGroups: ["export.kubevirt.io"]
+    resources:
+      - virtualmachineexports
+    verbs: ["*"]
+  # Migrations
+  - apiGroups: ["migrations.kubevirt.io"]
+    resources:
+      - migrationpolicies
+    verbs: ["*"]
+  # Clone resources
+  - apiGroups: ["clone.kubevirt.io"]
+    resources:
+      - virtualmachineclones
+    verbs: ["*"]
+  # kubevirt-manager CRD
+  - apiGroups: ["kubevirt-manager.io"]
+    resources:
+      - images
+    verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubevirt-manager
+subjects:
+  - kind: ServiceAccount
+    name: kubevirt-manager
+    namespace: kubevirt

--- a/kubernetes/apps/kubevirt/kubevirt-manager/ks.yaml
+++ b/kubernetes/apps/kubevirt/kubevirt-manager/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubevirt-manager
+spec:
+  dependsOn:
+    - name: kubevirt
+    - name: cdi
+  interval: 1h
+  path: ./kubernetes/apps/kubevirt/kubevirt-manager/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kubevirt
+  wait: false

--- a/kubernetes/apps/kubevirt/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/kustomization.yaml
@@ -12,5 +12,6 @@ resources:
   - ./namespace.yaml
   - ./kubevirt/ks.yaml
   - ./cdi/ks.yaml
+  - ./kubevirt-manager/ks.yaml
   - ./virtualmachines/ubuntu-server/ks.yaml
   - ./virtualmachines/windows-server/ks.yaml


### PR DESCRIPTION
Add kubevirt-manager for managing KubeVirt VMs through a web interface.
Includes HelmRelease using app-template, RBAC for VM management, and
HTTPRoute for internal access at kubevirt.${SECRET_DOMAIN}.

https://claude.ai/code/session_01KmeMGV3MWcXHpDvZL5goH1