### PR TITLE
fix(kubernetes): improve homepage RBAC, logging, and gateway support

### DIFF
--- a/kubernetes/apps/utils/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/homepage/app/helmrelease.yaml
@@ -22,6 +22,7 @@ spec:
               tag: v1.10.1
             env:
               HOMEPAGE_ALLOWED_HOSTS: homepage.00o.sh
+              LOG_TARGETS: stdout
             probes:
               liveness: &probes
                 enabled: true
@@ -48,12 +49,6 @@ spec:
               limits:
                 memory: 256Mi
 
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
-        runAsGroup: 65534
-
     serviceAccount:
       homepage: {}
 
@@ -72,8 +67,14 @@ spec:
               resources: [jobs, cronjobs]
               verbs: [get, list]
             - apiGroups: [gateway.networking.k8s.io]
-              resources: [httproutes]
+              resources: [gateways, httproutes]
               verbs: [get, list]
+            - apiGroups: [metrics.k8s.io]
+              resources: [nodes, pods]
+              verbs: [get, list]
+            - apiGroups: [apiextensions.k8s.io]
+              resources: [customresourcedefinitions/status]
+              verbs: [get]
       bindings:
         homepage:
           type: ClusterRoleBinding
@@ -106,6 +107,7 @@ spec:
         data:
           kubernetes.yaml: |
             mode: cluster
+            gateway: true
           docker.yaml: ""
           settings.yaml: |
             title: Home Operations
@@ -257,7 +259,3 @@ spec:
             subPath: kubernetes.yaml
           - path: /app/config/docker.yaml
             subPath: docker.yaml
-      logs:
-        type: emptyDir
-        globalMounts:
-          - path: /app/config/logs


### PR DESCRIPTION
- Add LOG_TARGETS=stdout to eliminate /app/config/logs permission error
- Remove logs emptyDir mount (no longer needed)
- Add metrics.k8s.io RBAC for Kubernetes CPU/memory widgets
- Add apiextensions.k8s.io RBAC for CRD status checks
- Add gateways to gateway.networking.k8s.io RBAC resources
- Enable gateway discovery in kubernetes.yaml config
- Remove forced UID/GID override (use container defaults)

https://claude.ai/code/session_0183E5F3cbsyrPxjLkgfBYvS