### PR TITLE
fix(kubernetes): wait for kanidm-tls certificate before starting pod

### DIFF
--- a/kubernetes/apps/identity/kanidm/ks.yaml
+++ b/kubernetes/apps/identity/kanidm/ks.yaml
@@ -25,6 +25,11 @@ spec:
     - name: kaniop
     - name: cert-manager
       namespace: cert-manager
+  healthChecks:
+    - apiVersion: cert-manager.io/v1
+      kind: Certificate
+      name: kanidm-tls
+      namespace: identity
   interval: 1h
   path: ./kubernetes/apps/identity/kanidm/instance
   postBuild:


### PR DESCRIPTION
Add healthCheck on the Certificate resource so Flux waits for cert-manager to issue the TLS secret before the Kanidm StatefulSet starts mounting it.

https://claude.ai/code/session_01Mq3NripjTc14dF6Eh2nosX