### PR TITLE
fix(kubernetes): bump forgejo runner charts to v0.2.22

### DIFF
--- a/kubernetes/apps/forgejo-runner-system/forgejo-runner-controller/app/ocirepository.yaml
+++ b/kubernetes/apps/forgejo-runner-system/forgejo-runner-controller/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.2.20
+    tag: 0.2.22
   url: oci://ghcr.io/00o-sh/act_runner/charts/act-runner-controller

--- a/kubernetes/apps/forgejo-runner-system/forgejo-runner-controller/runners/forgejo-runner/helmrelease.yaml
+++ b/kubernetes/apps/forgejo-runner-system/forgejo-runner-controller/runners/forgejo-runner/helmrelease.yaml
@@ -24,9 +24,8 @@ spec:
       size: 25Gi
     keda:
       enabled: true
-      triggerAuthenticationRef: forgejo-runner-controller
-      forgejoApiUrl: "${FORGEJO_INSTANCE_URL}"
-      forgejoApiScope: admin
+      triggerAuthenticationRef: forgejo-runner-controller-trigger-auth
+      metricsUrl: "${FORGEJO_INSTANCE_URL}/api/v1/admin/runners/jobs?status=waiting&limit=1"
       pollingInterval: 30
       cooldownPeriod: 300
       scaledJob:

--- a/kubernetes/apps/forgejo-runner-system/forgejo-runner-controller/runners/forgejo-runner/ocirepository.yaml
+++ b/kubernetes/apps/forgejo-runner-system/forgejo-runner-controller/runners/forgejo-runner/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.2.20
+    tag: 0.2.22
   url: oci://ghcr.io/00o-sh/act_runner/charts/act-runner-scale-set


### PR DESCRIPTION
Update KEDA config for v0.2.22 API changes:
- Replace forgejoApiUrl + forgejoApiScope with single metricsUrl
- Use Forgejo-specific /api/v1/admin/runners/jobs endpoint
- Fix triggerAuthenticationRef to include -trigger-auth suffix

https://claude.ai/code/session_01Lpq5QArRnCAqGBJfKo5zHN