### PR TITLE
feat(kubevirt): add SSO to kubevirt-manager and shutdown FreePBX VMs

### DIFF
--- a/kubernetes/apps/identity/kanidm/config/groups.yaml
+++ b/kubernetes/apps/identity/kanidm/config/groups.yaml
@@ -43,6 +43,16 @@ spec:
 apiVersion: kaniop.rs/v1beta1
 kind: KanidmGroup
 metadata:
+  name: kubevirt-manager-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
   name: penpot-users
 spec:
   kanidmRef:

--- a/kubernetes/apps/identity/kanidm/config/kustomization.yaml
+++ b/kubernetes/apps/identity/kanidm/config/kustomization.yaml
@@ -9,5 +9,6 @@ resources:
   - ./groups.yaml
   - ./oauth2-dbgate.yaml
   - ./oauth2-forgejo.yaml
+  - ./oauth2-kubevirt-manager.yaml
   - ./oauth2-opencost.yaml
   - ./oauth2-penpot.yaml

--- a/kubernetes/apps/identity/kanidm/config/oauth2-kubevirt-manager.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-kubevirt-manager.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: kubevirt-manager
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: KubeVirt Manager
+  origin: "https://kubevirt.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://kubevirt.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: kubevirt-manager-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/kubevirt/kubevirt-manager/app/externalsecret.yaml
+++ b/kubernetes/apps/kubevirt/kubevirt-manager/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kubevirt-manager-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: kubevirt-manager-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: kubevirt-manager-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/kubevirt/kubevirt-manager/app/kustomization.yaml
+++ b/kubernetes/apps/kubevirt/kubevirt-manager/app/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./rbac.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/kubevirt/kubevirt-manager/app/securitypolicy.yaml
+++ b/kubernetes/apps/kubevirt/kubevirt-manager/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: kubevirt-manager-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: kubevirt-manager
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/kubevirt-manager"
+    clientID: "kubevirt-manager"
+    clientSecret:
+      name: kubevirt-manager-oidc-secret
+    redirectURL: "https://kubevirt.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b1-k3s01/app/virtualmachine.yaml
@@ -4,7 +4,7 @@ kind: VirtualMachine
 metadata:
   name: ${VM_NAME}
 spec:
-  running: true
+  running: false
   template:
     metadata:
       labels:

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b2-k3s01/app/virtualmachine.yaml
@@ -4,7 +4,7 @@ kind: VirtualMachine
 metadata:
   name: ${VM_NAME}
 spec:
-  running: true
+  running: false
   template:
     metadata:
       labels:

--- a/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/virtualmachine.yaml
+++ b/kubernetes/apps/kubevirt/virtualmachines/freepbx/b3-k3s01/app/virtualmachine.yaml
@@ -4,7 +4,7 @@ kind: VirtualMachine
 metadata:
   name: ${VM_NAME}
 spec:
-  running: true
+  running: false
   template:
     metadata:
       labels:


### PR DESCRIPTION
Add Kanidm OIDC authentication to kubevirt-manager via Envoy Gateway
SecurityPolicy, matching the existing pattern used by dbgate and opencost.
Set all three FreePBX VMs (b1-k3s01, b2-k3s01, b3-k3s01) to running: false.

https://claude.ai/code/session_01Pv7fJb7kVybesQPr94rvpk