### PR TITLE
fix(kubernetes): mount writable cache dir for kanidm tools sidecar

### DIFF
--- a/kubernetes/apps/identity/kanidm/instance/helmrelease.yaml
+++ b/kubernetes/apps/identity/kanidm/instance/helmrelease.yaml
@@ -130,9 +130,9 @@ spec:
           kanidm:
             app:
               - path: /var/run
-      tools-home:
+      tools-cache:
         type: emptyDir
         advancedMounts:
           kanidm:
             tools:
-              - path: /home/kanidm
+              - path: /.cache


### PR DESCRIPTION
The kanidm CLI stores session tokens in ~/.cache which fails on a read-only filesystem. Mount an emptyDir at /.cache for token persistence.

https://claude.ai/code/session_01Mq3NripjTc14dF6Eh2nosX