### PR TITLE
Add Forgejo Git service deployment

### DIFF
--- a/kubernetes/apps/identity/kanidm/config/groups.yaml
+++ b/kubernetes/apps/identity/kanidm/config/groups.yaml
@@ -12,6 +12,16 @@ spec:
 apiVersion: kaniop.rs/v1beta1
 kind: KanidmGroup
 metadata:
+  name: forgejo-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - ebrody
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
   name: penpot-users
 spec:
   kanidmRef:

--- a/kubernetes/apps/identity/kanidm/config/kustomization.yaml
+++ b/kubernetes/apps/identity/kanidm/config/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./externalsecret-s3.yaml
   - ./persons.yaml
   - ./groups.yaml
+  - ./oauth2-forgejo.yaml
   - ./oauth2-penpot.yaml

--- a/kubernetes/apps/identity/kanidm/config/oauth2-forgejo.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-forgejo.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: forgejo
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: Forgejo
+  origin: "https://git.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://git.00o.sh/user/oauth2/kanidm/callback"
+  scopeMap:
+    - group: forgejo-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/utils/forgejo/app/externalsecret.yaml
+++ b/kubernetes/apps/utils/forgejo/app/externalsecret.yaml
@@ -24,6 +24,16 @@ spec:
         FORGEJO__database__USER: "{{ .FORGEJO_POSTGRES_USER }}"
         FORGEJO__database__PASSWD: "{{ .FORGEJO_POSTGRES_PASSWORD }}"
         FORGEJO__security__SECRET_KEY: "{{ .FORGEJO_SECRET_KEY }}"
+        FORGEJO_OIDC_CLIENT_SECRET: "{{ .FORGEJO_OIDC_CLIENT_SECRET }}"
+  data:
+    - secretKey: FORGEJO_OIDC_CLIENT_SECRET
+      sourceRef:
+        storeRef:
+          name: kubernetes-identity
+          kind: ClusterSecretStore
+      remoteRef:
+        key: forgejo-kanidm-oauth2-credentials
+        property: CLIENT_SECRET
   dataFrom:
     - extract:
         key: forgejo

--- a/kubernetes/apps/utils/forgejo/app/externalsecret.yaml
+++ b/kubernetes/apps/utils/forgejo/app/externalsecret.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: forgejo
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: forgejo-secret
+    template:
+      engineVersion: v2
+      data:
+        INIT_POSTGRES_DBNAME: "{{ .FORGEJO_POSTGRES_DB }}"
+        INIT_POSTGRES_HOST: postgres-rw.database.svc.cluster.local
+        INIT_POSTGRES_PORT: "5432"
+        INIT_POSTGRES_USER: "{{ .FORGEJO_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .FORGEJO_POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        FORGEJO__database__HOST: "postgres-rw.database.svc.cluster.local:5432"
+        FORGEJO__database__NAME: "{{ .FORGEJO_POSTGRES_DB }}"
+        FORGEJO__database__USER: "{{ .FORGEJO_POSTGRES_USER }}"
+        FORGEJO__database__PASSWD: "{{ .FORGEJO_POSTGRES_PASSWORD }}"
+        FORGEJO__security__SECRET_KEY: "{{ .FORGEJO_SECRET_KEY }}"
+  dataFrom:
+    - extract:
+        key: forgejo
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
@@ -29,10 +29,10 @@ spec:
               tag: 10.0.1
             env:
               FORGEJO__database__DB_TYPE: postgres
-              FORGEJO__server__DOMAIN: forgejo.00o.sh
-              FORGEJO__server__ROOT_URL: https://forgejo.00o.sh
+              FORGEJO__server__DOMAIN: git.00o.sh
+              FORGEJO__server__ROOT_URL: https://git.00o.sh
               FORGEJO__server__HTTP_PORT: &port 3000
-              FORGEJO__server__SSH_DOMAIN: forgejo.00o.sh
+              FORGEJO__server__SSH_DOMAIN: git.00o.sh
               FORGEJO__server__SSH_PORT: &sshPort 22
               FORGEJO__server__SSH_LISTEN_PORT: *sshPort
               FORGEJO__server__LFS_START_SERVER: "true"
@@ -77,7 +77,7 @@ spec:
         type: LoadBalancer
         controller: forgejo
         annotations:
-          external-dns.alpha.kubernetes.io/hostname: forgejo.00o.sh
+          external-dns.alpha.kubernetes.io/hostname: git.00o.sh
           lbipam.cilium.io/ips: 10.0.6.20
         externalTrafficPolicy: Cluster
         ports:
@@ -86,7 +86,7 @@ spec:
     route:
       app:
         hostnames:
-          - forgejo.00o.sh
+          - git.00o.sh
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
@@ -38,6 +38,10 @@ spec:
               FORGEJO__server__LFS_START_SERVER: "true"
               FORGEJO__service__DISABLE_REGISTRATION: "false"
               FORGEJO__service__REQUIRE_SIGNIN_VIEW: "false"
+              FORGEJO__openid__ENABLE_OPENID_SIGNIN: "true"
+              FORGEJO__oauth2_client__ENABLE_AUTO_REGISTRATION: "true"
+              FORGEJO__oauth2_client__OPENID_CONNECT_SCOPES: "openid email profile"
+              FORGEJO__oauth2_client__USERNAME: preferred_username
             envFrom:
               - secretRef:
                   name: forgejo-secret

--- a/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
               FORGEJO__server__DOMAIN: forgejo.00o.sh
               FORGEJO__server__ROOT_URL: https://forgejo.00o.sh
               FORGEJO__server__HTTP_PORT: &port 3000
-              FORGEJO__server__SSH_DOMAIN: git.00o.sh
+              FORGEJO__server__SSH_DOMAIN: forgejo.00o.sh
               FORGEJO__server__SSH_PORT: &sshPort 22
               FORGEJO__server__SSH_LISTEN_PORT: *sshPort
               FORGEJO__server__LFS_START_SERVER: "true"
@@ -77,7 +77,7 @@ spec:
         type: LoadBalancer
         controller: forgejo
         annotations:
-          external-dns.alpha.kubernetes.io/hostname: git.00o.sh
+          external-dns.alpha.kubernetes.io/hostname: forgejo.00o.sh
           lbipam.cilium.io/ips: 10.0.6.20
         externalTrafficPolicy: Cluster
         ports:
@@ -94,9 +94,9 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *port
-      git:
+      external:
         hostnames:
-          - git.00o.sh
+          - forgejo.00o.sh
         parentRefs:
           - name: envoy-external
             namespace: network

--- a/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
@@ -1,0 +1,105 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: forgejo
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: forgejo
+  interval: 1h
+  values:
+    controllers:
+      forgejo:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18@sha256:3c54d39f19fdb82ed5b3f286450e4071133cc6025bd0e25856bc2c522f8fc030
+            envFrom:
+              - secretRef:
+                  name: forgejo-secret
+        containers:
+          app:
+            image:
+              repository: codeberg.org/forgejo/forgejo
+              tag: 10.0.1
+            env:
+              FORGEJO__database__DB_TYPE: postgres
+              FORGEJO__server__DOMAIN: forgejo.00o.sh
+              FORGEJO__server__ROOT_URL: https://forgejo.00o.sh
+              FORGEJO__server__HTTP_PORT: &port 3000
+              FORGEJO__server__SSH_DOMAIN: forgejo.00o.sh
+              FORGEJO__server__SSH_PORT: &sshPort 22
+              FORGEJO__server__SSH_LISTEN_PORT: *sshPort
+              FORGEJO__server__LFS_START_SERVER: "true"
+              FORGEJO__service__DISABLE_REGISTRATION: "false"
+              FORGEJO__service__REQUIRE_SIGNIN_VIEW: "false"
+            envFrom:
+              - secretRef:
+                  name: forgejo-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/healthz
+                    port: *port
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+    service:
+      app:
+        controller: forgejo
+        ports:
+          http:
+            port: *port
+      ssh:
+        type: LoadBalancer
+        controller: forgejo
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: forgejo.00o.sh
+          lbipam.cilium.io/ips: 10.0.6.20
+        externalTrafficPolicy: Cluster
+        ports:
+          ssh:
+            port: *sshPort
+    route:
+      app:
+        hostnames:
+          - forgejo.00o.sh
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      data:
+        existingClaim: forgejo
+        globalMounts:
+          - path: /data
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
@@ -29,10 +29,10 @@ spec:
               tag: 10.0.1
             env:
               FORGEJO__database__DB_TYPE: postgres
-              FORGEJO__server__DOMAIN: forgejo.00o.sh
-              FORGEJO__server__ROOT_URL: https://forgejo.00o.sh
+              FORGEJO__server__DOMAIN: git.00o.sh
+              FORGEJO__server__ROOT_URL: https://git.00o.sh
               FORGEJO__server__HTTP_PORT: &port 3000
-              FORGEJO__server__SSH_DOMAIN: forgejo.00o.sh
+              FORGEJO__server__SSH_DOMAIN: git.00o.sh
               FORGEJO__server__SSH_PORT: &sshPort 22
               FORGEJO__server__SSH_LISTEN_PORT: *sshPort
               FORGEJO__server__LFS_START_SERVER: "true"
@@ -77,7 +77,7 @@ spec:
         type: LoadBalancer
         controller: forgejo
         annotations:
-          external-dns.alpha.kubernetes.io/hostname: forgejo.00o.sh
+          external-dns.alpha.kubernetes.io/hostname: git.00o.sh
           lbipam.cilium.io/ips: 10.0.6.20
         externalTrafficPolicy: Cluster
         ports:
@@ -86,7 +86,7 @@ spec:
     route:
       app:
         hostnames:
-          - forgejo.00o.sh
+          - git.00o.sh
         parentRefs:
           - name: envoy-internal
             namespace: network
@@ -96,7 +96,7 @@ spec:
                 port: *port
       external:
         hostnames:
-          - forgejo.00o.sh
+          - git.00o.sh
         parentRefs:
           - name: envoy-external
             namespace: network

--- a/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
@@ -94,6 +94,17 @@ spec:
           - backendRefs:
               - identifier: app
                 port: *port
+      git:
+        hostnames:
+          - git.00o.sh
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
     persistence:
       data:
         existingClaim: forgejo

--- a/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
@@ -37,9 +37,9 @@ spec:
               - |
                 forgejo environment-to-ini
                 forgejo migrate
-                if ! forgejo admin auth list | grep -q kanidm; then
+                if ! forgejo admin auth list | grep -q OIDC; then
                   forgejo admin auth add-oauth \
-                    --name kanidm \
+                    --name OIDC \
                     --provider openidConnect \
                     --key forgejo \
                     --secret "${FORGEJO_OIDC_CLIENT_SECRET}" \

--- a/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
@@ -22,6 +22,30 @@ spec:
             envFrom:
               - secretRef:
                   name: forgejo-secret
+          init-oauth:
+            dependsOn: init-db
+            image:
+              repository: codeberg.org/forgejo/forgejo
+              tag: 10.0.1
+            env:
+              FORGEJO__database__DB_TYPE: postgres
+            envFrom:
+              - secretRef:
+                  name: forgejo-secret
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                forgejo environment-to-ini
+                forgejo migrate
+                if ! forgejo admin auth list | grep -q kanidm; then
+                  forgejo admin auth add-oauth \
+                    --name kanidm \
+                    --provider openidConnect \
+                    --key forgejo \
+                    --secret "${FORGEJO_OIDC_CLIENT_SECRET}" \
+                    --auto-discover-url "https://auth.00o.sh/oauth2/openid/forgejo/.well-known/openid-configuration" \
+                    --scopes "openid email profile"
+                fi
         containers:
           app:
             image:

--- a/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
@@ -29,8 +29,8 @@ spec:
               tag: 10.0.1
             env:
               FORGEJO__database__DB_TYPE: postgres
-              FORGEJO__server__DOMAIN: git.00o.sh
-              FORGEJO__server__ROOT_URL: https://git.00o.sh
+              FORGEJO__server__DOMAIN: forgejo.00o.sh
+              FORGEJO__server__ROOT_URL: https://forgejo.00o.sh
               FORGEJO__server__HTTP_PORT: &port 3000
               FORGEJO__server__SSH_DOMAIN: git.00o.sh
               FORGEJO__server__SSH_PORT: &sshPort 22
@@ -86,7 +86,7 @@ spec:
     route:
       app:
         hostnames:
-          - git.00o.sh
+          - forgejo.00o.sh
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/utils/forgejo/app/kustomization.yaml
+++ b/kubernetes/apps/utils/forgejo/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/utils/forgejo/app/ocirepository.yaml
+++ b/kubernetes/apps/utils/forgejo/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: forgejo
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/utils/forgejo/ks.yaml
+++ b/kubernetes/apps/utils/forgejo/ks.yaml
@@ -1,0 +1,33 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app forgejo
+  namespace: flux-system
+spec:
+  targetNamespace: utils
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+    - name: postgres-cluster
+      namespace: database
+    - name: onepassword
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/utils/forgejo/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 10Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/utils/forgejo/ks.yaml
+++ b/kubernetes/apps/utils/forgejo/ks.yaml
@@ -19,6 +19,8 @@ spec:
       namespace: database
     - name: onepassword
       namespace: external-secrets
+    - name: kanidm-config
+      namespace: identity
   interval: 1h
   path: ./kubernetes/apps/utils/forgejo/app
   postBuild:

--- a/kubernetes/apps/utils/kustomization.yaml
+++ b/kubernetes/apps/utils/kustomization.yaml
@@ -9,6 +9,7 @@ components:
 
 resources:
   - ./namespace.yaml
+  - ./forgejo/ks.yaml
   - ./homepage/ks.yaml
   - ./penpot/ks.yaml
   - ./smtp-relay/ks.yaml


### PR DESCRIPTION
## Summary
This PR adds a complete Forgejo (self-hosted Git service) deployment to the Kubernetes cluster in the `utils` namespace. Forgejo is configured to use PostgreSQL for data persistence and integrates with the existing 1Password secret management system.

## Key Changes
- **ExternalSecret Configuration**: Added secret management for Forgejo that pulls credentials from 1Password, including PostgreSQL connection details and application secrets
- **Helm Release**: Deployed Forgejo using the bjw-s app-template Helm chart with:
  - PostgreSQL database backend integration
  - HTTP service on port 3000
  - SSH service exposed via LoadBalancer with static IP (10.0.6.20)
  - Dual routing configuration (internal and external Envoy gateways)
  - Health checks and resource limits
  - Init container for database initialization
- **OCI Repository**: Added Helm chart source pointing to the app-template v4.6.2
- **Kustomization**: Created Flux Kustomization resource with proper dependencies on PostgreSQL cluster and 1Password external secrets
- **Namespace Integration**: Registered Forgejo in the utils namespace kustomization

## Notable Implementation Details
- Uses `codeberg.org/forgejo/forgejo:10.0.1` image
- Configured with domain `git.00o.sh` for both HTTP and SSH access
- Persistent storage via existing `forgejo` PVC mounted at `/data`
- Security context enforces non-root user (UID 1000)
- Auto-reload annotations enabled for configuration changes
- Depends on `postgres-cluster` and `onepassword` being deployed first

https://claude.ai/code/session_017uCRLywvqqPq5hRqtkLEXE