### PR TITLE
Remove hardcoded VOLSYNC UID/GID from Kanidm kustomization

### DIFF
--- a/kubernetes/apps/identity/kanidm/ks.yaml
+++ b/kubernetes/apps/identity/kanidm/ks.yaml
@@ -40,8 +40,6 @@ spec:
     substitute:
       APP: kanidm
       VOLSYNC_CAPACITY: 10Gi
-      VOLSYNC_PUID: "999"
-      VOLSYNC_PGID: "999"
     substituteFrom:
       - name: cluster-secrets
         kind: Secret


### PR DESCRIPTION
## Summary
Removed hardcoded VOLSYNC_PUID and VOLSYNC_PGID values from the Kanidm kustomization file. These values were previously set to "999" but are no longer needed in the substitution configuration.

## Changes
- Removed `VOLSYNC_PUID: "999"` from the kustomization substitutes
- Removed `VOLSYNC_PGID: "999"` from the kustomization substitutes

## Details
The hardcoded UID/GID values for Volsync have been removed, likely allowing these values to be sourced from elsewhere (such as cluster-secrets or default configurations) or indicating they are no longer required for this deployment.

https://claude.ai/code/session_01X3H8zxbi1qzJE3fVQqnd4g