### PR TITLE
fix(observability): correct VictoriaLogs Grafana plugin ID and version

### DIFF
--- a/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/observability/grafana/instance/grafanadatasource.yaml
@@ -42,10 +42,10 @@ spec:
     matchLabels:
       grafana.internal/instance: grafana
   plugins:
-    - name: victorialogs-datasource
-      version: 0.14.1
+    - name: victoriametrics-logs-datasource
+      version: 0.24.0
   datasource:
-    type: victorialogs-datasource
+    type: victoriametrics-logs-datasource
     name: victoria-logs
     access: proxy
     url: http://victoria-logs.observability.svc.cluster.local:9428


### PR DESCRIPTION
Update plugin from victorialogs-datasource@0.14.1 (non-existent) to victoriametrics-logs-datasource@0.24.0 (correct plugin ID and latest version).

https://claude.ai/code/session_015C2Fjt5mMFnG6X3K92PLNC