### PR TITLE
fix(kubernetes): add ExternalSecret for Kaniop admin passwords from 1…

### DIFF
--- a/kubernetes/apps/identity/kanidm/config/externalsecret.yaml
+++ b/kubernetes/apps/identity/kanidm/config/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kanidm-admin-passwords
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: kanidm-admin-passwords
+    template:
+      engineVersion: v2
+      data:
+        admin: "{{ .admin_password }}"
+        idm_admin: "{{ .idm_admin_password }}"
+  dataFrom:
+    - extract:
+        key: kanidm

--- a/kubernetes/apps/identity/kanidm/config/kustomization.yaml
+++ b/kubernetes/apps/identity/kanidm/config/kustomization.yaml
@@ -3,6 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./persons.yaml
   - ./groups.yaml
   - ./oauth2-penpot.yaml

--- a/kubernetes/apps/identity/kanidm/ks.yaml
+++ b/kubernetes/apps/identity/kanidm/ks.yaml
@@ -61,6 +61,8 @@ metadata:
 spec:
   dependsOn:
     - name: kanidm
+    - name: onepassword
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/identity/kanidm/config
   prune: true


### PR DESCRIPTION
…Password

Kaniop operator needs kanidm-admin-passwords secret to authenticate to the Kanidm API for managing users, groups, and OAuth2 clients. Pull admin and idm_admin passwords from 1Password kanidm item.

https://claude.ai/code/session_01Mq3NripjTc14dF6Eh2nosX