### PR TITLE
feat(identity): add all-apps nested group for centralized app access

### DIFF
--- a/kubernetes/apps/identity/kanidm/config/groups.yaml
+++ b/kubernetes/apps/identity/kanidm/config/groups.yaml
@@ -2,7 +2,7 @@
 apiVersion: kaniop.rs/v1beta1
 kind: KanidmGroup
 metadata:
-  name: app-users
+  name: all-apps
 spec:
   kanidmRef:
     name: kanidm
@@ -17,7 +17,7 @@ spec:
   kanidmRef:
     name: kanidm
   members:
-    - ebrody
+    - all-apps
 ---
 apiVersion: kaniop.rs/v1beta1
 kind: KanidmGroup
@@ -27,4 +27,4 @@ spec:
   kanidmRef:
     name: kanidm
   members:
-    - ebrody
+    - all-apps


### PR DESCRIPTION
Replace per-user membership in individual app groups with an all-apps
group. Users added to all-apps automatically inherit access to all
OAuth2 apps (forgejo-users, penpot-users) via Kanidm nested groups.
This preserves granular per-app group control while providing a
convenient admin-level group.

https://claude.ai/code/session_019jiGTnX5M9KGzbmwQBNpuW