### PR TITLE
fix(kubernetes): use secretRef instead of userDataSecretRef for cloud…

### DIFF
--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/virtualmachine.yaml
@@ -59,7 +59,7 @@ spec:
                         gateway: ${VM_GATEWAY}
                         dns_nameservers:
                           - ${VM_DNS}
-            userDataSecretRef:
+            secretRef:
               name: ${VM_NAME}-cloudinit
   dataVolumeTemplates:
     - metadata:

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/virtualmachine.yaml
@@ -59,7 +59,7 @@ spec:
                         gateway: ${VM_GATEWAY}
                         dns_nameservers:
                           - ${VM_DNS}
-            userDataSecretRef:
+            secretRef:
               name: ${VM_NAME}-cloudinit
   dataVolumeTemplates:
     - metadata:

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/virtualmachine.yaml
@@ -59,7 +59,7 @@ spec:
                         gateway: ${VM_GATEWAY}
                         dns_nameservers:
                           - ${VM_DNS}
-            userDataSecretRef:
+            secretRef:
               name: ${VM_NAME}-cloudinit
   dataVolumeTemplates:
     - metadata:


### PR DESCRIPTION
…-init

KubeVirt cloudInitNoCloud uses `secretRef` (not `userDataSecretRef`) as the YAML field name for referencing a Secret containing userData.

https://claude.ai/code/session_01XXREUF9CaxrrTLo5q6p8oz