### PR TITLE
fix(kubevirt): replace Helm template syntax with actual VM names

### DIFF
--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/configmap.yaml
@@ -7,5 +7,10 @@ data:
   VM_NAME: debian-desktop
   VM_IP: 192.168.57.12
   VM_MAC: "52:54:00:57:00:12"
+  VM_CPU: "1"
+  VM_MEMORY: 1G
   VM_STORAGE: 50Gi
+  VM_GATEWAY: 192.168.57.1
+  VM_DNS: 192.168.57.1
+  VM_NETWORK: network/vm-macvtap
   VM_IMAGE: "docker://quay.io/containerdisks/debian:13"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/configmap.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: debian-desktop-vars
+data:
+  VM_NAME: debian-desktop
+  VM_IP: 192.168.57.12
+  VM_MAC: "52:54:00:57:00:12"
+  VM_STORAGE: 50Gi
+  VM_IMAGE: "docker://quay.io/containerdisks/debian:13"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/dnsendpoint.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/dnsendpoint.yaml
@@ -5,7 +5,7 @@ metadata:
   name: debian-desktop
 spec:
   endpoints:
-    - dnsName: "{{ .Release.Name }}.00o.sh"
+    - dnsName: debian-desktop.00o.sh
       recordTTL: 300
       recordType: A
       targets:

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/dnsendpoint.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/dnsendpoint.yaml
@@ -2,11 +2,11 @@
 apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
-  name: debian-desktop
+  name: ${VM_NAME}
 spec:
   endpoints:
-    - dnsName: debian-desktop.00o.sh
+    - dnsName: ${VM_NAME}.00o.sh
       recordTTL: 300
       recordType: A
       targets:
-        - 192.168.57.12
+        - ${VM_IP}

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./configmap.yaml
   - ./virtualmachine.yaml
   - ./dnsendpoint.yaml

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
@@ -21,10 +21,10 @@ spec:
       evictionStrategy: LiveMigrate
       domain:
         cpu:
-          cores: 1
+          cores: ${VM_CPU}
         resources:
           requests:
-            memory: 1G
+            memory: ${VM_MEMORY}
         devices:
           disks:
             - name: rootdisk
@@ -40,7 +40,7 @@ spec:
       networks:
         - name: lan
           multus:
-            networkName: network/vm-macvtap
+            networkName: ${VM_NETWORK}
       volumes:
         - name: rootdisk
           dataVolume:
@@ -56,9 +56,9 @@ spec:
                     subnets:
                       - type: static
                         address: ${VM_IP}/24
-                        gateway: 192.168.57.1
+                        gateway: ${VM_GATEWAY}
                         dns_nameservers:
-                          - 10.0.6.1
+                          - ${VM_DNS}
             userData: |
               #cloud-config
               hostname: ${VM_NAME}

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
@@ -2,20 +2,20 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name: &name debian-desktop
+  name: ${VM_NAME}
 spec:
   running: true
   template:
     metadata:
       labels:
-        kubevirt.io/vm: *name
+        kubevirt.io/vm: ${VM_NAME}
       annotations:
         kubevirt.io/allow-pod-bridge-network-live-migration: "true"
         k8s.v1.cni.cncf.io/networks: |-
           [{
             "name": "vm-macvtap",
             "namespace": "network",
-            "mac": "52:54:00:57:00:12"
+            "mac": "${VM_MAC}"
           }]
     spec:
       evictionStrategy: LiveMigrate
@@ -44,7 +44,7 @@ spec:
       volumes:
         - name: rootdisk
           dataVolume:
-            name: debian-desktop-pvc
+            name: ${VM_NAME}-pvc
         - name: cloudinitdisk
           cloudInitNoCloud:
             networkData: |
@@ -55,13 +55,13 @@ spec:
                     name: enp1s0
                     subnets:
                       - type: static
-                        address: 192.168.57.12/24
+                        address: ${VM_IP}/24
                         gateway: 192.168.57.1
                         dns_nameservers:
                           - 10.0.6.1
             userData: |
               #cloud-config
-              hostname: *name
+              hostname: ${VM_NAME}
               manage_etc_hosts: true
               no_ssh_fingerprints: true
               users:
@@ -90,15 +90,15 @@ spec:
                 - systemctl enable lightdm
   dataVolumeTemplates:
     - metadata:
-        name: debian-desktop-pvc
+        name: ${VM_NAME}-pvc
       spec:
         storage:
           resources:
             requests:
-              storage: 50Gi
+              storage: ${VM_STORAGE}
           accessModes:
             - ReadWriteMany
           storageClassName: nfs-fast
         source:
           registry:
-            url: "docker://quay.io/containerdisks/debian:13"
+            url: "${VM_IMAGE}"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/app/virtualmachine.yaml
@@ -44,7 +44,7 @@ spec:
       volumes:
         - name: rootdisk
           dataVolume:
-            name: "{{ .Release.Name }}-pvc"
+            name: debian-desktop-pvc
         - name: cloudinitdisk
           cloudInitNoCloud:
             networkData: |
@@ -90,7 +90,7 @@ spec:
                 - systemctl enable lightdm
   dataVolumeTemplates:
     - metadata:
-        name: "{{ .Release.Name }}-pvc"
+        name: debian-desktop-pvc
       spec:
         storage:
           resources:

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/ks.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-desktop/ks.yaml
@@ -16,6 +16,8 @@ spec:
     substituteFrom:
       - name: cluster-secrets
         kind: Secret
+      - name: debian-desktop-vars
+        kind: ConfigMap
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/configmap.yaml
@@ -7,5 +7,10 @@ data:
   VM_NAME: debian-server
   VM_IP: 192.168.57.11
   VM_MAC: "52:54:00:57:00:11"
+  VM_CPU: "1"
+  VM_MEMORY: 1G
   VM_STORAGE: 30Gi
+  VM_GATEWAY: 192.168.57.1
+  VM_DNS: 192.168.57.1
+  VM_NETWORK: network/vm-macvtap
   VM_IMAGE: "docker://quay.io/containerdisks/debian:13"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/configmap.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: debian-server-vars
+data:
+  VM_NAME: debian-server
+  VM_IP: 192.168.57.11
+  VM_MAC: "52:54:00:57:00:11"
+  VM_STORAGE: 30Gi
+  VM_IMAGE: "docker://quay.io/containerdisks/debian:13"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/dnsendpoint.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/dnsendpoint.yaml
@@ -2,11 +2,11 @@
 apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
-  name: debian-server
+  name: ${VM_NAME}
 spec:
   endpoints:
-    - dnsName: debian-server.00o.sh
+    - dnsName: ${VM_NAME}.00o.sh
       recordTTL: 300
       recordType: A
       targets:
-        - 192.168.57.11
+        - ${VM_IP}

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/dnsendpoint.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/dnsendpoint.yaml
@@ -5,7 +5,7 @@ metadata:
   name: debian-server
 spec:
   endpoints:
-    - dnsName: "{{ .Release.Name }}.00o.sh"
+    - dnsName: debian-server.00o.sh
       recordTTL: 300
       recordType: A
       targets:

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./configmap.yaml
   - ./virtualmachine.yaml
   - ./dnsendpoint.yaml

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
@@ -21,10 +21,10 @@ spec:
       evictionStrategy: LiveMigrate
       domain:
         cpu:
-          cores: 1
+          cores: ${VM_CPU}
         resources:
           requests:
-            memory: 1G
+            memory: ${VM_MEMORY}
         devices:
           disks:
             - name: rootdisk
@@ -40,7 +40,7 @@ spec:
       networks:
         - name: lan
           multus:
-            networkName: network/vm-macvtap
+            networkName: ${VM_NETWORK}
       volumes:
         - name: rootdisk
           dataVolume:
@@ -56,9 +56,9 @@ spec:
                     subnets:
                       - type: static
                         address: ${VM_IP}/24
-                        gateway: 192.168.57.1
+                        gateway: ${VM_GATEWAY}
                         dns_nameservers:
-                          - 10.0.6.1
+                          - ${VM_DNS}
             userData: |
               #cloud-config
               hostname: ${VM_NAME}

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
@@ -44,7 +44,7 @@ spec:
       volumes:
         - name: rootdisk
           dataVolume:
-            name: "{{ .Release.Name }}-pvc"
+            name: debian-server-pvc
         - name: cloudinitdisk
           cloudInitNoCloud:
             networkData: |
@@ -83,7 +83,7 @@ spec:
                 - systemctl enable --now qemu-guest-agent || true
   dataVolumeTemplates:
     - metadata:
-        name: "{{ .Release.Name }}-pvc"
+        name: debian-server-pvc
       spec:
         storage:
           resources:

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/app/virtualmachine.yaml
@@ -2,20 +2,20 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name: &name debian-server
+  name: ${VM_NAME}
 spec:
   running: true
   template:
     metadata:
       labels:
-        kubevirt.io/vm: *name
+        kubevirt.io/vm: ${VM_NAME}
       annotations:
         kubevirt.io/allow-pod-bridge-network-live-migration: "true"
         k8s.v1.cni.cncf.io/networks: |-
           [{
             "name": "vm-macvtap",
             "namespace": "network",
-            "mac": "52:54:00:57:00:11"
+            "mac": "${VM_MAC}"
           }]
     spec:
       evictionStrategy: LiveMigrate
@@ -44,7 +44,7 @@ spec:
       volumes:
         - name: rootdisk
           dataVolume:
-            name: debian-server-pvc
+            name: ${VM_NAME}-pvc
         - name: cloudinitdisk
           cloudInitNoCloud:
             networkData: |
@@ -55,13 +55,13 @@ spec:
                     name: enp1s0
                     subnets:
                       - type: static
-                        address: 192.168.57.11/24
+                        address: ${VM_IP}/24
                         gateway: 192.168.57.1
                         dns_nameservers:
                           - 10.0.6.1
             userData: |
               #cloud-config
-              hostname: *name
+              hostname: ${VM_NAME}
               manage_etc_hosts: true
               no_ssh_fingerprints: true
               users:
@@ -83,15 +83,15 @@ spec:
                 - systemctl enable --now qemu-guest-agent || true
   dataVolumeTemplates:
     - metadata:
-        name: debian-server-pvc
+        name: ${VM_NAME}-pvc
       spec:
         storage:
           resources:
             requests:
-              storage: 30Gi
+              storage: ${VM_STORAGE}
           accessModes:
             - ReadWriteMany
           storageClassName: nfs-fast
         source:
           registry:
-            url: "docker://quay.io/containerdisks/debian:13"
+            url: "${VM_IMAGE}"

--- a/kubernetes/apps/kubevirt/virtualmachines/debian-server/ks.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/debian-server/ks.yaml
@@ -16,6 +16,8 @@ spec:
     substituteFrom:
       - name: cluster-secrets
         kind: Secret
+      - name: debian-server-vars
+        kind: ConfigMap
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/configmap.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ubuntu-server-vars
+data:
+  VM_NAME: ubuntu-server
+  VM_IP: 192.168.57.10
+  VM_MAC: "52:54:00:57:00:10"
+  VM_STORAGE: 30Gi
+  VM_IMAGE: "docker://quay.io/containerdisks/ubuntu:24.04"

--- a/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/configmap.yaml
@@ -7,5 +7,10 @@ data:
   VM_NAME: ubuntu-server
   VM_IP: 192.168.57.10
   VM_MAC: "52:54:00:57:00:10"
+  VM_CPU: "1"
+  VM_MEMORY: 1G
   VM_STORAGE: 30Gi
+  VM_GATEWAY: 192.168.57.1
+  VM_DNS: 192.168.57.1
+  VM_NETWORK: network/vm-macvtap
   VM_IMAGE: "docker://quay.io/containerdisks/ubuntu:24.04"

--- a/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/dnsendpoint.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/dnsendpoint.yaml
@@ -7,7 +7,7 @@ metadata:
   name: ubuntu-server
 spec:
   endpoints:
-    - dnsName: "{{ .Release.Name }}.00o.sh"
+    - dnsName: ubuntu-server.00o.sh
       recordTTL: 300
       recordType: A
       targets:

--- a/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/dnsendpoint.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/dnsendpoint.yaml
@@ -1,14 +1,12 @@
 ---
-# DNSEndpoint for VM DNS registration.
-# VM uses macvtap for direct L2 network access with its own IP.
 apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
-  name: ubuntu-server
+  name: ${VM_NAME}
 spec:
   endpoints:
-    - dnsName: ubuntu-server.00o.sh
+    - dnsName: ${VM_NAME}.00o.sh
       recordTTL: 300
       recordType: A
       targets:
-        - 192.168.57.10
+        - ${VM_IP}

--- a/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./configmap.yaml
   - ./virtualmachine.yaml
   - ./dnsendpoint.yaml

--- a/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/virtualmachine.yaml
@@ -44,7 +44,7 @@ spec:
       volumes:
         - name: rootdisk
           dataVolume:
-            name: "{{ .Release.Name }}-pvc"
+            name: ubuntu-server-pvc
         - name: cloudinitdisk
           cloudInitNoCloud:
             networkData: |
@@ -61,7 +61,7 @@ spec:
                           - 10.0.6.1
             userData: |
               #cloud-config
-              hostname: *app
+              hostname: *name
               manage_etc_hosts: true
               no_ssh_fingerprints: true
               users:
@@ -83,7 +83,7 @@ spec:
                 - systemctl start qemu-guest-agent || true
   dataVolumeTemplates:
     - metadata:
-        name: "{{ .Release.Name }}-pvc"
+        name: ubuntu-server-pvc
       spec:
         storage:
           resources:

--- a/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/virtualmachine.yaml
@@ -21,10 +21,10 @@ spec:
       evictionStrategy: LiveMigrate
       domain:
         cpu:
-          cores: 1
+          cores: ${VM_CPU}
         resources:
           requests:
-            memory: 1G
+            memory: ${VM_MEMORY}
         devices:
           disks:
             - name: rootdisk
@@ -40,7 +40,7 @@ spec:
       networks:
         - name: lan
           multus:
-            networkName: network/vm-macvtap
+            networkName: ${VM_NETWORK}
       volumes:
         - name: rootdisk
           dataVolume:
@@ -56,9 +56,9 @@ spec:
                     subnets:
                       - type: static
                         address: ${VM_IP}/24
-                        gateway: 192.168.57.1
+                        gateway: ${VM_GATEWAY}
                         dns_nameservers:
-                          - 10.0.6.1
+                          - ${VM_DNS}
             userData: |
               #cloud-config
               hostname: ${VM_NAME}

--- a/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/app/virtualmachine.yaml
@@ -2,20 +2,20 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name: &name ubuntu-server
+  name: ${VM_NAME}
 spec:
   running: true
   template:
     metadata:
       labels:
-        kubevirt.io/vm: *name
+        kubevirt.io/vm: ${VM_NAME}
       annotations:
         kubevirt.io/allow-pod-bridge-network-live-migration: "true"
         k8s.v1.cni.cncf.io/networks: |-
           [{
             "name": "vm-macvtap",
             "namespace": "network",
-            "mac": "52:54:00:57:00:10"
+            "mac": "${VM_MAC}"
           }]
     spec:
       evictionStrategy: LiveMigrate
@@ -44,7 +44,7 @@ spec:
       volumes:
         - name: rootdisk
           dataVolume:
-            name: ubuntu-server-pvc
+            name: ${VM_NAME}-pvc
         - name: cloudinitdisk
           cloudInitNoCloud:
             networkData: |
@@ -55,13 +55,13 @@ spec:
                     name: enp1s0
                     subnets:
                       - type: static
-                        address: 192.168.57.10/24
+                        address: ${VM_IP}/24
                         gateway: 192.168.57.1
                         dns_nameservers:
                           - 10.0.6.1
             userData: |
               #cloud-config
-              hostname: *name
+              hostname: ${VM_NAME}
               manage_etc_hosts: true
               no_ssh_fingerprints: true
               users:
@@ -83,15 +83,15 @@ spec:
                 - systemctl start qemu-guest-agent || true
   dataVolumeTemplates:
     - metadata:
-        name: ubuntu-server-pvc
+        name: ${VM_NAME}-pvc
       spec:
         storage:
           resources:
             requests:
-              storage: 30Gi
+              storage: ${VM_STORAGE}
           accessModes:
             - ReadWriteMany
           storageClassName: nfs-fast
         source:
           registry:
-            url: "docker://quay.io/containerdisks/ubuntu:24.04"
+            url: "${VM_IMAGE}"

--- a/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/ks.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/ubuntu-server/ks.yaml
@@ -16,6 +16,8 @@ spec:
     substituteFrom:
       - name: cluster-secrets
         kind: Secret
+      - name: ubuntu-server-vars
+        kind: ConfigMap
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/configmap.yaml
@@ -7,7 +7,12 @@ data:
   VM_NAME: windows-server
   VM_IP: 192.168.57.13
   VM_MAC: "52:54:00:57:00:20"
+  VM_CPU: "2"
+  VM_MEMORY: 2G
   VM_STORAGE: 60Gi
+  VM_GATEWAY: 192.168.57.1
+  VM_DNS: 192.168.57.1
+  VM_NETWORK: network/vm-macvtap
   # renovate: datasource=docker depName=ghcr.io/00o-sh/windows-server
   VM_IMAGE: ghcr.io/00o-sh/windows-server:2022-np@sha256:a58fc901489c01315da03d76c16138ebc7e8dc09704b89d75f515d8e3d74e5aa
   # renovate: datasource=docker depName=ghcr.io/00o-sh/windows-drivers

--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/configmap.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: windows-server-vars
+data:
+  VM_NAME: windows-server
+  VM_IP: 192.168.57.13
+  VM_MAC: "52:54:00:57:00:20"
+  VM_STORAGE: 60Gi

--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/configmap.yaml
@@ -8,3 +8,7 @@ data:
   VM_IP: 192.168.57.13
   VM_MAC: "52:54:00:57:00:20"
   VM_STORAGE: 60Gi
+  # renovate: datasource=docker depName=ghcr.io/00o-sh/windows-server
+  VM_IMAGE: ghcr.io/00o-sh/windows-server:2022-np@sha256:a58fc901489c01315da03d76c16138ebc7e8dc09704b89d75f515d8e3d74e5aa
+  # renovate: datasource=docker depName=ghcr.io/00o-sh/windows-drivers
+  VM_DRIVERS_IMAGE: ghcr.io/00o-sh/windows-drivers:server@sha256:60baa212536bf8767b7cbc0047ada2300eb0ab300c0a6d1f2173bd61544f9aed

--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/dnsendpoint.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/dnsendpoint.yaml
@@ -2,11 +2,11 @@
 apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
-  name: windows-server
+  name: ${VM_NAME}
 spec:
   endpoints:
-    - dnsName: windows-server.00o.sh
+    - dnsName: ${VM_NAME}.00o.sh
       recordTTL: 300
       recordType: A
       targets:
-        - 192.168.57.13
+        - ${VM_IP}

--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/dnsendpoint.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/dnsendpoint.yaml
@@ -5,7 +5,7 @@ metadata:
   name: windows-server
 spec:
   endpoints:
-    - dnsName: "{{ .Release.Name }}.00o.sh"
+    - dnsName: windows-server.00o.sh
       recordTTL: 300
       recordType: A
       targets:

--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./configmap.yaml
   - ./virtualmachine.yaml
   - ./dnsendpoint.yaml

--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
@@ -21,10 +21,10 @@ spec:
       evictionStrategy: LiveMigrate
       domain:
         cpu:
-          cores: 2
+          cores: ${VM_CPU}
         resources:
           requests:
-            memory: 2G
+            memory: ${VM_MEMORY}
         features:
           acpi: {}
           apic: {}
@@ -52,7 +52,7 @@ spec:
       networks:
         - name: lan
           multus:
-            networkName: network/vm-macvtap
+            networkName: ${VM_NETWORK}
       volumes:
         - name: rootdisk
           dataVolume:

--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
@@ -59,12 +59,10 @@ spec:
             name: ${VM_NAME}-pvc
         - name: installiso
           containerDisk:
-            # renovate: datasource=docker depName=ghcr.io/00o-sh/windows-server
-            image: ghcr.io/00o-sh/windows-server:2022-np@sha256:a58fc901489c01315da03d76c16138ebc7e8dc09704b89d75f515d8e3d74e5aa
+            image: ${VM_IMAGE}
         - name: virtio-drivers
           containerDisk:
-            # renovate: datasource=docker depName=ghcr.io/00o-sh/windows-drivers
-            image: ghcr.io/00o-sh/windows-drivers:server@sha256:60baa212536bf8767b7cbc0047ada2300eb0ab300c0a6d1f2173bd61544f9aed
+            image: ${VM_DRIVERS_IMAGE}
   dataVolumeTemplates:
     - metadata:
         name: ${VM_NAME}-pvc

--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
@@ -56,7 +56,7 @@ spec:
       volumes:
         - name: rootdisk
           dataVolume:
-            name: "{{ .Release.Name }}-pvc"
+            name: windows-server-pvc
         - name: installiso
           containerDisk:
             # renovate: datasource=docker depName=ghcr.io/00o-sh/windows-server
@@ -67,7 +67,7 @@ spec:
             image: ghcr.io/00o-sh/windows-drivers:server@sha256:60baa212536bf8767b7cbc0047ada2300eb0ab300c0a6d1f2173bd61544f9aed
   dataVolumeTemplates:
     - metadata:
-        name: "{{ .Release.Name }}-pvc"
+        name: windows-server-pvc
       spec:
         storage:
           resources:

--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/app/virtualmachine.yaml
@@ -2,20 +2,20 @@
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
-  name: &name windows-server
+  name: ${VM_NAME}
 spec:
   running: true
   template:
     metadata:
       labels:
-        kubevirt.io/vm: *name
+        kubevirt.io/vm: ${VM_NAME}
       annotations:
         kubevirt.io/allow-pod-bridge-network-live-migration: "true"
         k8s.v1.cni.cncf.io/networks: |-
           [{
             "name": "vm-macvtap",
             "namespace": "network",
-            "mac": "52:54:00:57:00:20"
+            "mac": "${VM_MAC}"
           }]
     spec:
       evictionStrategy: LiveMigrate
@@ -56,7 +56,7 @@ spec:
       volumes:
         - name: rootdisk
           dataVolume:
-            name: windows-server-pvc
+            name: ${VM_NAME}-pvc
         - name: installiso
           containerDisk:
             # renovate: datasource=docker depName=ghcr.io/00o-sh/windows-server
@@ -67,12 +67,12 @@ spec:
             image: ghcr.io/00o-sh/windows-drivers:server@sha256:60baa212536bf8767b7cbc0047ada2300eb0ab300c0a6d1f2173bd61544f9aed
   dataVolumeTemplates:
     - metadata:
-        name: windows-server-pvc
+        name: ${VM_NAME}-pvc
       spec:
         storage:
           resources:
             requests:
-              storage: 60Gi
+              storage: ${VM_STORAGE}
           accessModes:
             - ReadWriteMany
           storageClassName: nfs-fast

--- a/kubernetes/apps/kubevirt/virtualmachines/windows-server/ks.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/windows-server/ks.yaml
@@ -16,6 +16,8 @@ spec:
     substituteFrom:
       - name: cluster-secrets
         kind: Secret
+      - name: windows-server-vars
+        kind: ConfigMap
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
The VM manifests were using Helm template syntax ({{ .Release.Name }})
but are deployed via Flux Kustomization, not HelmReleases. This caused
the dataVolume references to contain literal template strings instead of
actual names, preventing VM creation.

Changes:
- Replace {{ .Release.Name }}-pvc with <vm-name>-pvc in all VMs
- Fix ubuntu-server YAML anchor (*app -> *name)
- Update dnsendpoint.yaml files with actual VM hostnames

https://claude.ai/code/session_014giUow7neCHFouufqumEMT