### PR TITLE
fix(kubernetes): move kguardian patches to postRenderers

### DIFF
--- a/kubernetes/apps/kube-system/kguardian/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/kguardian/app/helmrelease.yaml
@@ -36,31 +36,33 @@ spec:
       enabled: false
     mcpServer:
       enabled: false
-  patches:
-    - target:
-        kind: Deployment
-        name: kguardian-broker
-      patch: |
-        - op: replace
-          path: /spec/template/spec/containers/0/env
-          value:
-            - name: DATABASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: kguardian-secret
-                  key: DATABASE_URL
-        - op: add
-          path: /spec/template/spec/initContainers
-          value:
-            - name: init-db
-              image: ghcr.io/home-operations/postgres-init:18@sha256:3c54d39f19fdb82ed5b3f286450e4071133cc6025bd0e25856bc2c522f8fc030
-              envFrom:
-                - secretRef:
-                    name: kguardian-secret
-    - target:
-        kind: Deployment
-        name: kguardian-database
-      patch: |
-        - op: replace
-          path: /spec/replicas
-          value: 0
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: Deployment
+              name: kguardian-broker
+            patch: |
+              - op: replace
+                path: /spec/template/spec/containers/0/env
+                value:
+                  - name: DATABASE_URL
+                    valueFrom:
+                      secretKeyRef:
+                        name: kguardian-secret
+                        key: DATABASE_URL
+              - op: add
+                path: /spec/template/spec/initContainers
+                value:
+                  - name: init-db
+                    image: ghcr.io/home-operations/postgres-init:18@sha256:3c54d39f19fdb82ed5b3f286450e4071133cc6025bd0e25856bc2c522f8fc030
+                    envFrom:
+                      - secretRef:
+                          name: kguardian-secret
+          - target:
+              kind: Deployment
+              name: kguardian-database
+            patch: |
+              - op: replace
+                path: /spec/replicas
+                value: 0


### PR DESCRIPTION
HelmRelease spec doesn't support patches directly - use postRenderers with kustomize patches to modify rendered Helm output.

https://claude.ai/code/session_01FJhpmb3AzozCBpCvMGvr7T