### PR TITLE
feat(kubevirt): deploy Debian server and desktop instances

### DIFF
--- a/kubernetes/apps/kubevirt/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/kustomization.yaml
@@ -13,5 +13,7 @@ resources:
   - ./kubevirt/ks.yaml
   - ./cdi/ks.yaml
   - ./kubevirt-manager/ks.yaml
+  - ./virtualmachines/debian-desktop/ks.yaml
+  - ./virtualmachines/debian-server/ks.yaml
   - ./virtualmachines/ubuntu-server/ks.yaml
   - ./virtualmachines/windows-server/ks.yaml

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/dnsendpoint.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/dnsendpoint.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: debian-desktop
+spec:
+  endpoints:
+    - dnsName: debian-desktop.00o.sh
+      recordTTL: 300
+      recordType: A
+      targets:
+        - 192.168.57.12

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./virtualmachine.yaml
+  - ./dnsendpoint.yaml

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
@@ -102,4 +102,4 @@ spec:
         source:
           registry:
             # renovate: datasource=docker depName=quay.io/containerdisks/debian
-            url: "docker://quay.io/containerdisks/debian:13"
+            url: "docker://quay.io/containerdisks/debian:13@sha256:caf1eab4dd2eec67dee402e8a827f26ad0dfb38b92d573bb0d4a47e9f06506a6"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
@@ -101,4 +101,5 @@ spec:
           storageClassName: nfs-fast
         source:
           registry:
-            url: "docker://quay.io/containerdisks/debian:12"
+            # renovate: datasource=docker depName=quay.io/containerdisks/debian
+            url: "docker://quay.io/containerdisks/debian:13"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: debian-desktop
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: debian-desktop
+      annotations:
+        kubevirt.io/allow-pod-bridge-network-live-migration: "true"
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "vm-macvtap",
+            "namespace": "network",
+            "mac": "52:54:00:57:00:12"
+          }]
+    spec:
+      evictionStrategy: LiveMigrate
+      domain:
+        cpu:
+          cores: 2
+        resources:
+          requests:
+            memory: 4G
+        devices:
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: lan
+              binding:
+                name: macvtap
+      networks:
+        - name: lan
+          multus:
+            networkName: network/vm-macvtap
+      volumes:
+        - name: rootdisk
+          dataVolume:
+            name: debian-desktop-pvc
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            networkData: |
+              network:
+                version: 1
+                config:
+                  - type: physical
+                    name: enp1s0
+                    subnets:
+                      - type: static
+                        address: 192.168.57.12/24
+                        gateway: 192.168.57.1
+                        dns_nameservers:
+                          - 10.0.6.1
+            userData: |
+              #cloud-config
+              hostname: debian-desktop
+              manage_etc_hosts: true
+              no_ssh_fingerprints: true
+              users:
+                - name: user
+                  gecos: User
+                  groups: [adm, sudo]
+                  shell: /bin/bash
+                  sudo: ALL=(ALL) NOPASSWD:ALL
+                  lock_passwd: true
+                  ssh_authorized_keys:
+                    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKTGSd9Ukp/CKEWssokvlEop1wrACYVS75fdKy5gNo37
+                    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAqkeDwM1SWrSy7w+tR0oyVzLIcAU5yz5doTgI8u/eaw
+                    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKRG6pXx4rXDOY8X5xamGwrZCb/OLTXgv963EsqI0HJp
+              package_update: true
+              package_upgrade: true
+              packages:
+                - qemu-guest-agent
+                - xfce4
+                - xfce4-goodies
+                - lightdm
+                - firefox-esr
+                - dbus-x11
+              runcmd:
+                - systemctl enable --now qemu-guest-agent || true
+                - systemctl set-default graphical.target
+                - systemctl enable lightdm
+  dataVolumeTemplates:
+    - metadata:
+        name: debian-desktop-pvc
+      spec:
+        storage:
+          resources:
+            requests:
+              storage: 50Gi
+          accessModes:
+            - ReadWriteMany
+          storageClassName: nfs-fast
+        source:
+          registry:
+            url: "docker://quay.io/containerdisks/debian:12"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/ks.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: debian-desktop
+spec:
+  dependsOn:
+    - name: kubevirt
+    - name: cdi
+    - name: macvtap-cni
+      namespace: network
+  interval: 1h
+  path: ./kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kubevirt
+  wait: false

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/dnsendpoint.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/dnsendpoint.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: debian-server
+spec:
+  endpoints:
+    - dnsName: debian-server.00o.sh
+      recordTTL: 300
+      recordType: A
+      targets:
+        - 192.168.57.11

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./virtualmachine.yaml
+  - ./dnsendpoint.yaml

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
@@ -95,4 +95,4 @@ spec:
         source:
           registry:
             # renovate: datasource=docker depName=quay.io/containerdisks/debian
-            url: "docker://quay.io/containerdisks/debian:13"
+            url: "docker://quay.io/containerdisks/debian:13@sha256:caf1eab4dd2eec67dee402e8a827f26ad0dfb38b92d573bb0d4a47e9f06506a6"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
@@ -94,4 +94,5 @@ spec:
           storageClassName: nfs-fast
         source:
           registry:
-            url: "docker://quay.io/containerdisks/debian:12"
+            # renovate: datasource=docker depName=quay.io/containerdisks/debian
+            url: "docker://quay.io/containerdisks/debian:13"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: debian-server
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: debian-server
+      annotations:
+        kubevirt.io/allow-pod-bridge-network-live-migration: "true"
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "vm-macvtap",
+            "namespace": "network",
+            "mac": "52:54:00:57:00:11"
+          }]
+    spec:
+      evictionStrategy: LiveMigrate
+      domain:
+        cpu:
+          cores: 1
+        resources:
+          requests:
+            memory: 1G
+        devices:
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: lan
+              binding:
+                name: macvtap
+      networks:
+        - name: lan
+          multus:
+            networkName: network/vm-macvtap
+      volumes:
+        - name: rootdisk
+          dataVolume:
+            name: debian-server-pvc
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            networkData: |
+              network:
+                version: 1
+                config:
+                  - type: physical
+                    name: enp1s0
+                    subnets:
+                      - type: static
+                        address: 192.168.57.11/24
+                        gateway: 192.168.57.1
+                        dns_nameservers:
+                          - 10.0.6.1
+            userData: |
+              #cloud-config
+              hostname: debian-server
+              manage_etc_hosts: true
+              no_ssh_fingerprints: true
+              users:
+                - name: user
+                  gecos: User
+                  groups: [adm, sudo]
+                  shell: /bin/bash
+                  sudo: ALL=(ALL) NOPASSWD:ALL
+                  lock_passwd: true
+                  ssh_authorized_keys:
+                    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKTGSd9Ukp/CKEWssokvlEop1wrACYVS75fdKy5gNo37
+                    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAqkeDwM1SWrSy7w+tR0oyVzLIcAU5yz5doTgI8u/eaw
+                    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKRG6pXx4rXDOY8X5xamGwrZCb/OLTXgv963EsqI0HJp
+              package_update: true
+              package_upgrade: true
+              packages:
+                - qemu-guest-agent
+              runcmd:
+                - systemctl enable --now qemu-guest-agent || true
+  dataVolumeTemplates:
+    - metadata:
+        name: debian-server-pvc
+      spec:
+        storage:
+          resources:
+            requests:
+              storage: 30Gi
+          accessModes:
+            - ReadWriteMany
+          storageClassName: nfs-fast
+        source:
+          registry:
+            url: "docker://quay.io/containerdisks/debian:12"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/ks.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: debian-server
+spec:
+  dependsOn:
+    - name: kubevirt
+    - name: cdi
+    - name: macvtap-cni
+      namespace: network
+  interval: 1h
+  path: ./kubernetes/apps/kubevirt/virtualmachines/debian-server/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kubevirt
+  wait: false


### PR DESCRIPTION
- Add debian-server VM (1 CPU, 1GB RAM, 30Gi storage)
- Add debian-desktop VM with XFCE (2 CPU, 4GB RAM, 50Gi storage)
- Both use Debian 12 (Bookworm) container disk image
- Configure macvtap networking with static IPs (192.168.57.11/12)
- Include DNS endpoints for external access

https://claude.ai/code/session_012j6kSBYdND1rBeHhv2dAxs