### PR TITLE
fix(kubernetes): resolve homepage probe host validation and logs perm…

### DIFF
--- a/kubernetes/apps/utils/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/homepage/app/helmrelease.yaml
@@ -30,6 +30,9 @@ spec:
                   httpGet:
                     path: /api/healthcheck
                     port: &port 3000
+                    httpHeaders:
+                      - name: Host
+                        value: homepage.00o.sh
                   initialDelaySeconds: 0
                   periodSeconds: 10
                   timeoutSeconds: 1
@@ -254,3 +257,7 @@ spec:
             subPath: kubernetes.yaml
           - path: /app/config/docker.yaml
             subPath: docker.yaml
+      logs:
+        type: emptyDir
+        globalMounts:
+          - path: /app/config/logs


### PR DESCRIPTION
…ission

Add Host header to health probes so kubelet requests pass the HOMEPAGE_ALLOWED_HOSTS validation. Add emptyDir mount at /app/config/logs to fix EACCES permission error for the non-root process.

https://claude.ai/code/session_0183E5F3cbsyrPxjLkgfBYvS