### PR TITLE
fix(kubernetes): fix KanidmOAuth2Client CRD field names and types

### DIFF
--- a/kubernetes/apps/identity/kanidm/config/oauth2-penpot.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-penpot.yaml
@@ -8,8 +8,9 @@ spec:
     name: kanidm
   displayname: Penpot
   origin: "https://penpot.00o.sh"
-  redirectUrl: "https://penpot.00o.sh/api/auth/oauth/kanidm/callback"
-  scopeMaps:
+  redirectUrl:
+    - "https://penpot.00o.sh/api/auth/oauth/kanidm/callback"
+  scopeMap:
     - group: penpot-users
       scopes:
         - openid


### PR DESCRIPTION
redirectUrl must be a list, not a string. scopeMaps -> scopeMap per the Kaniop CRD schema (camelCase serde rename).

https://claude.ai/code/session_01Mq3NripjTc14dF6Eh2nosX