### PR TITLE
Add FreePBX virtual machine deployment to KubeVirt

### DIFF
--- a/kubernetes/apps/kubevirt/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - ./virtualmachines/debian-server/app/configmap.yaml
   - ./virtualmachines/ubuntu-server/app/configmap.yaml
   - ./virtualmachines/windows-server/app/configmap.yaml
+  - ./virtualmachines/freepbx/app/configmap.yaml
   - ./kubevirt/ks.yaml
   - ./cdi/ks.yaml
   - ./kubevirt-manager/ks.yaml
@@ -21,3 +22,4 @@ resources:
   - ./virtualmachines/debian-server/ks.yaml
   - ./virtualmachines/ubuntu-server/ks.yaml
   - ./virtualmachines/windows-server/ks.yaml
+  - ./virtualmachines/freepbx/ks.yaml

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/configmap.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: freepbx-vars
 data:
-  VM_NAME: freepbx
+  VM_NAME: b1-k3s01
   VM_IP: 192.168.57.14
   VM_MAC: "52:54:00:57:00:14"
   VM_CPU: "2"

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/configmap.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: freepbx-vars
+data:
+  VM_NAME: freepbx
+  VM_IP: 192.168.57.14
+  VM_MAC: "52:54:00:57:00:14"
+  VM_CPU: "2"
+  VM_MEMORY: 4G
+  VM_STORAGE: 50Gi
+  VM_GATEWAY: 192.168.57.1
+  VM_DNS: 192.168.57.1
+  VM_NETWORK: network/vm-macvtap
+  VM_IMAGE: "docker://quay.io/containerdisks/debian:12"

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/dnsendpoint.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/dnsendpoint.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: ${VM_NAME}
+spec:
+  endpoints:
+    - dnsName: ${VM_NAME}.00o.sh
+      recordTTL: 300
+      recordType: A
+      targets:
+        - ${VM_IP}

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/externalsecret.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/externalsecret.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: freepbx
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: freepbx-secret
+    template:
+      data:
+        FPBX_CF_TUNNEL_TOKEN: "{{ .FPBX_CF_TUNNEL_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: freepbx

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./virtualmachine.yaml
+  - ./dnsendpoint.yaml

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/kustomization.yaml
@@ -2,5 +2,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./virtualmachine.yaml
   - ./dnsendpoint.yaml

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/virtualmachine.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: ${VM_NAME}
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: ${VM_NAME}
+      annotations:
+        kubevirt.io/allow-pod-bridge-network-live-migration: "true"
+        k8s.v1.cni.cncf.io/networks: |-
+          [{
+            "name": "vm-macvtap",
+            "namespace": "network",
+            "mac": "${VM_MAC}"
+          }]
+    spec:
+      evictionStrategy: LiveMigrate
+      domain:
+        cpu:
+          cores: ${VM_CPU}
+        resources:
+          requests:
+            memory: ${VM_MEMORY}
+        devices:
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+            - name: cloudinitdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: lan
+              binding:
+                name: macvtap
+      networks:
+        - name: lan
+          multus:
+            networkName: ${VM_NETWORK}
+      volumes:
+        - name: rootdisk
+          dataVolume:
+            name: ${VM_NAME}-pvc
+        - name: cloudinitdisk
+          cloudInitNoCloud:
+            networkData: |
+              network:
+                version: 1
+                config:
+                  - type: physical
+                    name: enp1s0
+                    subnets:
+                      - type: static
+                        address: ${VM_IP}/24
+                        gateway: ${VM_GATEWAY}
+                        dns_nameservers:
+                          - ${VM_DNS}
+            userData: |
+              #cloud-config
+              hostname: ${VM_NAME}
+              manage_etc_hosts: true
+              no_ssh_fingerprints: true
+              users:
+                - name: user
+                  gecos: User
+                  groups: [adm, sudo]
+                  shell: /bin/bash
+                  sudo: ALL=(ALL) NOPASSWD:ALL
+                  lock_passwd: true
+                  ssh_authorized_keys:
+                    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKTGSd9Ukp/CKEWssokvlEop1wrACYVS75fdKy5gNo37
+                    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAqkeDwM1SWrSy7w+tR0oyVzLIcAU5yz5doTgI8u/eaw
+                    - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKRG6pXx4rXDOY8X5xamGwrZCb/OLTXgv963EsqI0HJp
+              package_update: true
+              package_upgrade: true
+              packages:
+                - qemu-guest-agent
+                - wget
+                - curl
+                - gnupg
+              runcmd:
+                - systemctl enable --now qemu-guest-agent || true
+                - wget -qO /root/sng_freepbx_debian_install.sh https://github.com/FreePBX/sng_freepbx_debian_install/raw/master/sng_freepbx_debian_install.sh
+                - bash /root/sng_freepbx_debian_install.sh --nointeractive
+  dataVolumeTemplates:
+    - metadata:
+        name: ${VM_NAME}-pvc
+      spec:
+        storage:
+          resources:
+            requests:
+              storage: ${VM_STORAGE}
+          accessModes:
+            - ReadWriteMany
+          storageClassName: nfs-fast
+        source:
+          registry:
+            url: "${VM_IMAGE}"

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/app/virtualmachine.yaml
@@ -86,6 +86,12 @@ spec:
                 - systemctl enable --now qemu-guest-agent || true
                 - wget -qO /root/sng_freepbx_debian_install.sh https://github.com/FreePBX/sng_freepbx_debian_install/raw/master/sng_freepbx_debian_install.sh
                 - bash /root/sng_freepbx_debian_install.sh --nointeractive
+                - mkdir -p --mode=0755 /usr/share/keyrings
+                - curl -fsSL https://pkg.cloudflare.com/cloudflare-public-v2.gpg -o /usr/share/keyrings/cloudflare-public-v2.gpg
+                - echo 'deb [signed-by=/usr/share/keyrings/cloudflare-public-v2.gpg] https://pkg.cloudflare.com/cloudflared any main' > /etc/apt/sources.list.d/cloudflared.list
+                - apt-get update
+                - apt-get install -y cloudflared
+                - cloudflared service install ${FPBX_CF_TUNNEL_TOKEN}
   dataVolumeTemplates:
     - metadata:
         name: ${VM_NAME}-pvc

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/ks.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/ks.yaml
@@ -10,6 +10,8 @@ spec:
     - name: cdi
     - name: macvtap-cni
       namespace: network
+    - name: onepassword
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/kubevirt/virtualmachines/freepbx/app
   postBuild:
@@ -18,6 +20,8 @@ spec:
         kind: Secret
       - name: freepbx-vars
         kind: ConfigMap
+      - name: freepbx-secret
+        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/ks.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: freepbx
+spec:
+  dependsOn:
+    - name: kubevirt
+    - name: cdi
+    - name: macvtap-cni
+      namespace: network
+  interval: 1h
+  path: ./kubernetes/apps/kubevirt/virtualmachines/freepbx/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+      - name: freepbx-vars
+        kind: ConfigMap
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kubevirt
+  wait: false


### PR DESCRIPTION
## Summary
This PR adds a new FreePBX virtual machine deployment to the KubeVirt infrastructure, enabling automated provisioning and configuration of a FreePBX instance on Kubernetes.

## Key Changes
- **Virtual Machine Definition**: Added `virtualmachine.yaml` with a complete KubeVirt VM specification for FreePBX including:
  - CPU (2 cores) and memory (4GB) allocation
  - Debian 12 container disk as root volume
  - Cloud-init configuration for network setup and system initialization
  - Automatic FreePBX installation via the official installer script
  - SSH key-based authentication for three authorized users
  - Live migration support with macvtap networking

- **Configuration Management**: Added `configmap.yaml` with VM parameters:
  - Network configuration (IP: 192.168.57.14, MAC, gateway, DNS)
  - Storage allocation (50Gi)
  - Container image reference (Debian 12)

- **DNS Integration**: Added `dnsendpoint.yaml` for automatic DNS record creation via ExternalDNS, mapping the VM hostname to its IP address

- **Kustomization**: 
  - Created `kustomization.yaml` for the FreePBX app resources
  - Added `ks.yaml` (Flux Kustomization) with proper dependencies on kubevirt, cdi, and macvtap-cni
  - Updated parent `kustomization.yaml` to include FreePBX configuration and deployment manifests

## Notable Implementation Details
- Uses cloud-init for zero-touch provisioning with automatic package updates and FreePBX installation
- Implements macvtap networking for direct network access
- Includes eviction strategy for live migration support in cluster maintenance scenarios
- Pre-configured with multiple SSH public keys for secure access
- Leverages Flux CD for GitOps-based deployment with variable substitution

https://claude.ai/code/session_01XXREUF9CaxrrTLo5q6p8oz