### PR TITLE
fix(kubernetes): revert flux reconcile namespace in vm:redeploy task

### DIFF
--- a/.taskfiles/vm/Taskfile.yaml
+++ b/.taskfiles/vm/Taskfile.yaml
@@ -12,7 +12,7 @@ tasks:
       - kubectl delete vm {{.name}} -n {{.namespace}} --ignore-not-found
       - kubectl delete dv {{.name}}-pvc -n {{.namespace}} --ignore-not-found
       - kubectl delete secret {{.name}}-cloudinit -n {{.namespace}} --ignore-not-found
-      - flux reconcile ks {{.name}} -n flux-system
+      - flux reconcile ks {{.name}} -n {{.namespace}}
     requires:
       vars: [name]
     preconditions:


### PR DESCRIPTION
The Flux Kustomizations for VMs are deployed in the kubevirt namespace, not flux-system. Revert to using {{.namespace}} which defaults to kubevirt.

https://claude.ai/code/session_01XXREUF9CaxrrTLo5q6p8oz