### PR TITLE
feat(kubernetes): add Kanidm user/group/OAuth2 CRDs and Penpot OIDC

### DIFF
--- a/kubernetes/apps/identity/kanidm/config/groups.yaml
+++ b/kubernetes/apps/identity/kanidm/config/groups.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: app-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - ebrody
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: penpot-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - ebrody

--- a/kubernetes/apps/identity/kanidm/config/kustomization.yaml
+++ b/kubernetes/apps/identity/kanidm/config/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./persons.yaml
+  - ./groups.yaml
+  - ./oauth2-penpot.yaml

--- a/kubernetes/apps/identity/kanidm/config/oauth2-penpot.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-penpot.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: penpot
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: Penpot
+  origin: "https://penpot.00o.sh"
+  redirectUrl: "https://penpot.00o.sh/api/auth/oauth/kanidm/callback"
+  scopeMaps:
+    - group: penpot-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/persons.yaml
+++ b/kubernetes/apps/identity/kanidm/config/persons.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmPersonAccount
+metadata:
+  name: ebrody
+spec:
+  kanidmRef:
+    name: kanidm
+  personAttributes:
+    displayname: E Brody
+    mail:
+      - ebrody@bbb.consulting

--- a/kubernetes/apps/identity/kanidm/instance/helmrelease.yaml
+++ b/kubernetes/apps/identity/kanidm/instance/helmrelease.yaml
@@ -97,10 +97,7 @@ spec:
 
     persistence:
       data:
-        type: persistentVolumeClaim
-        accessMode: ReadWriteOnce
-        size: 10Gi
-        storageClass: openebs-hostpath
+        existingClaim: kanidm
         advancedMounts:
           kanidm:
             app:

--- a/kubernetes/apps/identity/kanidm/ks.yaml
+++ b/kubernetes/apps/identity/kanidm/ks.yaml
@@ -21,10 +21,14 @@ kind: Kustomization
 metadata:
   name: kanidm
 spec:
+  components:
+    - ../../../../components/volsync
   dependsOn:
     - name: kaniop
     - name: cert-manager
       namespace: cert-manager
+    - name: volsync
+      namespace: volsync-system
   healthChecks:
     - apiVersion: cert-manager.io/v1
       kind: Certificate
@@ -33,9 +37,32 @@ spec:
   interval: 1h
   path: ./kubernetes/apps/identity/kanidm/instance
   postBuild:
+    substitute:
+      APP: kanidm
+      VOLSYNC_CAPACITY: 10Gi
+      VOLSYNC_PUID: "999"
+      VOLSYNC_PGID: "999"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: identity
+  wait: false
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kanidm-config
+spec:
+  dependsOn:
+    - name: kanidm
+  interval: 1h
+  path: ./kubernetes/apps/identity/kanidm/config
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/utils/penpot/app/externalsecret.yaml
+++ b/kubernetes/apps/utils/penpot/app/externalsecret.yaml
@@ -14,6 +14,7 @@ spec:
       engineVersion: v2
       data:
         PENPOT_SECRET_KEY: "{{ .PENPOT_SECRET_KEY }}"
+        PENPOT_OIDC_CLIENT_SECRET: "{{ .PENPOT_OIDC_CLIENT_SECRET }}"
         PENPOT_DATABASE_URI: "postgresql://postgres-rw.database.svc.cluster.local:5432/{{ .PENPOT_POSTGRES_DB }}"
         INIT_POSTGRES_DBNAME: "{{ .PENPOT_POSTGRES_DB }}"
         INIT_POSTGRES_HOST: postgres-rw.database.svc.cluster.local

--- a/kubernetes/apps/utils/penpot/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/penpot/app/helmrelease.yaml
@@ -29,7 +29,20 @@ spec:
               tag: 2.13.0
             env:
               PENPOT_PUBLIC_URI: https://penpot.00o.sh
-              PENPOT_FLAGS: enable-registration enable-login-with-password disable-email-verification
+              PENPOT_FLAGS: enable-registration enable-login-with-password enable-login-with-oidc disable-email-verification
+              PENPOT_OIDC_CLIENT_ID: penpot
+              PENPOT_OIDC_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: penpot-secret
+                    key: PENPOT_OIDC_CLIENT_SECRET
+              PENPOT_OIDC_BASE_URI: https://auth.00o.sh/oauth2/openid/penpot
+              PENPOT_OIDC_AUTH_URI: https://auth.00o.sh/ui/oauth2
+              PENPOT_OIDC_TOKEN_URI: https://auth.00o.sh/oauth2/token
+              PENPOT_OIDC_USER_URI: https://auth.00o.sh/oauth2/openid/penpot/userinfo
+              PENPOT_OIDC_SCOPES: "openid email profile"
+              PENPOT_OIDC_NAME_ATTR: name
+              PENPOT_OIDC_EMAIL_ATTR: email
               PENPOT_DATABASE_URI:
                 valueFrom:
                   secretKeyRef:
@@ -87,7 +100,7 @@ spec:
               repository: penpotapp/frontend
               tag: 2.13.0
             env:
-              PENPOT_FLAGS: enable-registration enable-login-with-password disable-email-verification
+              PENPOT_FLAGS: enable-registration enable-login-with-password enable-login-with-oidc disable-email-verification
               PENPOT_BACKEND_URI: http://penpot-backend:6060
               PENPOT_EXPORTER_URI: http://penpot-exporter:6061
             probes:


### PR DESCRIPTION
- Create ebrody person account (ebrody@bbb.consulting)
- Create app-users and penpot-users groups
- Create Penpot OAuth2 client with scope maps
- Wire Penpot backend/frontend with OIDC env vars
- Add PENPOT_OIDC_CLIENT_SECRET to ExternalSecret (1Password)
- Add Volsync backup for Kanidm PVC
- Switch Kanidm data PVC to Volsync-managed claim

After deploying: retrieve Penpot OAuth2 client secret from Kanidm and store it in 1Password under the penpot item as PENPOT_OIDC_CLIENT_SECRET.

https://claude.ai/code/session_01Mq3NripjTc14dF6Eh2nosX