### PR TITLE
fix(talos): use installer-secureboot image for singlenodemaster upgrades

### DIFF
--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -23,7 +23,7 @@ nodes:
     installDisk: "/dev/sda"
     machineSpec:
       secureboot: true
-    talosImageURL: factory.talos.dev/metal-installer/1f27123b6d8a11ff4f1b5f09f839f3662244f6bb11124faebe050c632291947b
+    talosImageURL: factory.talos.dev/installer-secureboot/1f27123b6d8a11ff4f1b5f09f839f3662244f6bb11124faebe050c632291947b
     controlPlane: true
 
     networkInterfaces:


### PR DESCRIPTION
The singlenodemaster was using metal-installer which is a bare-metal ISO
image type, not the UKI-signed secure boot installer. This caused secure
boot key enrollment to break after every Talos version upgrade because the
upgrade image lacked proper UKI signatures for the UEFI secure boot chain.

https://claude.ai/code/session_01HkJKGU8SdTmeq5EfT7YUBf