### PR TITLE
feat(database): add DbGate web-based database manager

### DIFF
--- a/kubernetes/apps/database/dbgate/app/externalsecret.yaml
+++ b/kubernetes/apps/database/dbgate/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: dbgate-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: dbgate-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: dbgate-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/database/dbgate/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dbgate/app/helmrelease.yaml
@@ -1,0 +1,85 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dbgate
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: dbgate
+  interval: 1h
+  values:
+    controllers:
+      dbgate:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image:
+              repository: dbgate/dbgate
+              tag: 7.0.3-alpine
+            env:
+              CONNECTIONS: postgres-cluster
+              LABEL_postgres-cluster: Postgres Cluster
+              SERVER_postgres-cluster: postgres-rw.database.svc.cluster.local
+              USER_postgres-cluster: postgres
+              PASSWORD_postgres-cluster:
+                valueFrom:
+                  secretKeyRef:
+                    name: cloudnative-pg-secret
+                    key: password
+              PORT_postgres-cluster: "5432"
+              ENGINE_postgres-cluster: postgres@dbgate-plugin-postgres
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &port 3000
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+    service:
+      app:
+        controller: dbgate
+        ports:
+          http:
+            port: *port
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Infrastructure
+          gethomepage.dev/name: DbGate
+          gethomepage.dev/icon: mdi-database-search
+          gethomepage.dev/description: Database Manager
+          gethomepage.dev/href: "https://dbgate.00o.sh"
+        hostnames:
+          - dbgate.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+    persistence:
+      data:
+        type: emptyDir
+        advancedMounts:
+          dbgate:
+            app:
+              - path: /root/.dbgate

--- a/kubernetes/apps/database/dbgate/app/kustomization.yaml
+++ b/kubernetes/apps/database/dbgate/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/database/dbgate/app/kustomization.yaml
+++ b/kubernetes/apps/database/dbgate/app/kustomization.yaml
@@ -3,5 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/database/dbgate/app/ocirepository.yaml
+++ b/kubernetes/apps/database/dbgate/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: dbgate
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/database/dbgate/app/securitypolicy.yaml
+++ b/kubernetes/apps/database/dbgate/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: dbgate-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: dbgate-app
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/dbgate"
+    clientID: "dbgate"
+    clientSecret:
+      name: dbgate-oidc-secret
+    redirectURL: "https://dbgate.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/database/dbgate/ks.yaml
+++ b/kubernetes/apps/database/dbgate/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dbgate
+spec:
+  dependsOn:
+    - name: cloudnative-pg
+  interval: 1h
+  path: ./kubernetes/apps/database/dbgate/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  wait: false

--- a/kubernetes/apps/database/dbgate/ks.yaml
+++ b/kubernetes/apps/database/dbgate/ks.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   dependsOn:
     - name: cloudnative-pg
+    - name: kanidm-config
+      namespace: identity
+    - name: onepassword
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/database/dbgate/app
   postBuild:

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -10,4 +10,5 @@ components:
 resources:
   - ./namespace.yaml
   - ./cloudnative-pg/ks.yaml
+  - ./dbgate/ks.yaml
   - ./dragonfly/ks.yaml

--- a/kubernetes/apps/identity/kanidm/config/groups.yaml
+++ b/kubernetes/apps/identity/kanidm/config/groups.yaml
@@ -22,6 +22,16 @@ spec:
 apiVersion: kaniop.rs/v1beta1
 kind: KanidmGroup
 metadata:
+  name: dbgate-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
   name: penpot-users
 spec:
   kanidmRef:

--- a/kubernetes/apps/identity/kanidm/config/kustomization.yaml
+++ b/kubernetes/apps/identity/kanidm/config/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - ./externalsecret-s3.yaml
   - ./persons.yaml
   - ./groups.yaml
+  - ./oauth2-dbgate.yaml
   - ./oauth2-forgejo.yaml
   - ./oauth2-penpot.yaml

--- a/kubernetes/apps/identity/kanidm/config/oauth2-dbgate.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-dbgate.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: dbgate
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: DbGate
+  origin: "https://dbgate.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://dbgate.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: dbgate-users
+      scopes:
+        - openid
+        - email
+        - profile


### PR DESCRIPTION
Deploy DbGate 7.0.3 to the database namespace for managing PostgreSQL
and other databases via a web UI. Pre-configured with a connection to
the CloudNative-PG postgres cluster, exposed internally at dbgate.00o.sh.

https://claude.ai/code/session_016s5ZMuH8BFqxDhiHosWPns