### PR TITLE
Add S3 bucket initialization job for CloudNative-PG backups

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/bucket-init.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/bucket-init.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cnpg-bucket-init
+spec:
+  ttlSecondsAfterFinished: 3600
+  backoffLimit: 6
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bucket-init
+          image: amazon/aws-cli:2.27.28
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: cloudnative-pg-secret
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cloudnative-pg-secret
+                  key: AWS_SECRET_ACCESS_KEY
+            - name: AWS_DEFAULT_REGION
+              value: eu-west-1
+          command:
+            - /bin/sh
+            - -c
+            - |
+              aws --endpoint-url http://garage.volsync-system.svc.cluster.local:3900 \
+                s3api head-bucket --bucket cnpg 2>/dev/null && \
+                echo "Bucket cnpg already exists" && exit 0
+              aws --endpoint-url http://garage.volsync-system.svc.cluster.local:3900 \
+                s3 mb s3://cnpg && \
+                echo "Bucket cnpg created successfully"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault

--- a/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./bucket-init.yaml
   - ./cluster.yaml
   - ./externalsecret.yaml
   - ./scheduledbackup.yaml


### PR DESCRIPTION
## Summary
This PR adds a Kubernetes Job that initializes an S3 bucket for CloudNative-PG backups on the Garage S3-compatible storage service.

## Changes
- **New file**: `bucket-init.yaml` - Adds a one-time initialization Job that:
  - Checks if the `cnpg` S3 bucket already exists
  - Creates the bucket if it doesn't exist
  - Uses AWS CLI to interact with Garage S3 endpoint
  - Runs with minimal security context (non-root user, no capabilities)
  
- **Modified**: `kustomization.yaml` - Includes the new bucket-init Job in the CloudNative-PG cluster resources

## Implementation Details
- The Job uses `amazon/aws-cli:2.27.28` image to interact with the S3-compatible Garage service
- AWS credentials are sourced from the existing `cloudnative-pg-secret`
- Configured to target the Garage endpoint at `http://garage.volsync-system.svc.cluster.local:3900`
- Job is set to auto-cleanup after 1 hour (`ttlSecondsAfterFinished: 3600`)
- Implements security best practices: non-root user (UID 1000), dropped capabilities, RuntimeDefault seccomp profile
- Idempotent design - safely handles cases where bucket already exists

https://claude.ai/code/session_01JcdeKAURREctuzS99nhRhU