### PR TITLE
feat(observability): deploy OpenCost for Kubernetes cost monitoring

### DIFF
--- a/kubernetes/apps/identity/kanidm/config/groups.yaml
+++ b/kubernetes/apps/identity/kanidm/config/groups.yaml
@@ -33,6 +33,16 @@ spec:
 apiVersion: kaniop.rs/v1beta1
 kind: KanidmGroup
 metadata:
+  name: opencost-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
   name: penpot-users
 spec:
   kanidmRef:

--- a/kubernetes/apps/identity/kanidm/config/kustomization.yaml
+++ b/kubernetes/apps/identity/kanidm/config/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - ./groups.yaml
   - ./oauth2-dbgate.yaml
   - ./oauth2-forgejo.yaml
+  - ./oauth2-opencost.yaml
   - ./oauth2-penpot.yaml

--- a/kubernetes/apps/identity/kanidm/config/oauth2-opencost.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-opencost.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: opencost
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: OpenCost
+  origin: "https://opencost.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://opencost.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: opencost-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -16,5 +16,6 @@ resources:
   - ./keda/ks.yaml
   - ./kromgo/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
+  - ./opencost/ks.yaml
   - ./silence-operator/ks.yaml
   - ./victoria-logs/ks.yaml

--- a/kubernetes/apps/observability/opencost/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/opencost/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: opencost-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: opencost-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: opencost-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/observability/opencost/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/opencost/app/helmrelease.yaml
@@ -5,13 +5,9 @@ kind: HelmRelease
 metadata:
   name: opencost
 spec:
-  chart:
-    spec:
-      chart: opencost
-      version: "2.5.8"
-      sourceRef:
-        kind: HelmRepository
-        name: opencost
+  chartRef:
+    kind: OCIRepository
+    name: opencost
   interval: 1h
   values:
     opencost:
@@ -47,5 +43,13 @@ spec:
           spotRAM: "0.65"
           GPU: "693.50"
           storage: "0.04"
+    service:
+      annotations:
+        gethomepage.dev/enabled: "true"
+        gethomepage.dev/group: Monitoring
+        gethomepage.dev/name: OpenCost
+        gethomepage.dev/icon: https://raw.githubusercontent.com/opencost/opencost/HEAD/ui/src/opencost-icon.svg
+        gethomepage.dev/description: Kubernetes Cost Monitoring
+        gethomepage.dev/href: "https://opencost.00o.sh"
     serviceMonitor:
       enabled: true

--- a/kubernetes/apps/observability/opencost/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/opencost/app/helmrelease.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: opencost
+spec:
+  chart:
+    spec:
+      chart: opencost
+      version: "2.5.8"
+      sourceRef:
+        kind: HelmRepository
+        name: opencost
+  interval: 1h
+  values:
+    opencost:
+      exporter:
+        defaultClusterId: special-winner
+        resources:
+          requests:
+            cpu: 10m
+            memory: 55Mi
+          limits:
+            memory: 256Mi
+      prometheus:
+        internal:
+          enabled: true
+          namespaceName: observability
+          serviceName: prometheus-operated
+          port: 9090
+      ui:
+        enabled: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 55Mi
+          limits:
+            memory: 128Mi
+      customPricing:
+        enabled: true
+        provider: custom
+        costModel:
+          CPU: "28.0"
+          spotCPU: "6.5"
+          RAM: "3.09"
+          spotRAM: "0.65"
+          GPU: "693.50"
+          storage: "0.04"
+    serviceMonitor:
+      enabled: true

--- a/kubernetes/apps/observability/opencost/app/helmrepository.yaml
+++ b/kubernetes/apps/observability/opencost/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: opencost
+spec:
+  interval: 1h
+  url: https://opencost.github.io/opencost-helm-chart

--- a/kubernetes/apps/observability/opencost/app/helmrepository.yaml
+++ b/kubernetes/apps/observability/opencost/app/helmrepository.yaml
@@ -1,9 +1,0 @@
----
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
-apiVersion: source.toolkit.fluxcd.io/v1
-kind: HelmRepository
-metadata:
-  name: opencost
-spec:
-  interval: 1h
-  url: https://opencost.github.io/opencost-helm-chart

--- a/kubernetes/apps/observability/opencost/app/httproute.yaml
+++ b/kubernetes/apps/observability/opencost/app/httproute.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: opencost
+spec:
+  hostnames:
+    - opencost.00o.sh
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: opencost
+          port: 9090

--- a/kubernetes/apps/observability/opencost/app/kustomization.yaml
+++ b/kubernetes/apps/observability/opencost/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./helmrepository.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/observability/opencost/app/kustomization.yaml
+++ b/kubernetes/apps/observability/opencost/app/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
-  - ./helmrepository.yaml
   - ./httproute.yaml
+  - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/observability/opencost/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/opencost/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: opencost
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 2.5.8
+  url: oci://ghcr.io/opencost/charts/opencost

--- a/kubernetes/apps/observability/opencost/app/securitypolicy.yaml
+++ b/kubernetes/apps/observability/opencost/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: opencost-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: opencost
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/opencost"
+    clientID: "opencost"
+    clientSecret:
+      name: opencost-oidc-secret
+    redirectURL: "https://opencost.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/observability/opencost/ks.yaml
+++ b/kubernetes/apps/observability/opencost/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: opencost
+spec:
+  dependsOn:
+    - name: kube-prometheus-stack
+  interval: 1h
+  path: ./kubernetes/apps/observability/opencost/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: observability
+  wait: false

--- a/kubernetes/apps/observability/opencost/ks.yaml
+++ b/kubernetes/apps/observability/opencost/ks.yaml
@@ -7,6 +7,10 @@ metadata:
 spec:
   dependsOn:
     - name: kube-prometheus-stack
+    - name: kanidm-config
+      namespace: identity
+    - name: onepassword
+      namespace: external-secrets
   interval: 1h
   path: ./kubernetes/apps/observability/opencost/app
   prune: true


### PR DESCRIPTION
Adds OpenCost to the observability namespace with:
- HelmRepository source for the opencost chart (v2.5.8)
- Prometheus integration via prometheus-operated service
- Web UI exposed at opencost.00o.sh via Envoy Gateway
- Custom pricing model for on-prem/homelab environment
- ServiceMonitor for Prometheus metrics scraping
- Dependency on kube-prometheus-stack

https://claude.ai/code/session_01UcbZsamuhMi7ATp8H8h1PD