### PR TITLE
Add Spegel container image registry to kube-system

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - ./reloader/ks.yaml
   - ./snapshot-controller/ks.yaml
   - ./csi-driver-nfs/ks.yaml
+  - ./spegel/ks.yaml

--- a/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/helmrelease.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: spegel
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: spegel
+  interval: 1h
+  values:
+    spegel:
+      containerdSock: /run/containerd/containerd.sock
+      containerdRegistryConfigPath: /etc/cri/conf.d/hosts
+    service:
+      registry:
+        hostPort: 29999
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/apps/kube-system/spegel/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/kube-system/spegel/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/spegel/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: spegel
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.6.0
+  url: oci://ghcr.io/spegel-org/helm-charts/spegel

--- a/kubernetes/apps/kube-system/spegel/ks.yaml
+++ b/kubernetes/apps/kube-system/spegel/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: spegel
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/kube-system/spegel/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kube-system
+  wait: false


### PR DESCRIPTION
## Summary
This PR adds Spegel, a peer-to-peer container image registry, to the kube-system namespace. Spegel enables efficient image distribution across cluster nodes by leveraging P2P technology.

## Changes
- Added Spegel Helm chart deployment via Flux CD with OCIRepository source
- Configured Spegel to use containerd socket at `/run/containerd/containerd.sock`
- Set registry service to listen on host port 29999
- Enabled Prometheus ServiceMonitor for metrics collection
- Pinned Spegel chart version to 0.6.0
- Integrated with cluster secrets for configuration management

## Implementation Details
- Uses Flux CD's HelmRelease and OCIRepository resources for GitOps-based deployment
- Configured containerd registry config path at `/etc/cri/conf.d/hosts`
- Set 15-minute interval for OCI repository checks and 1-hour interval for Helm release reconciliation
- Deployed to kube-system namespace with pruning enabled for clean resource management

https://claude.ai/code/session_013P4jmVRL5hR9uXa9XqadkJ