### PR TITLE
fix(kubevirt): update Windows containerDisk image names

### DIFF
--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
@@ -59,12 +59,10 @@ spec:
             name: windows-server-pvc
         - name: installiso
           containerDisk:
-            image: ghcr.io/00o-sh/windows-server:ltsc2022-eval
-            imagePullPolicy: Always
+            image: ghcr.io/00o-sh/windows-server@sha256:157478dbf143fab09f5f3131c2eb6be8e0652edeed351b4d87b0b467e8c27065
         - name: virtio-drivers
           containerDisk:
-            image: ghcr.io/00o-sh/windows-drivers:ltsc2022-eval
-            imagePullPolicy: Always
+            image: ghcr.io/00o-sh/windows-drivers@sha256:26ebafe33944fb5ae3350ff4b812d2907d1cb5264571e11cc2bb90e0d4ca41ae
   dataVolumeTemplates:
     - metadata:
         name: windows-server-pvc

--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
@@ -59,11 +59,11 @@ spec:
             name: windows-server-pvc
         - name: installiso
           containerDisk:
-            image: ghcr.io/00o-sh/windows-server-2022-eval-iso:ltsc2022-eval
+            image: ghcr.io/00o-sh/windows-server:ltsc2022-eval
             imagePullPolicy: Always
         - name: virtio-drivers
           containerDisk:
-            image: ghcr.io/00o-sh/windows-virtio-drivers:ltsc2022-eval
+            image: ghcr.io/00o-sh/windows-drivers:ltsc2022-eval
             imagePullPolicy: Always
   dataVolumeTemplates:
     - metadata:


### PR DESCRIPTION
- windows-server:ltsc2022-eval (ISO)
- windows-drivers:ltsc2022-eval (drivers + autounattend)

https://claude.ai/code/session_01B8SGs6frQS9NJZ2dhotNdy