### PR TITLE
fix(kubevirt): use userDataSecretRef with inline networkData

### DIFF
--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/secret.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/secret.yaml
@@ -5,18 +5,6 @@ metadata:
   name: ${VM_NAME}-cloudinit
 type: Opaque
 stringData:
-  networkdata: |
-    network:
-      version: 1
-      config:
-        - type: physical
-          name: enp1s0
-          subnets:
-            - type: static
-              address: ${VM_IP}/24
-              gateway: ${VM_GATEWAY}
-              dns_nameservers:
-                - ${VM_DNS}
   userdata: |
     #cloud-config
     hostname: ${VM_NAME}

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/virtualmachine.yaml
@@ -47,7 +47,19 @@ spec:
             name: ${VM_NAME}-pvc
         - name: cloudinitdisk
           cloudInitNoCloud:
-            secretRef:
+            networkData: |
+              network:
+                version: 1
+                config:
+                  - type: physical
+                    name: enp1s0
+                    subnets:
+                      - type: static
+                        address: ${VM_IP}/24
+                        gateway: ${VM_GATEWAY}
+                        dns_nameservers:
+                          - ${VM_DNS}
+            userDataSecretRef:
               name: ${VM_NAME}-cloudinit
   dataVolumeTemplates:
     - metadata:

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/secret.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/secret.yaml
@@ -5,18 +5,6 @@ metadata:
   name: ${VM_NAME}-cloudinit
 type: Opaque
 stringData:
-  networkdata: |
-    network:
-      version: 1
-      config:
-        - type: physical
-          name: enp1s0
-          subnets:
-            - type: static
-              address: ${VM_IP}/24
-              gateway: ${VM_GATEWAY}
-              dns_nameservers:
-                - ${VM_DNS}
   userdata: |
     #cloud-config
     hostname: ${VM_NAME}

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/virtualmachine.yaml
@@ -47,7 +47,19 @@ spec:
             name: ${VM_NAME}-pvc
         - name: cloudinitdisk
           cloudInitNoCloud:
-            secretRef:
+            networkData: |
+              network:
+                version: 1
+                config:
+                  - type: physical
+                    name: enp1s0
+                    subnets:
+                      - type: static
+                        address: ${VM_IP}/24
+                        gateway: ${VM_GATEWAY}
+                        dns_nameservers:
+                          - ${VM_DNS}
+            userDataSecretRef:
               name: ${VM_NAME}-cloudinit
   dataVolumeTemplates:
     - metadata:

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/secret.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/secret.yaml
@@ -5,18 +5,6 @@ metadata:
   name: ${VM_NAME}-cloudinit
 type: Opaque
 stringData:
-  networkdata: |
-    network:
-      version: 1
-      config:
-        - type: physical
-          name: enp1s0
-          subnets:
-            - type: static
-              address: ${VM_IP}/24
-              gateway: ${VM_GATEWAY}
-              dns_nameservers:
-                - ${VM_DNS}
   userdata: |
     #cloud-config
     hostname: ${VM_NAME}

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/virtualmachine.yaml
@@ -47,7 +47,19 @@ spec:
             name: ${VM_NAME}-pvc
         - name: cloudinitdisk
           cloudInitNoCloud:
-            secretRef:
+            networkData: |
+              network:
+                version: 1
+                config:
+                  - type: physical
+                    name: enp1s0
+                    subnets:
+                      - type: static
+                        address: ${VM_IP}/24
+                        gateway: ${VM_GATEWAY}
+                        dns_nameservers:
+                          - ${VM_DNS}
+            userDataSecretRef:
               name: ${VM_NAME}-cloudinit
   dataVolumeTemplates:
     - metadata:


### PR DESCRIPTION
secretRef didn't apply networkData correctly — VMs got DHCP instead of static IPs. Split approach: keep networkData inline (small, works reliably) and use userDataSecretRef for the large userData only.

https://claude.ai/code/session_01XXREUF9CaxrrTLo5q6p8oz