### PR TITLE
fix(kubevirt): remove invalid --nointeractive flag from FreePBX insta…

### DIFF
--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/virtualmachine.yaml
@@ -84,8 +84,9 @@ spec:
                 - gnupg
               runcmd:
                 - systemctl enable --now qemu-guest-agent || true
+                - export DEBIAN_FRONTEND=noninteractive
                 - wget -qO /root/sng_freepbx_debian_install.sh https://github.com/FreePBX/sng_freepbx_debian_install/raw/master/sng_freepbx_debian_install.sh
-                - bash /root/sng_freepbx_debian_install.sh --nointeractive
+                - bash /root/sng_freepbx_debian_install.sh
                 - mkdir -p --mode=0755 /usr/share/keyrings
                 - curl -fsSL https://pkg.cloudflare.com/cloudflare-public-v2.gpg -o /usr/share/keyrings/cloudflare-public-v2.gpg
                 - echo 'deb [signed-by=/usr/share/keyrings/cloudflare-public-v2.gpg] https://pkg.cloudflare.com/cloudflared any main' > /etc/apt/sources.list.d/cloudflared.list


### PR DESCRIPTION
…ller

The Sangoma installer script has no --nointeractive flag. Set DEBIAN_FRONTEND=noninteractive instead to suppress apt prompts.

https://claude.ai/code/session_01XXREUF9CaxrrTLo5q6p8oz