### PR TITLE
fix(kubernetes): use correct autobrr API key field in Homepage Extern…

### DIFF
--- a/kubernetes/apps/utils/homepage/app/externalsecret.yaml
+++ b/kubernetes/apps/utils/homepage/app/externalsecret.yaml
@@ -19,7 +19,7 @@ spec:
         HOMEPAGE_VAR_SEERR_API_KEY: "{{ .SEERR_API_KEY }}"
         HOMEPAGE_VAR_TAUTULLI_API_KEY: "{{ .TAUTULLI_API_KEY }}"
         HOMEPAGE_VAR_PLEX_TOKEN: "{{ .PLEX_CLAIM }}"
-        HOMEPAGE_VAR_AUTOBRR_API_KEY: "{{ .AUTOBRR_SESSION_SECRET }}"
+        HOMEPAGE_VAR_AUTOBRR_API_KEY: "{{ .AUTOBRR_API_KEY }}"
   dataFrom:
     - extract:
         key: radarr


### PR DESCRIPTION
…alSecret

AUTOBRR_SESSION_SECRET is the session cookie secret, not an API key. Map to AUTOBRR_API_KEY instead.

https://claude.ai/code/session_0183E5F3cbsyrPxjLkgfBYvS