### PR TITLE
feat(kubernetes): add Kopia widget to Homepage dashboard

### DIFF
--- a/kubernetes/apps/utils/homepage/app/externalsecret.yaml
+++ b/kubernetes/apps/utils/homepage/app/externalsecret.yaml
@@ -21,6 +21,8 @@ spec:
         HOMEPAGE_VAR_PLEX_TOKEN: "{{ .PLEX_TOKEN }}"
         HOMEPAGE_VAR_AUTOBRR_API_KEY: "{{ .AUTOBRR_API_KEY }}"
         HOMEPAGE_VAR_BAZARR_API_KEY: "{{ .BAZARR_API_KEY }}"
+        HOMEPAGE_VAR_KOPIA_USERNAME: "{{ .KOPIA_USERNAME }}"
+        HOMEPAGE_VAR_KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
   dataFrom:
     - extract:
         key: radarr
@@ -38,3 +40,5 @@ spec:
         key: autobrr
     - extract:
         key: bazarr
+    - extract:
+        key: volsync-template

--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -76,6 +76,10 @@ spec:
           gethomepage.dev/icon: kopia.png
           gethomepage.dev/description: Backup Repository
           gethomepage.dev/href: "https://kopia.00o.sh"
+          gethomepage.dev/widget.type: kopia
+          gethomepage.dev/widget.url: "http://kopia.volsync-system.svc.cluster.local:80"
+          gethomepage.dev/widget.username: "{{`{{HOMEPAGE_VAR_KOPIA_USERNAME}}`}}"
+          gethomepage.dev/widget.password: "{{`{{HOMEPAGE_VAR_KOPIA_PASSWORD}}`}}"
         hostnames:
           - "{{ .Release.Name }}.00o.sh"
         parentRefs:


### PR DESCRIPTION
Add kopia widget annotations on route with username/password auth. Pulls credentials from volsync-template 1Password item via ExternalSecret.

https://claude.ai/code/session_0183E5F3cbsyrPxjLkgfBYvS