### PR TITLE
fix(kubernetes): add networkDataSecretRef for FreePBX VM network config

### DIFF
--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/virtualmachine.yaml
@@ -49,6 +49,8 @@ spec:
           cloudInitNoCloud:
             secretRef:
               name: ${VM_NAME}-cloudinit
+            networkDataSecretRef:
+              name: ${VM_NAME}-cloudinit
   dataVolumeTemplates:
     - metadata:
         name: ${VM_NAME}-pvc

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/virtualmachine.yaml
@@ -49,6 +49,8 @@ spec:
           cloudInitNoCloud:
             secretRef:
               name: ${VM_NAME}-cloudinit
+            networkDataSecretRef:
+              name: ${VM_NAME}-cloudinit
   dataVolumeTemplates:
     - metadata:
         name: ${VM_NAME}-pvc

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/virtualmachine.yaml
@@ -49,6 +49,8 @@ spec:
           cloudInitNoCloud:
             secretRef:
               name: ${VM_NAME}-cloudinit
+            networkDataSecretRef:
+              name: ${VM_NAME}-cloudinit
   dataVolumeTemplates:
     - metadata:
         name: ${VM_NAME}-pvc


### PR DESCRIPTION
secretRef only reads the userdata key from the secret - it does NOT read networkdata. Must use networkDataSecretRef separately to read the networkdata key. Both point to the same secret.

Verified against KubeVirt source: rendervolumes.go creates separate pod volumes (-udata and -ndata) for each secret ref.

https://claude.ai/code/session_01XXREUF9CaxrrTLo5q6p8oz