### PR TITLE
Add KubeVirt Manager to virtualization stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 **Virtualization:**
 - [KubeVirt](https://kubevirt.io/) - Virtual machine management on Kubernetes
 - [CDI](https://github.com/kubevirt/containerized-data-importer) - Containerized Data Importer for VM disk images
+- [KubeVirt Manager](https://kubevirt-manager.io/) - Web UI for VM management
 - [Macvtap CNI](https://github.com/kubevirt/macvtap-cni) - Direct network connectivity for VMs
 
 **System Management:**
@@ -635,7 +636,7 @@ If this repo is too hot to handle or too cold to hold check out these following 
 **Deployed Components:** 55+ applications across 15 namespaces
 **Template Source:** [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template)
 **Infrastructure:** GitOps with Flux CD + Talos Linux
-**Last Updated:** 2026-02-02
+**Last Updated:** 2026-02-04
 
 ---
 


### PR DESCRIPTION
## Summary
This PR adds KubeVirt Manager to the cluster's virtualization component list and updates the last modified date.

## Changes
- Added [KubeVirt Manager](https://kubevirt-manager.io/) to the Virtualization section as a web UI for VM management
- Updated the "Last Updated" timestamp from 2026-02-02 to 2026-02-04

## Details
KubeVirt Manager provides a user-friendly web interface for managing virtual machines in the cluster, complementing the existing KubeVirt and CDI components in the virtualization stack.

https://claude.ai/code/session_0132i8g57CdPoNBs8usPjdBB