### PR TITLE
fix(kubevirt): bump FreePBX VMs to 2 CPU, 4G RAM, 50Gi storage

### DIFF
--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/configmap.yaml
@@ -7,9 +7,9 @@ data:
   VM_NAME: b1-k3s01
   VM_IP: 192.168.57.14
   VM_MAC: "52:54:00:57:00:14"
-  VM_CPU: "1"
-  VM_MEMORY: 1G
-  VM_STORAGE: 20Gi
+  VM_CPU: "2"
+  VM_MEMORY: 4G
+  VM_STORAGE: 50Gi
   VM_GATEWAY: 192.168.57.1
   VM_DNS: 192.168.57.1
   VM_NETWORK: network/vm-macvtap

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/configmap.yaml
@@ -7,9 +7,9 @@ data:
   VM_NAME: b2-k3s01
   VM_IP: 192.168.57.15
   VM_MAC: "52:54:00:57:00:15"
-  VM_CPU: "1"
-  VM_MEMORY: 1G
-  VM_STORAGE: 20Gi
+  VM_CPU: "2"
+  VM_MEMORY: 4G
+  VM_STORAGE: 50Gi
   VM_GATEWAY: 192.168.57.1
   VM_DNS: 192.168.57.1
   VM_NETWORK: network/vm-macvtap

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/configmap.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/configmap.yaml
@@ -7,9 +7,9 @@ data:
   VM_NAME: b3-k3s01
   VM_IP: 192.168.57.16
   VM_MAC: "52:54:00:57:00:16"
-  VM_CPU: "1"
-  VM_MEMORY: 1G
-  VM_STORAGE: 20Gi
+  VM_CPU: "2"
+  VM_MEMORY: 4G
+  VM_STORAGE: 50Gi
   VM_GATEWAY: 192.168.57.1
   VM_DNS: 192.168.57.1
   VM_NETWORK: network/vm-macvtap


### PR DESCRIPTION
1 CPU and 1G RAM is insufficient for FreePBX — the installer compiles Asterisk from source and needs headroom for MariaDB, Apache, and PHP.

https://claude.ai/code/session_01XXREUF9CaxrrTLo5q6p8oz