### PR TITLE
fix(kubernetes): pull forgejo instance URL from 1Password secret

### DIFF
--- a/kubernetes/apps/forgejo-runner-system/forgejo-runner/app/externalsecret.yaml
+++ b/kubernetes/apps/forgejo-runner-system/forgejo-runner/app/externalsecret.yaml
@@ -13,6 +13,7 @@ spec:
     template:
       data:
         token: "{{ .FORGEJO_RUNNER_TOKEN }}"
+        instance_url: "{{ .FORGEJO_INSTANCE_URL }}"
   dataFrom:
     - extract:
         key: forgejo-runner

--- a/kubernetes/apps/forgejo-runner-system/forgejo-runner/app/helmrelease.yaml
+++ b/kubernetes/apps/forgejo-runner-system/forgejo-runner/app/helmrelease.yaml
@@ -34,7 +34,10 @@ spec:
         tag: 28-dind
       env:
         - name: GITEA_INSTANCE_URL
-          value: "${FORGEJO_INSTANCE_URL}"
+          valueFrom:
+            secretKeyRef:
+              name: forgejo-runner-secret
+              key: instance_url
         - name: GITEA_RUNNER_EPHEMERAL
           value: "1"
       persistence:

--- a/kubernetes/apps/forgejo-runner-system/forgejo-runner/ks.yaml
+++ b/kubernetes/apps/forgejo-runner-system/forgejo-runner/ks.yaml
@@ -10,10 +10,6 @@ spec:
       namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/forgejo-runner-system/forgejo-runner/app
-  postBuild:
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/forgejo-runner-system/kustomization.yaml
+++ b/kubernetes/apps/forgejo-runner-system/kustomization.yaml
@@ -6,6 +6,7 @@ namespace: forgejo-runner-system
 
 components:
   - ../../components/alerts
+  - ../../components/sops
 
 resources:
   - ./namespace.yaml

--- a/kubernetes/apps/forgejo-runner-system/kustomization.yaml
+++ b/kubernetes/apps/forgejo-runner-system/kustomization.yaml
@@ -6,7 +6,6 @@ namespace: forgejo-runner-system
 
 components:
   - ../../components/alerts
-  - ../../components/sops
 
 resources:
   - ./namespace.yaml


### PR DESCRIPTION
Move FORGEJO_INSTANCE_URL from cluster-secrets postBuild substitution
to the ExternalSecret, sourcing it from the same 1Password item as the
runner token. Removes the need for sops component and postBuild block.

https://claude.ai/code/session_01Lpq5QArRnCAqGBJfKo5zHN