### PR TITLE
fix(kubernetes): add explicit talosctl image spec to KubernetesUpgrade

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -8,6 +8,11 @@ spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
     version: v1.35.0
+  talosctl:
+    image:
+      repository: ghcr.io/siderolabs/talosctl
+      # renovate: datasource=docker depName=ghcr.io/siderolabs/talosctl
+      tag: v1.12.4
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource


### PR DESCRIPTION
The tuppr v0.0.57 webhook validates that spec.talosctl.image.repository
and spec.talosctl.image.tag are both specified together or both omitted.
CRD defaulting sets repository but not tag, causing the validating
webhook to reject the resource. Explicitly set both fields.

https://claude.ai/code/session_01NDFQhom4VGABtrvgKWocj9