### PR TITLE
fix(kubernetes): rename api-token secret key to valid env var name

### DIFF
--- a/kubernetes/apps/forgejo-runner-system/forgejo-runner/app/externalsecret.yaml
+++ b/kubernetes/apps/forgejo-runner-system/forgejo-runner/app/externalsecret.yaml
@@ -13,7 +13,7 @@ spec:
     template:
       data:
         token: "{{ .FORGEJO_RUNNER_TOKEN }}"
-        api-token: "{{ .FORGEJO_SVC_TOKEN }}"
+        API_TOKEN: "{{ .FORGEJO_SVC_TOKEN }}"
         FORGEJO_INSTANCE_URL: "{{ .FORGEJO_INSTANCE_URL }}"
   dataFrom:
     - extract:

--- a/kubernetes/apps/forgejo-runner-system/forgejo-runner/app/triggerauthentication.yaml
+++ b/kubernetes/apps/forgejo-runner-system/forgejo-runner/app/triggerauthentication.yaml
@@ -8,4 +8,4 @@ spec:
   secretTargetRef:
     - parameter: token
       name: forgejo-runner-secret
-      key: api-token
+      key: API_TOKEN


### PR DESCRIPTION
The hyphenated key `api-token` in the forgejo-runner ExternalSecret caused
Flux post-build envsubst to fail because hyphens are not valid in
environment variable names. Renamed to `API_TOKEN` and updated the
TriggerAuthentication reference accordingly.

https://claude.ai/code/session_01DCAvMJ3ZPcFxbR3kb5iKRe