### PR TITLE
fix(kubernetes): move networkData into cloud-init secret for FreePBX VMs

### DIFF
--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/secret.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/secret.yaml
@@ -57,3 +57,15 @@ stringData:
       - apt-get update
       - apt-get install -y cloudflared
       - cloudflared service install ${FPBX_CF_TUNNEL_TOKEN}
+  networkdata: |
+    network:
+      version: 1
+      config:
+        - type: physical
+          name: enp1s0
+          subnets:
+            - type: static
+              address: ${VM_IP}/24
+              gateway: ${VM_GATEWAY}
+              dns_nameservers:
+                - ${VM_DNS}

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/virtualmachine.yaml
@@ -47,18 +47,6 @@ spec:
             name: ${VM_NAME}-pvc
         - name: cloudinitdisk
           cloudInitNoCloud:
-            networkData: |
-              network:
-                version: 1
-                config:
-                  - type: physical
-                    name: enp1s0
-                    subnets:
-                      - type: static
-                        address: ${VM_IP}/24
-                        gateway: ${VM_GATEWAY}
-                        dns_nameservers:
-                          - ${VM_DNS}
             secretRef:
               name: ${VM_NAME}-cloudinit
   dataVolumeTemplates:

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/secret.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/secret.yaml
@@ -57,3 +57,15 @@ stringData:
       - apt-get update
       - apt-get install -y cloudflared
       - cloudflared service install ${FPBX_CF_TUNNEL_TOKEN}
+  networkdata: |
+    network:
+      version: 1
+      config:
+        - type: physical
+          name: enp1s0
+          subnets:
+            - type: static
+              address: ${VM_IP}/24
+              gateway: ${VM_GATEWAY}
+              dns_nameservers:
+                - ${VM_DNS}

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/virtualmachine.yaml
@@ -47,18 +47,6 @@ spec:
             name: ${VM_NAME}-pvc
         - name: cloudinitdisk
           cloudInitNoCloud:
-            networkData: |
-              network:
-                version: 1
-                config:
-                  - type: physical
-                    name: enp1s0
-                    subnets:
-                      - type: static
-                        address: ${VM_IP}/24
-                        gateway: ${VM_GATEWAY}
-                        dns_nameservers:
-                          - ${VM_DNS}
             secretRef:
               name: ${VM_NAME}-cloudinit
   dataVolumeTemplates:

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/secret.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/secret.yaml
@@ -57,3 +57,15 @@ stringData:
       - apt-get update
       - apt-get install -y cloudflared
       - cloudflared service install ${FPBX_CF_TUNNEL_TOKEN}
+  networkdata: |
+    network:
+      version: 1
+      config:
+        - type: physical
+          name: enp1s0
+          subnets:
+            - type: static
+              address: ${VM_IP}/24
+              gateway: ${VM_GATEWAY}
+              dns_nameservers:
+                - ${VM_DNS}

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/virtualmachine.yaml
@@ -47,18 +47,6 @@ spec:
             name: ${VM_NAME}-pvc
         - name: cloudinitdisk
           cloudInitNoCloud:
-            networkData: |
-              network:
-                version: 1
-                config:
-                  - type: physical
-                    name: enp1s0
-                    subnets:
-                      - type: static
-                        address: ${VM_IP}/24
-                        gateway: ${VM_GATEWAY}
-                        dns_nameservers:
-                          - ${VM_DNS}
             secretRef:
               name: ${VM_NAME}-cloudinit
   dataVolumeTemplates:


### PR DESCRIPTION
When secretRef is used, KubeVirt ignores inline networkData. Move the network configuration into the same secret as userdata so secretRef reads both keys (userdata + networkdata).

https://claude.ai/code/session_01XXREUF9CaxrrTLo5q6p8oz