### PR TITLE
Increase PostgreSQL cluster instances and add pod anti-affinity

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -5,9 +5,13 @@ kind: Cluster
 metadata:
   name: postgres
 spec:
-  instances: 2
+  instances: 3
   imageName: ghcr.io/cloudnative-pg/postgresql:17.7-202601260808-system-bullseye
   primaryUpdateStrategy: unsupervised
+
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
 
   storage:
     size: 20Gi


### PR DESCRIPTION
## Summary
Enhanced the CloudNative PG cluster configuration to improve reliability and distribution by scaling up the number of instances and implementing pod anti-affinity rules.

## Key Changes
- **Increased cluster instances** from 2 to 3 replicas for improved high availability and fault tolerance
- **Added pod anti-affinity** configuration to ensure PostgreSQL pods are distributed across different nodes (using `kubernetes.io/hostname` topology key), preventing multiple replicas from running on the same host

## Implementation Details
The anti-affinity configuration uses the hostname topology key, which ensures that each PostgreSQL instance runs on a separate Kubernetes node. This provides better resilience against node failures and improves resource utilization across the cluster.

These changes work together to create a more robust PostgreSQL deployment with better distribution and redundancy.

https://claude.ai/code/session_01KYQaQ7LsLABsbMHLgn9oc4