### PR TITLE
Increase replica count to 3 for external-secrets and cloudflare-tunnel

### DIFF
--- a/kubernetes/apps/external-secrets/onepassword/app/helmrelease.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/app/helmrelease.yaml
@@ -12,6 +12,7 @@ spec:
   values:
     controllers:
       onepassword:
+        replicas: 3
         strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"

--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -11,6 +11,7 @@ spec:
   values:
     controllers:
       cloudflare-tunnel:
+        replicas: 3
         strategy: RollingUpdate
         annotations:
           reloader.stakater.com/auto: "true"


### PR DESCRIPTION
## Summary
Increases the replica count from the default (1) to 3 for both the OnePassword external-secrets controller and Cloudflare Tunnel deployment to improve high availability and resilience.

## Changes
- **external-secrets/onepassword**: Set `replicas: 3` for the OnePassword controller
- **network/cloudflare-tunnel**: Set `replicas: 3` for the Cloudflare Tunnel controller

## Details
Both deployments now use 3 replicas with the existing `RollingUpdate` strategy, ensuring:
- Better fault tolerance with multiple instances running simultaneously
- Improved availability during rolling updates
- Load distribution across replicas for these critical infrastructure components

https://claude.ai/code/session_01Cx2vGux11D7Lu47ZBaYngF