### PR TITLE
fix(kubernetes): migrate CNPG backups to barman-cloud plugin

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster.yaml
@@ -38,6 +38,12 @@ spec:
       min_wal_size: 1GB
       max_wal_size: 4GB
 
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: cnpg-garage
+
   monitoring:
     enablePodMonitor: true
 
@@ -47,21 +53,3 @@ spec:
       memory: 512Mi
     limits:
       memory: 2Gi
-
-  backup:
-    retentionPolicy: 30d
-    barmanObjectStore:
-      destinationPath: s3://cnpg/
-      endpointURL: http://garage.volsync-system.svc.cluster.local:3900
-      s3Credentials:
-        accessKeyId:
-          name: cloudnative-pg-secret
-          key: AWS_ACCESS_KEY_ID
-        secretAccessKey:
-          name: cloudnative-pg-secret
-          key: AWS_SECRET_ACCESS_KEY
-      wal:
-        compression: bzip2
-        maxParallel: 2
-      data:
-        compression: bzip2

--- a/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: cnpg-garage
+spec:
+  configuration:
+    destinationPath: s3://cnpg/
+    endpointURL: http://garage.volsync-system.svc.cluster.local:3900
+    s3Credentials:
+      accessKeyId:
+        name: cloudnative-pg-secret
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        name: cloudnative-pg-secret
+        key: AWS_SECRET_ACCESS_KEY
+  wal:
+    compression: bzip2
+    maxParallel: 2
+  data:
+    compression: bzip2
+  retentionPolicy: "30d"

--- a/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/scheduledbackup.yaml
@@ -9,4 +9,7 @@ spec:
   backupOwnerReference: self
   cluster:
     name: postgres
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
   immediate: true

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -19,6 +19,24 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: plugin-barman-cloud
+spec:
+  dependsOn:
+    - name: cloudnative-pg
+  interval: 1h
+  path: ./kubernetes/apps/database/cloudnative-pg/plugin
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: cnpg-bucket-init
 spec:
   dependsOn:
@@ -46,6 +64,7 @@ metadata:
 spec:
   dependsOn:
     - name: cloudnative-pg
+    - name: plugin-barman-cloud
     - name: cnpg-bucket-init
   interval: 1h
   path: ./kubernetes/apps/database/cloudnative-pg/cluster

--- a/kubernetes/apps/database/cloudnative-pg/plugin/helmrelease.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/plugin/helmrelease.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: plugin-barman-cloud
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: plugin-barman-cloud
+  interval: 1h

--- a/kubernetes/apps/database/cloudnative-pg/plugin/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/plugin/kustomization.yaml
@@ -3,7 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./cluster.yaml
-  - ./externalsecret.yaml
-  - ./objectstore.yaml
-  - ./scheduledbackup.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/database/cloudnative-pg/plugin/ocirepository.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/plugin/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: plugin-barman-cloud
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.5.0
+  url: oci://ghcr.io/cloudnative-pg/charts/plugin-barman-cloud

--- a/kubernetes/apps/database/cloudnative-pg/recovery/cluster.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/recovery/cluster.yaml
@@ -28,18 +28,17 @@ spec:
 
   externalClusters:
     - name: postgres-backup
-      barmanObjectStore:
-        destinationPath: s3://cnpg/
-        endpointURL: http://garage.volsync-system.svc.cluster.local:3900
-        s3Credentials:
-          accessKeyId:
-            name: cloudnative-pg-secret
-            key: AWS_ACCESS_KEY_ID
-          secretAccessKey:
-            name: cloudnative-pg-secret
-            key: AWS_SECRET_ACCESS_KEY
-        wal:
-          maxParallel: 2
+      plugin:
+        name: barman-cloud.cloudnative-pg.io
+        parameters:
+          barmanObjectName: cnpg-garage
+          serverName: postgres
+
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: cnpg-garage
 
   postgresql:
     parameters:
@@ -66,22 +65,3 @@ spec:
       memory: 512Mi
     limits:
       memory: 2Gi
-
-  # Resume backups after recovery
-  backup:
-    retentionPolicy: 30d
-    barmanObjectStore:
-      destinationPath: s3://cnpg/
-      endpointURL: http://garage.volsync-system.svc.cluster.local:3900
-      s3Credentials:
-        accessKeyId:
-          name: cloudnative-pg-secret
-          key: AWS_ACCESS_KEY_ID
-        secretAccessKey:
-          name: cloudnative-pg-secret
-          key: AWS_SECRET_ACCESS_KEY
-      wal:
-        compression: bzip2
-        maxParallel: 2
-      data:
-        compression: bzip2

--- a/kubernetes/apps/database/cloudnative-pg/recovery/kustomization.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/recovery/kustomization.yaml
@@ -5,4 +5,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../cluster/externalsecret.yaml
+  - ../cluster/objectstore.yaml
   - ./cluster.yaml


### PR DESCRIPTION
The inline spec.backup.barmanObjectStore is deprecated since CNPG 1.26
and no longer functional in 1.27. This migrates to the barman-cloud
CNPG-I plugin architecture for S3 backups to Garage.

- Deploy plugin-barman-cloud Helm chart (v0.5.0)
- Add ObjectStore CRD resource for Garage S3 configuration
- Update Cluster spec to use plugins section with WAL archiver
- Update ScheduledBackup to use method: plugin
- Update recovery cluster to use plugin-based external clusters

https://claude.ai/code/session_01R86jntqTgP6A6Jnbzvkxnt