### PR TITLE
fix(kubevirt): remove digest pin causing import failures

### DIFF
--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
@@ -101,5 +101,4 @@ spec:
           storageClassName: nfs-fast
         source:
           registry:
-            # renovate: datasource=docker depName=quay.io/containerdisks/debian
-            url: "docker://quay.io/containerdisks/debian:13@sha256:caf1eab4dd2eec67dee402e8a827f26ad0dfb38b92d573bb0d4a47e9f06506a6"
+            url: "docker://quay.io/containerdisks/debian:13"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
@@ -94,5 +94,4 @@ spec:
           storageClassName: nfs-fast
         source:
           registry:
-            # renovate: datasource=docker depName=quay.io/containerdisks/debian
-            url: "docker://quay.io/containerdisks/debian:13@sha256:caf1eab4dd2eec67dee402e8a827f26ad0dfb38b92d573bb0d4a47e9f06506a6"
+            url: "docker://quay.io/containerdisks/debian:13"


### PR DESCRIPTION
Use tag-only reference like other VMs to avoid multi-arch manifest issues

https://claude.ai/code/session_012j6kSBYdND1rBeHhv2dAxs