### PR TITLE
fix(utils): remove init-oauth container causing crash loop

### DIFF
--- a/kubernetes/apps/identity/kanidm/config/oauth2-forgejo.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-forgejo.yaml
@@ -10,7 +10,7 @@ spec:
   origin: "https://git.00o.sh"
   allowInsecureClientDisablePkce: true
   redirectUrl:
-    - "https://git.00o.sh/user/oauth2/kanidm/callback"
+    - "https://git.00o.sh/user/oauth2/OIDC/callback"
   scopeMap:
     - group: forgejo-users
       scopes:

--- a/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/forgejo/app/helmrelease.yaml
@@ -22,30 +22,6 @@ spec:
             envFrom:
               - secretRef:
                   name: forgejo-secret
-          init-oauth:
-            dependsOn: init-db
-            image:
-              repository: codeberg.org/forgejo/forgejo
-              tag: 10.0.1
-            env:
-              FORGEJO__database__DB_TYPE: postgres
-            envFrom:
-              - secretRef:
-                  name: forgejo-secret
-            command: ["/bin/sh", "-c"]
-            args:
-              - |
-                forgejo environment-to-ini
-                forgejo migrate
-                if ! forgejo admin auth list | grep -q OIDC; then
-                  forgejo admin auth add-oauth \
-                    --name OIDC \
-                    --provider openidConnect \
-                    --key forgejo \
-                    --secret "${FORGEJO_OIDC_CLIENT_SECRET}" \
-                    --auto-discover-url "https://auth.00o.sh/oauth2/openid/forgejo/.well-known/openid-configuration" \
-                    --scopes "openid email profile"
-                fi
         containers:
           app:
             image:


### PR DESCRIPTION
The init container can't reliably run forgejo CLI commands before the main server has started. Also fix OAuth2 redirect URL to match the auth source name (OIDC).

The OAuth2 auth source will need a one-time setup via the admin UI or API after first boot.

https://claude.ai/code/session_017uCRLywvqqPq5hRqtkLEXE