### PR TITLE
fix(kubernetes): fix Homepage crash by moving emptyDir from server/pa…

### DIFF
--- a/kubernetes/apps/utils/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/homepage/app/helmrelease.yaml
@@ -176,7 +176,7 @@ spec:
       next-cache:
         type: emptyDir
         globalMounts:
-          - path: /app/.next/server/pages
+          - path: /app/.next/cache
       config:
         type: configMap
         identifier: config


### PR DESCRIPTION
…ges to cache

The emptyDir at /app/.next/server/pages was overwriting the pre-built Next.js pages (healthcheck.js, _document.js) from the container image. Move to /app/.next/cache which is the actual writable cache directory.

https://claude.ai/code/session_0183E5F3cbsyrPxjLkgfBYvS