### PR TITLE
docs(github): update CLAUDE.md with current repository state

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,45 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/**
+      - mkdocs.yml
+      - .github/workflows/docs.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14.x"
+
+      - name: Install dependencies
+        run: pip install mkdocs-material
+
+      - name: Build site
+        run: mkdocs build --strict
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: site
+          command: pages deploy --project-name=special-winner-docs --branch main .

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,17 +10,19 @@ This document provides comprehensive guidance for AI assistants working with thi
 
 ### Core Components
 
-- **OS**: Talos Linux 1.12.2 (immutable Kubernetes OS)
+- **OS**: Talos Linux 1.12.4 (immutable Kubernetes OS)
 - **Orchestration**: Kubernetes 1.34.0
 - **GitOps**: Flux CD 2.7.5 (declarative continuous delivery)
 - **CNI**: Cilium 1.19.0 (eBPF-based networking)
-- **Ingress**: Envoy Gateway (HTTP routing)
+- **Ingress**: Envoy Gateway v1.6.3 (HTTP routing)
 - **Secrets**: SOPS 3.11.0 + Age 1.3.1 encryption
+- **Identity**: Kanidm (SSO/OAuth2 identity provider)
 - **DNS**: k8s_gateway + CoreDNS + External-DNS
 - **Certificates**: cert-manager with Cloudflare integration
-- **Package Management**: Helm 4.1.0 (Helm v4 for chart management)
+- **Package Management**: Helm 4.1.1 (Helm v4 for chart management)
 - **Database**: CloudNative-PG (PostgreSQL 17.7) + Dragonfly (Redis-compatible)
 - **Virtualization**: KubeVirt 1.7.0 (virtual machine management)
+- **External Secrets**: External Secrets Operator 2.0.0 + 1Password integration
 
 ## Directory Structure
 
@@ -36,7 +38,8 @@ special-winner/
 ├── .taskfiles/                       # Task automation definitions
 │   ├── bootstrap/Taskfile.yaml       # Bootstrap tasks
 │   ├── talos/Taskfile.yaml          # Talos operations
-│   └── template/Taskfile.yaml       # Template rendering
+│   ├── template/Taskfile.yaml       # Template rendering
+│   └── vm/Taskfile.yaml             # Virtual machine operations
 │
 ├── bootstrap/                        # Initial cluster bootstrap
 │   ├── helmfile.d/                  # Helm releases
@@ -76,6 +79,7 @@ special-winner/
 │       ├── global/                # All nodes
 │       ├── controller/            # Controller-specific
 │       ├── worker/                # Worker-specific
+│       ├── vm-node/              # VM-specific (KubeVirt nodes)
 │       └── ${node-hostname}/      # Per-node
 │
 ├── templates/                       # Jinja2 templates
@@ -410,6 +414,20 @@ When adding a new Kubernetes application:
    sops --encrypt --in-place kubernetes/apps/<namespace>/<app-name>/app/secret.sops.yaml
    ```
 
+6. **Consider SSO integration** - If the app has a web UI, ask whether Kanidm OAuth2 SSO should be configured (add OAuth2 client definition in `kubernetes/apps/identity/kanidm/app/`)
+
+7. **Add to Homepage dashboard** - New services should be added to the Homepage configuration in `kubernetes/apps/utils/homepage/`
+
+8. **Update documentation** - Update this CLAUDE.md file with the new application entry in the Deployed Applications section
+
+9. **Add Volsync backup config** - Stateful apps with persistent data should include Volsync backup configuration (use `kubernetes/components/volsync/` component)
+
+10. **Add monitoring** - If the app exposes metrics, add ServiceMonitor/PodMonitor and Grafana dashboards when available
+
+11. **Add Discord alert notifications** - Critical applications should have Discord webhook alert integration configured
+
+12. **Add NFS-scaler component** - Applications that mount NFS volumes should use the NFS-scaler component (`kubernetes/components/nfs-scaler/`) to prevent crash-loops when NFS is unavailable
+
 ### Security Considerations
 
 1. **Never commit unencrypted secrets** - All sensitive data must be in `*.sops.yaml` files
@@ -431,7 +449,7 @@ When adding a new Kubernetes application:
 5. **Don't add unnecessary complexity** - Follow the principle of minimal necessary changes
 6. **Don't add comments/docstrings** to code you didn't modify
 7. **Don't create abstractions** for one-time operations
-8. **Be aware of Helm v4** - The repository uses Helm 4.0.5, which has breaking changes from v3 (see bootstrap scripts)
+8. **Be aware of Helm v4** - The repository uses Helm 4.1.1, which has breaking changes from v3 (see bootstrap scripts)
 9. **Self-hosted runners** - Be aware that some workflows run on `special-winner-runner` (self-hosted) which has cluster access
 
 ### File Location Reference
@@ -474,6 +492,8 @@ When adding a new Kubernetes application:
 | Reset cluster | `task talos:reset` |
 | Validate K8s manifests | `task template:validate-kubernetes-config` |
 | Tidy templates | `task template:tidy` |
+| VM console | `task vm:console VM=<name>` |
+| VM start/stop | `task vm:start VM=<name>` / `task vm:stop VM=<name>` |
 
 ## Renovate Automation
 
@@ -537,6 +557,11 @@ CRD schema extraction and publishing:
 - Runs on self-hosted runner (special-winner-runner)
 - Uses Python 3.14 and Node 24.x for processing
 - Enables IDE autocompletion and validation for custom resources
+
+### label-generate.yaml
+Generates label configuration from repository structure:
+- Automates `.github/labels.yaml` and `.github/labeler.yaml` updates
+- Ensures labels stay in sync with namespace and directory changes
 
 ## Template System Details
 
@@ -607,7 +632,8 @@ talosctl logs --nodes <ip> --insecure
 
 **database**: Database infrastructure
 - cloudnative-pg (PostgreSQL operator)
-- postgres-cluster (PostgreSQL 17.7 HA cluster with 2 instances)
+- dbgate (database management web UI)
+- postgres-cluster (PostgreSQL 17.7 HA cluster with 3 instances)
 - dragonfly (Redis-compatible in-memory datastore operator)
 
 **default**: Default namespace
@@ -622,6 +648,12 @@ talosctl logs --nodes <ip> --insecure
 - flux-instance
 - flux-operator
 
+**forgejo-runner-system**: Forgejo CI/CD Infrastructure
+- forgejo-runner (Forgejo Actions runner with ScaledJob for on-demand scaling)
+
+**identity**: Identity and SSO
+- kanidm (identity provider with OAuth2 integrations for dbgate, forgejo, kubevirt-manager, opencost, penpot)
+
 **kube-system**: Core Kubernetes
 - cilium (CNI)
 - coredns (DNS)
@@ -629,13 +661,14 @@ talosctl logs --nodes <ip> --insecure
 - metrics-server
 - reloader (automatic pod restarts)
 - snapshot-controller (volume snapshots)
+- kguardian (Kubernetes security monitoring and guardian)
 - spegel (peer-to-peer container image sharing)
 
 **kubevirt**: Virtual machine infrastructure
 - cdi (Containerized Data Importer for VM disk management)
 - kubevirt (KubeVirt operator)
 - kubevirt-manager (web UI for VM management)
-- virtualmachines (VM instances: debian-desktop, debian-server, ubuntu-server, windows-server)
+- virtualmachines (VM instances: debian-desktop, debian-server, ubuntu-server, windows-server, freepbx-b1-k3s01, freepbx-b2-k3s01, freepbx-b3-k3s01)
 
 **media**: Media applications
 - autobrr (automation for torrent trackers)
@@ -657,8 +690,10 @@ talosctl logs --nodes <ip> --insecure
 - cloudflare-tunnel (external access)
 - envoy-gateway (ingress)
 - k8s-gateway (internal DNS)
+- macvtap-cni (macvtap CNI plugin for direct VM network access)
 - multus (multi-network CNI)
 - unifi-dns
+- unifi-toolkit (Unifi network management toolkit)
 
 **observability**: Monitoring and alerting
 - blackbox-exporter (endpoint monitoring)
@@ -668,6 +703,7 @@ talosctl logs --nodes <ip> --insecure
 - keda (event-driven autoscaling)
 - kromgo (custom metrics)
 - kube-prometheus-stack (Prometheus, AlertManager, Grafana)
+- opencost (Kubernetes cost monitoring and analysis)
 - silence-operator (alert silencing)
 - victoria-logs (log aggregation)
 
@@ -678,6 +714,8 @@ talosctl logs --nodes <ip> --insecure
 - tuppr (automated upgrades)
 
 **utils**: Utility services
+- forgejo (self-hosted Git repository service)
+- homepage (cluster dashboard)
 - penpot (open-source design and prototyping platform)
 - smtp-relay (SMTP relay for outbound email using Maddy)
 
@@ -697,23 +735,43 @@ talosctl logs --nodes <ip> --insecure
   - [SOPS](https://github.com/getsops/sops)
   - [Helm](https://helm.sh/) (Note: Using v4)
   - [KubeVirt](https://kubevirt.io/)
+  - [Kanidm](https://kanidm.com/) (Identity/SSO)
+  - [Forgejo](https://forgejo.org/) (Self-hosted Git)
+  - [OpenCost](https://www.opencost.io/) (Cost monitoring)
 
 ## Version Information
 
 This documentation applies to:
-- Talos Linux: 1.12.2
+- Talos Linux: 1.12.4
 - Kubernetes: 1.34.0
 - Flux CD: 2.7.5
 - Cilium: 1.19.0
-- Helm: 4.1.0
+- Helm: 4.1.1
 - Python: 3.14.3
+- Envoy Gateway: v1.6.3
+- External Secrets: 2.0.0
 - CloudNative-PG: PostgreSQL 17.7
 - KubeVirt: 1.7.0
+- kGuardian: 1.7.0
+- Kanidm: (identity provider)
 
 Check `.mise.toml` for exact versions of all tools.
 
 ## Recent Notable Changes
 
+- **2026-02-14**: Added Kanidm identity provider with OAuth2 SSO for dbgate, forgejo, kubevirt-manager, opencost, penpot
+- **2026-02-14**: Added Forgejo self-hosted Git service and Forgejo runner system
+- **2026-02-14**: Added Homepage cluster dashboard to utils namespace
+- **2026-02-14**: Added DBGate database management UI to database namespace
+- **2026-02-14**: Added kGuardian security monitoring to kube-system
+- **2026-02-14**: Added OpenCost Kubernetes cost analysis to observability
+- **2026-02-14**: Added macvtap-cni and unifi-toolkit to network namespace
+- **2026-02-14**: Added FreePBX telephony VMs (3 instances: b1-k3s01, b2-k3s01, b3-k3s01)
+- **2026-02-14**: Added VM task automation (.taskfiles/vm/Taskfile.yaml)
+- **2026-02-14**: Added label-generate workflow for automated label management
+- **2026-02-14**: Talos Linux updated from 1.12.2 to 1.12.4
+- **2026-02-14**: Helm updated from 4.1.0 to 4.1.1
+- **2026-02-14**: PostgreSQL HA cluster expanded from 2 to 3 instances
 - **2026-02-04**: Added KubeVirt virtualization namespace with VMs (debian-desktop, debian-server, ubuntu-server, windows-server)
 - **2026-02-04**: Added Spegel for peer-to-peer container image sharing in kube-system
 - **2026-02-04**: Added kubevirt-manager web UI for VM management
@@ -761,6 +819,9 @@ Located in `kubernetes/apps/kubevirt/`, this namespace provides virtual machine 
 - **debian-server**: Debian 13 headless server (1 CPU, 1G RAM, 50Gi NFS storage)
 - **ubuntu-server**: Ubuntu server instance
 - **windows-server**: Windows Server 2022 with virtio drivers (2 CPU, 2G RAM, 60Gi NFS storage)
+- **freepbx-b1-k3s01**: FreePBX telephony/PBX system (with secrets)
+- **freepbx-b2-k3s01**: FreePBX telephony/PBX system (with secrets)
+- **freepbx-b3-k3s01**: FreePBX telephony/PBX system (with secrets)
 
 **Storage**:
 - Uses NFS (nfs-fast storageClass) for VM disks with ReadWriteMany access
@@ -902,11 +963,13 @@ Located in `kubernetes/apps/database/`, this namespace provides centralized data
 
 **CloudNative-PG (PostgreSQL)**:
 - Kubernetes-native PostgreSQL operator
-- Runs PostgreSQL 17.7 with 2 instances for high availability
+- Runs PostgreSQL 17.7 with 3 instances for high availability
 - Uses OpenEBS hostpath storage (20Gi per instance)
-- Automated backups to Garage S3 storage with 30-day retention
+- Pod anti-affinity for distribution across hosts
+- Automated backups to Garage S3 storage via barman-cloud plugin
 - Monitoring enabled via PodMonitor
-- Tuned for performance: 200 max connections, optimized buffer settings
+- Tuned for performance: 200 max connections, 256MB shared_buffers, 512MB effective_cache_size
+- Resources: 100m CPU request, 512Mi memory request, 2Gi memory limit
 
 **Cluster Architecture**:
 ```
@@ -958,7 +1021,66 @@ Located in `kubernetes/apps/utils/penpot/`, Penpot is an open-source design and 
 - Telemetry disabled
 - Automatic pod restarts via Reloader on secret changes
 
+### Kanidm Identity Provider
+
+Located in `kubernetes/apps/identity/kanidm/`, Kanidm provides centralized identity management and SSO for the cluster.
+
+**How it works**:
+- Modern identity provider with OAuth2/OIDC support
+- Provides single sign-on for multiple cluster applications
+- Manages user accounts, groups, and authentication policies
+
+**OAuth2 Integrations**:
+- **DBGate**: Database management UI authentication
+- **Forgejo**: Git service authentication
+- **KubeVirt Manager**: VM management UI authentication
+- **OpenCost**: Cost analysis dashboard authentication
+- **Penpot**: Design platform authentication
+
+**Important**: When adding new applications that have a web UI, always consider whether Kanidm SSO integration should be configured. Each OAuth2 client is defined in a separate YAML file under `kubernetes/apps/identity/kanidm/app/`.
+
+### Forgejo (Self-Hosted Git)
+
+Located in `kubernetes/apps/utils/forgejo/`, Forgejo is a lightweight, self-hosted Git service.
+
+**Features**:
+- Git repository hosting
+- Kanidm SSO integration for authentication
+- Forgejo Actions (CI/CD) via forgejo-runner-system namespace
+
+**Related**: The `forgejo-runner-system` namespace provides on-demand CI/CD runners using KEDA ScaledJobs that scale based on Forgejo webhook events.
+
+### kGuardian (Security Monitoring)
+
+Located in `kubernetes/apps/kube-system/kguardian/`, kGuardian provides security monitoring and guardianship for the Kubernetes cluster.
+
+**Components**:
+- **Broker** (v1.6.0): Message broker for security events
+- **Controller** (v1.7.0): Core security monitoring engine
+- **Frontend** (v1.6.2): Web UI for security insights
+- **PostgreSQL**: Uses external CloudNative-PG database (init container for DB setup)
+
+**Configuration**:
+- LLM Bridge: disabled
+- MCP Server: disabled
+- Excluded namespaces: kube-system (from database monitoring)
+
+### OpenCost (Cost Monitoring)
+
+Located in `kubernetes/apps/observability/opencost/`, OpenCost provides Kubernetes cost monitoring and analysis.
+
+**Features**:
+- Real-time cost allocation and analysis
+- Kanidm SSO integration for dashboard access
+- Integrates with Prometheus for metrics
+
+### Homepage (Cluster Dashboard)
+
+Located in `kubernetes/apps/utils/homepage/`, Homepage provides a unified dashboard for all cluster services and applications.
+
+**Purpose**: Central entry point for accessing all deployed services with status monitoring.
+
 ---
 
-**Last Updated**: 2026-02-04
+**Last Updated**: 2026-02-14
 **Template Source**: [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 ### Core Infrastructure
 
 **Operating System & Orchestration:**
-- [Talos Linux](https://github.com/siderolabs/talos) 1.12.2 - Immutable Kubernetes OS
+- [Talos Linux](https://github.com/siderolabs/talos) 1.12.4 - Immutable Kubernetes OS
 - [Kubernetes](https://kubernetes.io/) 1.34.0 - Container orchestration
 - [Flux CD](https://github.com/fluxcd/flux2) 2.7.5 - GitOps continuous delivery
 
@@ -30,8 +30,13 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 - [k8s_gateway](https://github.com/ori-edge/k8s_gateway) - Internal DNS for cluster services
 - [Cloudflare Tunnel](https://github.com/cloudflare/cloudflared) - Secure external access
 - [Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni) - Multi-network support
+- [Macvtap CNI](https://github.com/kubevirt/macvtap-cni) - Direct network connectivity for VMs
 
-**Security & Secrets:**
+**Identity & Security:**
+- [Kanidm](https://kanidm.com/) - Identity provider with OAuth2/OIDC SSO
+- [kGuardian](https://github.com/kguardian-dev/kguardian) - eBPF-based security monitoring
+
+**Secrets:**
 - [cert-manager](https://github.com/cert-manager/cert-manager) - TLS certificate automation
 - [External Secrets Operator](https://external-secrets.io/) - External secret management
 - [1Password](https://1password.com/) - Secret storage backend
@@ -46,8 +51,9 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 - [Snapshot Controller](https://github.com/kubernetes-csi/external-snapshotter) - Volume snapshots
 
 **Database:**
-- [CloudNative-PG](https://cloudnative-pg.io/) - PostgreSQL 17.7 HA cluster (2 instances)
+- [CloudNative-PG](https://cloudnative-pg.io/) - PostgreSQL 17.7 HA cluster (3 instances)
 - [Dragonfly](https://www.dragonflydb.io/) - Redis-compatible in-memory datastore
+- [DBGate](https://dbgate.org/) - Database management web UI
 
 **Observability:**
 - [Grafana](https://grafana.com/) - Metrics visualization
@@ -59,12 +65,12 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 - [Blackbox Exporter](https://github.com/prometheus/blackbox_exporter) - Endpoint monitoring
 - [Kromgo](https://github.com/kashalls/kromgo) - Custom metrics publishing
 - [Silence Operator](https://github.com/kbudde/silence-operator) - Alert silencing automation
+- [OpenCost](https://www.opencost.io/) - Kubernetes cost monitoring and analysis
 
 **Virtualization:**
 - [KubeVirt](https://kubevirt.io/) - Virtual machine management on Kubernetes
 - [CDI](https://github.com/kubevirt/containerized-data-importer) - Containerized Data Importer for VM disk images
 - [KubeVirt Manager](https://kubevirt-manager.io/) - Web UI for VM management
-- [Macvtap CNI](https://github.com/kubevirt/macvtap-cni) - Direct network connectivity for VMs
 
 **System Management:**
 - [Reloader](https://github.com/stakater/Reloader) - Automatic pod restarts on config changes
@@ -90,8 +96,10 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 
 **Infrastructure & Utilities:**
 - [GitHub Actions Runner Controller](https://github.com/actions/actions-runner-controller) - Self-hosted GitHub Actions runners
+- [Forgejo](https://forgejo.org/) - Self-hosted Git repository service with CI/CD runners
 - [SMTP Relay](https://github.com/foxcpp/maddy) - Outbound email relay using Maddy
 - [Penpot](https://penpot.app/) - Open-source design and prototyping platform
+- [Homepage](https://gethomepage.dev/) - Cluster dashboard for all services
 
 **Additional DNS:**
 - Cloudflare DNS integration
@@ -486,6 +494,12 @@ This cluster already includes several advanced features beyond the base template
 - **✅ SMTP Relay** - Centralized email relay for cluster applications
 - **✅ Advanced Automation** - KEDA autoscaling, NFS-aware scaling, Discord alerts, automated image pre-pulling
 - **✅ KubeVirt Virtualization** - VM management with CDI and Macvtap CNI for direct network access
+- **✅ Identity & SSO** - Kanidm identity provider with OAuth2 integrations for cluster applications
+- **✅ Self-hosted Git** - Forgejo with CI/CD runners for internal Git workflows
+- **✅ Cluster Dashboard** - Homepage for unified service access and status monitoring
+- **✅ Security Monitoring** - kGuardian eBPF-based security toolkit for runtime policy generation
+- **✅ Cost Analysis** - OpenCost for Kubernetes cost monitoring and allocation
+- **✅ Database Management** - DBGate web UI for database administration
 
 ### Additional Enhancements to Consider
 
@@ -551,7 +565,7 @@ Community member [@whazor](https://github.com/whazor) created [Kubesearch](https
 - [x] [kguardian](https://github.com/kguardian-dev/kguardian) - eBPF-based security toolkit for auto-generating NetworkPolicy/CiliumNetworkPolicy and seccomp profiles from observed runtime behavior (audit mode)
 
 **Additional Services**
-- [ ] Forgejo (self-hosted Git platform)
+- [x] Forgejo (self-hosted Git platform)
 - [ ] Home Assistant + IoT stack (if needed)
 - [x] Kanidm (via Kaniop operator) for identity management and SSO
 - [ ] Migrate External Secrets from 1Password Connect to 1Password SDK (enables PushSecret for cross-namespace secret sync)
@@ -635,10 +649,10 @@ If this repo is too hot to handle or too cold to hold check out these following 
 
 ## 📊 Repository Stats
 
-**Deployed Components:** 55+ applications across 15 namespaces
+**Deployed Components:** 65+ applications across 17 namespaces
 **Template Source:** [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template)
 **Infrastructure:** GitOps with Flux CD + Talos Linux
-**Last Updated:** 2026-02-04
+**Last Updated:** 2026-02-14
 
 ---
 

--- a/docs/applications/index.md
+++ b/docs/applications/index.md
@@ -1,0 +1,67 @@
+# Applications
+
+All applications are deployed via Flux CD from manifests in `kubernetes/apps/`.
+
+## Application Catalog
+
+### Media Stack
+
+| App | Description | Namespace |
+|-----|-------------|-----------|
+| [Plex](https://www.plex.tv/) | Media server | media |
+| [Radarr](https://radarr.video/) | Movie collection manager | media |
+| [Sonarr](https://sonarr.tv/) | TV series collection manager | media |
+| [Prowlarr](https://prowlarr.com/) | Indexer manager | media |
+| [Bazarr](https://www.bazarr.media/) | Subtitle management | media |
+| [qBittorrent](https://www.qbittorrent.org/) | Torrent client | media |
+| [Qui](https://github.com/autobrr/qui) | qBittorrent web UI | media |
+| [Autobrr](https://autobrr.com/) | Torrent tracker automation | media |
+| [Recyclarr](https://recyclarr.dev/) | Quality profile management | media |
+| [Seerr](https://github.com/seerr-team/seerr) | Media request platform | media |
+| [Tautulli](https://tautulli.com/) | Plex monitoring | media |
+| [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) | Cloudflare bypass | media |
+| [TheLounge](https://thelounge.chat/) | IRC client | media |
+
+### Infrastructure & Utilities
+
+| App | Description | Namespace |
+|-----|-------------|-----------|
+| [Forgejo](https://forgejo.org/) | Self-hosted Git | utils |
+| [Homepage](https://gethomepage.dev/) | Cluster dashboard | utils |
+| [Penpot](https://penpot.app/) | Design platform | utils |
+| [SMTP Relay](https://github.com/foxcpp/maddy) | Email relay (Maddy) | utils |
+| [DBGate](https://dbgate.org/) | Database web UI | database |
+
+### Virtualization
+
+| App | Description | Namespace |
+|-----|-------------|-----------|
+| [KubeVirt](https://kubevirt.io/) | VM operator | kubevirt |
+| [CDI](https://github.com/kubevirt/containerized-data-importer) | Disk importer | kubevirt |
+| [KubeVirt Manager](https://kubevirt-manager.io/) | VM web UI | kubevirt |
+
+### Observability
+
+| App | Description | Namespace |
+|-----|-------------|-----------|
+| [Grafana](https://grafana.com/) | Metrics visualization | observability |
+| [Prometheus](https://prometheus.io/) | Metrics collection | observability |
+| [Victoria Logs](https://victoriametrics.com/) | Log aggregation | observability |
+| [Gatus](https://github.com/TwiN/gatus) | Health monitoring | observability |
+| [OpenCost](https://www.opencost.io/) | Cost analysis | observability |
+| [Fluent Bit](https://fluentbit.io/) | Log forwarding | observability |
+| [KEDA](https://keda.sh/) | Event-driven autoscaling | observability |
+
+### CI/CD
+
+| App | Description | Namespace |
+|-----|-------------|-----------|
+| Actions Runner Controller | GitHub Actions runners | actions-runner-system |
+| Forgejo Runner | Forgejo CI/CD runners | forgejo-runner-system |
+
+See the detailed pages for more on each category:
+
+- [Media Stack](media.md)
+- [Virtualization](virtualization.md)
+- [Observability](observability.md)
+- [Utilities](utilities.md)

--- a/docs/applications/media.md
+++ b/docs/applications/media.md
@@ -1,0 +1,80 @@
+# Media Stack
+
+The media namespace contains 13 applications for media management and consumption.
+
+## Architecture
+
+```mermaid
+graph LR
+    Seerr[Seerr<br/>Requests] --> Radarr
+    Seerr --> Sonarr
+    Prowlarr[Prowlarr<br/>Indexers] --> Radarr
+    Prowlarr --> Sonarr
+    Radarr[Radarr<br/>Movies] --> qBit[qBittorrent]
+    Sonarr[Sonarr<br/>TV] --> qBit
+    Autobrr[Autobrr<br/>Automation] --> qBit
+    qBit --> Plex[Plex<br/>Media Server]
+    Bazarr[Bazarr<br/>Subtitles] --> Radarr
+    Bazarr --> Sonarr
+    Tautulli[Tautulli] --> Plex
+    FlareSolverr[FlareSolverr] --> Prowlarr
+```
+
+## Applications
+
+### Plex
+
+Media server for streaming movies, TV shows, music, and photos.
+
+- Multiple component directories for complex configuration
+- NFS storage for media library
+
+### Radarr & Sonarr
+
+Movie and TV series collection managers:
+
+- Automate downloading and organizing media
+- Integration with Prowlarr for indexer management
+- Quality profiles managed by Recyclarr
+
+### Prowlarr
+
+Centralized indexer manager for all *arr applications:
+
+- Uses FlareSolverr for Cloudflare-protected sites
+- Syncs indexers to Radarr and Sonarr
+
+### qBittorrent + Qui
+
+Torrent client with a custom web UI:
+
+- qBittorrent handles downloads
+- Qui provides a modern web interface
+
+### Autobrr
+
+Automation for torrent trackers:
+
+- Monitors IRC announces and RSS feeds
+- Sends releases to *arr apps or directly to qBittorrent
+
+### Seerr
+
+Media request and discovery platform:
+
+- Users can request movies and TV shows
+- Integrates with Radarr and Sonarr for automatic fulfillment
+
+### Bazarr
+
+Subtitle management:
+
+- Automatically downloads subtitles for movies and TV shows
+- Integrates with Radarr and Sonarr
+
+### Supporting Services
+
+- **Recyclarr** -- Syncs quality profiles to *arr apps from TRaSH Guides
+- **Tautulli** -- Plex monitoring and statistics
+- **FlareSolverr** -- Cloudflare bypass proxy for Prowlarr
+- **TheLounge** -- Self-hosted IRC client for tracker communication

--- a/docs/applications/observability.md
+++ b/docs/applications/observability.md
@@ -1,0 +1,107 @@
+# Observability
+
+The observability namespace provides comprehensive monitoring, logging, and alerting.
+
+## Stack Overview
+
+```mermaid
+graph TB
+    subgraph Collection
+        FB[Fluent Bit] -->|logs| VL[Victoria Logs]
+        BB[Blackbox Exporter] -->|probes| Prom[Prometheus]
+        SM[ServiceMonitors] -->|metrics| Prom
+    end
+
+    subgraph Visualization
+        Prom --> Grafana
+        VL --> Grafana
+    end
+
+    subgraph Alerting
+        Prom --> AM[AlertManager]
+        AM --> Discord
+        AM --> GitHub[GitHub Status]
+    end
+
+    subgraph Health
+        Gatus[Gatus] -->|uptime| Grafana
+    end
+
+    subgraph Scaling
+        Prom --> KEDA
+    end
+
+    subgraph Cost
+        OC[OpenCost] --> Prom
+    end
+```
+
+## Components
+
+### kube-prometheus-stack
+
+The foundation of the monitoring stack:
+
+- **Prometheus** -- Metrics collection and storage
+- **AlertManager** -- Alert routing and notification
+- **Grafana** -- Dashboards and visualization
+- Pre-configured with Kubernetes dashboards
+
+### Victoria Logs
+
+Log aggregation and search:
+
+- Receives logs from Fluent Bit
+- Grafana datasource for log querying
+- Lower resource usage than Elasticsearch/Loki
+
+### Fluent Bit
+
+Log forwarding and collection:
+
+- Collects logs from all pods
+- Forwards to Victoria Logs
+- Lightweight DaemonSet
+
+### Gatus
+
+Health monitoring and uptime tracking:
+
+- Monitors service endpoints
+- Provides uptime dashboards
+- Configurable health checks
+
+### OpenCost
+
+Kubernetes cost monitoring:
+
+- Real-time cost allocation per namespace, deployment, pod
+- Kanidm SSO integration
+- Prometheus metrics integration
+
+### KEDA
+
+Event-driven autoscaling:
+
+- Powers the NFS-scaler component
+- Powers Forgejo runner scaling
+- Queries Prometheus for scaling decisions
+
+### Supporting Tools
+
+- **Blackbox Exporter** -- Probe endpoints for HTTP, TCP, DNS, ICMP
+- **Kromgo** -- Custom metrics publishing
+- **Silence Operator** -- Declarative alert silencing
+
+## Alert Channels
+
+| Channel | Integration | Purpose |
+|---------|-------------|---------|
+| Discord | Webhook | Real-time notifications |
+| GitHub | Status API | PR/commit status updates |
+
+Alert configuration is modular via `kubernetes/components/alerts/`:
+
+- `alertmanager/` -- Routing rules
+- `discord/` -- Discord webhook config
+- `github-status/` -- GitHub integration

--- a/docs/applications/utilities.md
+++ b/docs/applications/utilities.md
@@ -1,0 +1,90 @@
+# Utilities
+
+## Forgejo
+
+[Forgejo](https://forgejo.org/) is a self-hosted Git repository service:
+
+- Located in `kubernetes/apps/utils/forgejo/`
+- Kanidm SSO for authentication
+- Forgejo Actions CI/CD via `forgejo-runner-system` namespace
+- KEDA ScaledJobs for on-demand CI runners
+
+## Homepage
+
+[Homepage](https://gethomepage.dev/) provides a unified dashboard for all cluster services:
+
+- Located in `kubernetes/apps/utils/homepage/`
+- Central entry point for accessing all deployed services
+- Status monitoring for services
+
+!!! note
+    When adding new applications, always add them to the Homepage configuration.
+
+## Penpot
+
+[Penpot](https://penpot.app/) is an open-source design and prototyping platform:
+
+- Located in `kubernetes/apps/utils/penpot/`
+- Multi-component: backend, frontend, exporter, Valkey cache
+- PostgreSQL database via CloudNative-PG
+- Persistent storage for assets via VolSync (20Gi)
+- Exposed at `penpot.00o.sh`
+- Kanidm SSO integration
+
+### Dependencies
+
+- CloudNative-PG postgres-cluster
+- VolSync for persistent storage
+- 1Password for secrets
+
+## SMTP Relay
+
+[Maddy](https://github.com/foxcpp/maddy) provides centralized SMTP relay:
+
+- Located in `kubernetes/apps/utils/smtp-relay/`
+- Accepts email on port 25 via LoadBalancer
+- Relays through external SMTP provider
+- Hostname: `smtp-relay.00o.sh`
+
+### Usage
+
+Applications send email to:
+
+```
+smtp-relay.utils.svc.cluster.local:25
+```
+
+### Security
+
+- Non-root user (UID/GID 1000)
+- Read-only root filesystem
+- All capabilities dropped
+
+## CI/CD Runners
+
+### GitHub Actions (actions-runner-system)
+
+Self-hosted GitHub Actions runners:
+
+- Uses official Actions Runner Controller (ARC)
+- Ephemeral runner pods
+- Scales on webhook events
+- Cluster access for image pulling and schema publishing
+
+### Forgejo Runners (forgejo-runner-system)
+
+Forgejo CI/CD runners:
+
+- KEDA ScaledJobs for on-demand scaling
+- Scales based on Forgejo webhook events
+- Isolated execution environment
+
+## Spegel
+
+[Spegel](https://github.com/spegel-org/spegel) enables peer-to-peer container image sharing:
+
+- Located in `kubernetes/apps/kube-system/spegel/`
+- Nodes share images directly with each other
+- Auto-enables with 2+ nodes
+- Registry host port: 29999
+- Reduces external registry pulls and bandwidth

--- a/docs/applications/virtualization.md
+++ b/docs/applications/virtualization.md
@@ -1,0 +1,78 @@
+# Virtualization
+
+[KubeVirt](https://kubevirt.io/) 1.7.0 enables virtual machine management within the Kubernetes cluster.
+
+## Components
+
+| Component | Purpose |
+|-----------|---------|
+| **KubeVirt** | VM lifecycle operator |
+| **CDI** | Containerized Data Importer for disk provisioning |
+| **KubeVirt Manager** | Web UI at `kubevirt.00o.sh` |
+| **Macvtap CNI** | Direct network access for VMs |
+
+## Feature Gates
+
+- **LiveMigration** -- Move VMs between nodes without downtime
+- **Macvtap** -- Direct network attachment
+- **HotplugVolumes** -- Attach/detach volumes without restart
+- **HostDevices** -- PCI device passthrough
+- **GPU** -- GPU passthrough support
+- **NetworkBindingPlugins** -- Advanced networking
+
+## Current VMs
+
+| VM | OS | CPU | RAM | Storage |
+|----|----|-----|-----|---------|
+| debian-desktop | Debian 13 + XFCE4 | 1 | 1Gi | 50Gi NFS |
+| debian-server | Debian 13 headless | 1 | 1Gi | 50Gi NFS |
+| ubuntu-server | Ubuntu | 1 | 1Gi | varies |
+| windows-server | Windows Server 2022 | 2 | 2Gi | 60Gi NFS |
+| freepbx-b1-k3s01 | FreePBX | varies | varies | NFS |
+| freepbx-b2-k3s01 | FreePBX | varies | varies | NFS |
+| freepbx-b3-k3s01 | FreePBX | varies | varies | NFS |
+
+## Storage
+
+- VM disks use **NFS** (`nfs-fast` storageClass) with ReadWriteMany access
+- Enables live migration between nodes
+- CDI uses `openebs-hostpath` for scratch space during disk imports
+
+## Networking
+
+- VMs use **Multus** with **macvtap** for direct L2 network access
+- Each VM has a dedicated MAC address
+- DNS endpoints configured via external-dns
+
+## VM Management
+
+### CLI (virtctl)
+
+```sh
+virtctl console <vm-name>      # Access VM console
+virtctl ssh <vm-name>          # SSH into VM
+virtctl start <vm-name>        # Start VM
+virtctl stop <vm-name>         # Stop VM
+virtctl migrate <vm-name>      # Live migrate VM
+virtctl restart <vm-name>      # Restart VM
+```
+
+### Task Runner
+
+```sh
+task vm:console VM=<name>
+task vm:start VM=<name>
+task vm:stop VM=<name>
+```
+
+### Web UI
+
+KubeVirt Manager is accessible at `kubevirt.00o.sh` with Kanidm SSO.
+
+## Adding a New VM
+
+1. Create a VirtualMachine manifest in `kubernetes/apps/kubevirt/virtualmachines/`
+2. Define disk source (CDI DataVolume or existing PVC)
+3. Configure networking (macvtap interface with MAC address)
+4. Add external-dns annotation for DNS entry
+5. Add to the namespace kustomization

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,168 @@
+# Architecture
+
+## High-Level Overview
+
+```mermaid
+graph TB
+    subgraph Internet
+        CF[Cloudflare Tunnel]
+    end
+
+    subgraph Cluster["Kubernetes Cluster (Talos Linux)"]
+        subgraph GitOps["GitOps Layer"]
+            Flux[Flux CD]
+            Git[GitHub Repository]
+        end
+
+        subgraph Networking["Networking Layer"]
+            Cilium[Cilium CNI]
+            Envoy[Envoy Gateway]
+            DNS[CoreDNS + k8s_gateway]
+            Multus[Multus CNI]
+        end
+
+        subgraph Identity["Identity Layer"]
+            Kanidm[Kanidm SSO]
+        end
+
+        subgraph Data["Data Layer"]
+            PG[CloudNative-PG]
+            Dragonfly[Dragonfly]
+            OpenEBS[OpenEBS]
+            NFS[NFS Storage]
+        end
+
+        subgraph Apps["Application Layer"]
+            Media[Media Stack]
+            VMs[KubeVirt VMs]
+            Utils[Utilities]
+            Obs[Observability]
+        end
+
+        subgraph Security["Security Layer"]
+            SOPS[SOPS + Age]
+            ExtSec[External Secrets]
+            CertMgr[cert-manager]
+            kGuardian[kGuardian]
+        end
+    end
+
+    CF --> Envoy
+    Git --> Flux
+    Flux --> Apps
+    Flux --> Networking
+    Flux --> Data
+    Flux --> Security
+    Envoy --> Apps
+    Kanidm --> Apps
+    PG --> Apps
+    Cilium --> Envoy
+    Multus --> VMs
+```
+
+## GitOps Flow
+
+All cluster state is defined in Git. Changes flow through this pipeline:
+
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant Git as GitHub
+    participant Flux as Flux CD
+    participant K8s as Kubernetes
+
+    Dev->>Git: Push manifests
+    Git->>Flux: Webhook / Poll
+    Flux->>Flux: Reconcile Kustomizations
+    Flux->>K8s: Apply HelmReleases
+    K8s->>K8s: Deploy workloads
+    Flux->>Git: Update status
+```
+
+## Directory Layout
+
+```
+special-winner/
+├── .github/workflows/     # CI/CD pipelines
+├── .taskfiles/            # Task automation (bootstrap, talos, template, vm)
+├── bootstrap/             # Initial cluster bootstrap (Helmfile, SOPS secrets)
+├── kubernetes/
+│   ├── apps/              # Application manifests (17 namespaces)
+│   ├── components/        # Shared components (alerts, nfs-scaler, volsync, sops)
+│   └── flux/              # Flux configuration (root Kustomization)
+├── talos/                 # Talos Linux config and patches
+├── templates/             # Jinja2 templates for config generation
+├── scripts/               # Bootstrap and utility scripts
+├── docs/                  # This documentation
+├── mkdocs.yml             # Documentation site config
+├── Taskfile.yaml          # Root task runner
+├── .mise.toml             # Development tool versions
+├── .sops.yaml             # SOPS encryption rules
+└── makejinja.toml         # Template rendering config
+```
+
+## Application Structure
+
+Every application follows a consistent pattern:
+
+```
+kubernetes/apps/<namespace>/<app-name>/
+├── app/
+│   ├── helmrelease.yaml       # Helm chart deployment
+│   ├── ocirepository.yaml     # OCI chart source
+│   ├── secret.sops.yaml       # Encrypted secrets (if needed)
+│   └── kustomization.yaml     # Manifest aggregation
+└── ks.yaml                    # Flux Kustomization
+```
+
+## Namespace Map
+
+| Namespace | Purpose | Key Apps |
+|-----------|---------|----------|
+| `actions-runner-system` | CI/CD runners | Actions Runner Controller |
+| `cert-manager` | TLS certificates | cert-manager |
+| `database` | Database services | CloudNative-PG, Dragonfly, DBGate |
+| `default` | Test workloads | echo |
+| `external-secrets` | Secret management | External Secrets, 1Password |
+| `flux-system` | GitOps | Flux Operator, Flux Instance |
+| `forgejo-runner-system` | Forgejo CI/CD | Forgejo Runner (ScaledJob) |
+| `identity` | SSO/Identity | Kanidm (OAuth2 for 5+ apps) |
+| `kube-system` | Core services | Cilium, CoreDNS, Spegel, kGuardian |
+| `kubevirt` | Virtualization | KubeVirt, CDI, VMs |
+| `media` | Media apps | Plex, *arr stack, qBittorrent |
+| `network` | Network infra | Envoy Gateway, Cloudflare, Multus |
+| `observability` | Monitoring | Prometheus, Grafana, Victoria Logs |
+| `openebs-system` | Block storage | OpenEBS |
+| `system-upgrade` | Upgrades | Tuppr |
+| `utils` | Utilities | Forgejo, Homepage, Penpot, SMTP |
+| `volsync-system` | Backups | VolSync, Garage, Kopia |
+
+## Network Architecture
+
+- **Cilium** provides eBPF-based CNI with advanced network policies
+- **Envoy Gateway** handles HTTP routing with internal and external gateways
+- **Cloudflare Tunnel** provides secure external access without port forwarding
+- **Multus + Macvtap** gives VMs direct network access with dedicated MAC addresses
+- **k8s_gateway** provides split-horizon DNS for internal service resolution
+
+## Storage Architecture
+
+| Storage Class | Backend | Use Case |
+|---------------|---------|----------|
+| `openebs-hostpath` | OpenEBS | Database volumes, high-performance local |
+| `nfs-fast` | CSI Driver NFS | VM disks, shared media, ReadWriteMany |
+| Garage S3 | Garage | Backup destination for VolSync/Kopia |
+
+## Secret Flow
+
+```mermaid
+graph LR
+    A[1Password] -->|ExternalSecrets| B[Kubernetes Secrets]
+    C[age.key] -->|SOPS| D[Encrypted YAML in Git]
+    D -->|Flux Decryption| B
+    B --> E[Applications]
+```
+
+- **SOPS + Age**: Encrypts secrets in Git (`*.sops.yaml` files)
+- **External Secrets Operator**: Pulls secrets from 1Password at runtime
+- **Flux**: Automatically decrypts SOPS secrets during reconciliation

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -1,0 +1,85 @@
+# CI/CD Pipelines
+
+GitHub Actions workflows automate testing, validation, and deployment.
+
+## Workflows
+
+### flux-local.yaml
+
+Validates Flux manifests on pull requests:
+
+- Checks Flux configuration with `--enable-helm --all-namespaces`
+- Generates diffs for HelmReleases and Kustomizations
+- Triggers on `kubernetes/**` file changes
+
+### e2e.yaml
+
+End-to-end testing of the configuration pipeline:
+
+- Runs `task init` and `task configure`
+- Tests with sample configurations (public/private matrix)
+- Validates with flux-local
+
+### labeler.yaml
+
+Automated PR labeling:
+
+- **Area labels** based on changed file paths
+- **Size labels**: xs (<10 lines), s (<30), m (<100), l (<500), xl (500+)
+- Ignores markdown files for size calculation
+
+### label-sync.yaml
+
+Synchronizes GitHub labels from `.github/labels.yaml`:
+
+- Triggered on pushes to main
+- Deletes undefined labels
+- Maintains consistent labeling
+
+### label-generate.yaml
+
+Auto-generates label configuration:
+
+- Updates `.github/labels.yaml` and `.github/labeler.yaml`
+- Keeps labels in sync with namespace/directory changes
+
+### image-pull.yaml
+
+Pre-pulls container images to cluster nodes:
+
+- Extracts images from Flux manifests on PRs
+- Compares images between PR and main branch
+- Pulls new images via Talosctl
+- Runs on self-hosted runner (`special-winner-runner`)
+- Max 4 parallel pulls
+
+### schemas.yaml
+
+CRD schema extraction and publishing:
+
+- Scheduled daily
+- Extracts CRD schemas via datreeio/crd-extractor
+- Publishes to Cloudflare Pages (`kubernetes-schemas` project)
+- Runs on self-hosted runner
+- Enables IDE autocompletion for custom resources
+
+### docs.yaml
+
+Documentation site publishing:
+
+- Builds MkDocs Material site
+- Publishes to Cloudflare Pages (`special-winner-docs` project)
+- Triggered on docs/ or mkdocs.yml changes
+
+### release.yaml
+
+Repository release management.
+
+## Self-Hosted Runners
+
+Some workflows run on `special-winner-runner` (self-hosted) with cluster access:
+
+- `image-pull.yaml` -- Needs Talosctl for image pulling
+- `schemas.yaml` -- Needs kubectl for CRD extraction
+
+Runners are managed by Actions Runner Controller in the `actions-runner-system` namespace.

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -1,0 +1,114 @@
+# Contributing
+
+## Git Commit Conventions
+
+This repository uses **semantic commits** with Renovate conventions:
+
+```
+<type>(<scope>): <message>
+```
+
+### Types
+
+| Type | Usage |
+|------|-------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `chore` | Maintenance |
+| `ci` | CI/CD changes |
+| `docs` | Documentation |
+| `refactor` | Code refactoring |
+
+### Scopes
+
+| Scope | Usage |
+|-------|-------|
+| `container` | Docker images |
+| `helm` | Helm charts |
+| `github-action` | GitHub Actions |
+| `kubernetes` | Kubernetes manifests |
+| `observability` | Monitoring and alerting |
+| `volsync` | Backup and replication |
+| `github` | GitHub configuration |
+| `mise` | Development tools |
+| `media` | Media applications |
+| `network` | Network infrastructure |
+| `utils` | Utility services |
+
+### Examples
+
+```
+fix(container): update image ghcr.io/app/name ( 1.0.0 → 1.1.0 )
+feat(helm): update chart app-template ( 3.0.0 → 4.0.0 )
+ci(github-action): update action/checkout ( v3 → v4 )
+docs(github): update CLAUDE.md with current repository state
+```
+
+## Application Checklist
+
+When adding a new application, follow this checklist:
+
+- [ ] Create directory: `kubernetes/apps/<namespace>/<app-name>/app/`
+- [ ] Create `helmrelease.yaml`, `ocirepository.yaml`, `kustomization.yaml`
+- [ ] Create `ks.yaml` Flux Kustomization
+- [ ] Update namespace `kustomization.yaml`
+- [ ] Encrypt secrets with SOPS (if needed)
+- [ ] Consider Kanidm SSO integration (web UI apps)
+- [ ] Add to Homepage dashboard
+- [ ] Add VolSync backup config (stateful apps)
+- [ ] Add monitoring (ServiceMonitor/PodMonitor)
+- [ ] Add Discord alerts (critical apps)
+- [ ] Add NFS-scaler component (NFS-dependent apps)
+- [ ] Update CLAUDE.md deployed applications list
+
+## Security Guidelines
+
+- **Never commit unencrypted secrets** -- Use `*.sops.yaml` files
+- **Validate encryption** -- Check for `sops:` metadata
+- **Follow security contexts**:
+
+```yaml
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities: { drop: ["ALL"] }
+```
+
+## Common Mistakes
+
+1. Don't modify files in `talos/clusterconfig/` (generated)
+2. Don't commit plaintext secrets
+3. Don't skip `task configure` after template changes
+4. Don't push directly to main
+5. Be aware of **Helm v4** breaking changes from v3
+6. Some workflows need the self-hosted runner (`special-winner-runner`)
+
+## Bash Script Conventions
+
+Scripts in `scripts/` use:
+
+```bash
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+source "$(dirname "${0}")/lib/common.sh"
+
+export LOG_LEVEL="debug"
+export ROOT_DIR="$(git rev-parse --show-toplevel)"
+```
+
+### Logging
+
+```bash
+log debug "Debug message"
+log info "Information message" "var=value"
+log warn "Warning message"
+log error "Error message"  # Exits with code 1
+```
+
+### Environment Checks
+
+```bash
+check_env KUBECONFIG TALOSCONFIG
+check_cli kubectl flux sops
+```

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,0 +1,9 @@
+# Development
+
+Guides for developing and contributing to the cluster repository.
+
+## Pages
+
+- [Template System](templates.md) -- Jinja2 configuration templating
+- [CI/CD Pipelines](ci-cd.md) -- GitHub Actions workflows
+- [Contributing](contributing.md) -- Conventions and guidelines

--- a/docs/development/templates.md
+++ b/docs/development/templates.md
@@ -1,0 +1,79 @@
+# Template System
+
+The cluster uses [makejinja](https://github.com/mirkolenz/makejinja) for configuration templating.
+
+## Configuration
+
+Defined in `makejinja.toml`:
+
+```toml
+[makejinja]
+inputs = ["./templates/overrides","./templates/config"]
+output = "./"
+exclude_patterns = ["*.partial.yaml.j2"]
+data = ["./cluster.yaml", "./nodes.yaml"]
+import_paths = ["./templates/scripts"]
+jinja_suffix = ".j2"
+force = true
+undefined = "chainable"
+```
+
+## Custom Delimiters
+
+To avoid conflicts with YAML and Helm templating:
+
+| Element | Syntax | Standard Jinja2 |
+|---------|--------|-----------------|
+| Variables | `#{ variable }#` | `{{ variable }}` |
+| Blocks | `#% if condition %# ... #% endif %#` | `{% if %} ... {% endif %}` |
+| Comments | `#| comment #|` | `{# comment #}` |
+
+## Custom Filters
+
+Located in `templates/scripts/plugin.py`:
+
+| Filter | Usage | Example |
+|--------|-------|---------|
+| `nthhost` | Get Nth host in CIDR | `#{ "10.0.0.0/24" \| nthhost(1) }#` → `10.0.0.1` |
+| `age_key` | Extract age key | `#{ "public" \| age_key }#` |
+| `basename` | Filename without ext | `#{ "path/file.txt" \| basename }#` → `file` |
+
+## Data Sources
+
+Templates read from two configuration files (generated via `task init`, gitignored):
+
+- **`cluster.yaml`** -- Cluster-wide settings
+- **`nodes.yaml`** -- Node definitions
+
+## Directory Structure
+
+```
+templates/
+├── config/           # Main configuration templates
+│   └── talos/       # Talos Linux config templates
+├── overrides/       # Output file overrides
+└── scripts/         # Custom Jinja2 filters
+    └── plugin.py    # nthhost, age_key, basename
+```
+
+## Workflow
+
+```sh
+# Generate configs from samples
+task init
+
+# Edit cluster.yaml and nodes.yaml
+
+# Render templates and validate
+task configure
+
+# Validate specific configs
+task template:validate-kubernetes-config
+task template:validate-talos-config
+
+# Clean up after bootstrap
+task template:tidy
+```
+
+!!! warning
+    Never modify files in `talos/clusterconfig/` directly -- they are generated from templates. Edit the source templates instead.

--- a/docs/getting-started/bootstrap.md
+++ b/docs/getting-started/bootstrap.md
@@ -1,0 +1,48 @@
+# Bootstrap
+
+!!! warning
+    Bootstrap takes **10+ minutes**. Errors like "couldn't get current server API group list" and "no matching resources found" are **normal** during this process. If interrupted with Ctrl+C, you may need to [reset the cluster](../operations/troubleshooting.md#reset-cluster) before retrying.
+
+## Stage 1: Install Talos
+
+```sh
+task bootstrap:talos
+```
+
+Push the generated secrets:
+
+```sh
+git add -A
+git commit -m "chore: add talhelper encrypted secret"
+git push
+```
+
+## Stage 2: Install Core Components
+
+This installs Cilium (CNI), CoreDNS (DNS), Flux (GitOps), and syncs the cluster to Git:
+
+```sh
+task bootstrap:apps
+```
+
+!!! note
+    Spegel (peer-to-peer image sharing) automatically activates when a second node joins the cluster.
+
+## Stage 3: Watch Deployment
+
+```sh
+kubectl get pods --all-namespaces --watch
+```
+
+## What Happens During Bootstrap
+
+The `scripts/bootstrap-apps.sh` script runs these steps:
+
+1. **Wait for nodes** -- Polls until nodes reach maintenance mode
+2. **Apply namespaces** -- Creates all namespace resources
+3. **Apply SOPS secrets** -- Decrypts and applies bootstrap secrets (deploy key, age key, cluster secrets)
+4. **Apply CRDs** -- Extracts CRDs from Helmfile (`00-crds.yaml`)
+5. **Sync Helm releases** -- Installs core applications from Helmfile (`01-apps.yaml`)
+6. **Apply ClusterSecretStore** -- Configures 1Password integration
+
+After bootstrap, Flux takes over and continuously reconciles the cluster state from Git.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,62 @@
+# Configuration
+
+## Generate Config Files
+
+```sh
+task init
+```
+
+This creates `cluster.yaml`, `nodes.yaml`, `age.key`, and other configuration files from samples.
+
+## Edit Configuration
+
+Fill out the generated files using the comments as guidance:
+
+- **`cluster.yaml`** -- Cluster-wide settings (domain, network CIDRs, feature flags)
+- **`nodes.yaml`** -- Node definitions (hostnames, IPs, roles, disk paths)
+
+## Render and Validate
+
+```sh
+task configure
+```
+
+This runs makejinja to render Jinja2 templates and validates the output.
+
+## Template System
+
+The configuration uses [makejinja](https://github.com/mirkolenz/makejinja) with custom Jinja2 delimiters to avoid YAML conflicts:
+
+| Delimiter | Syntax | Standard Jinja2 |
+|-----------|--------|-----------------|
+| Variables | `#{ variable }#` | `{{ variable }}` |
+| Blocks | `#% if condition %# ... #% endif %#` | `{% if %} ... {% endif %}` |
+| Comments | `#| comment #|` | `{# comment #}` |
+
+Templates are located in `templates/config/` and `templates/overrides/`, with custom filters in `templates/scripts/plugin.py`:
+
+```python
+nthhost(cidr, index)      # Get Nth host in CIDR range
+age_key(key_type)         # Extract age public/private key
+basename(path)            # Get filename without extension
+```
+
+## Verify Encryption
+
+Before pushing, verify all secrets are encrypted:
+
+```sh
+# All .sops.yaml files should contain 'sops:' metadata
+grep -r "sops:" kubernetes/**/*.sops.yaml bootstrap/**/*.sops.yaml
+```
+
+## Push Configuration
+
+```sh
+git add -A
+git commit -m "chore: initial commit"
+git push
+```
+
+!!! warning
+    Using a **private repository**? Paste the public key from `github-deploy.key.pub` into your repository's deploy keys settings.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -1,0 +1,27 @@
+# Getting Started
+
+This guide walks through deploying the cluster from bare metal to a fully operational GitOps-managed Kubernetes environment.
+
+## Overview
+
+There are **5 stages** to complete:
+
+1. **[Prerequisites](prerequisites.md)** -- Prepare machines and install tools
+2. **[Configuration](configuration.md)** -- Configure cluster and node settings
+3. **[Bootstrap](bootstrap.md)** -- Deploy Talos, Kubernetes, and Flux
+4. **[Post-Install](post-install.md)** -- Verify and configure DNS, webhooks
+
+## Minimum Requirements
+
+| Role | Cores | Memory | System Disk |
+|------|-------|--------|-------------|
+| Control/Worker | 4 | 16GB | 256GB SSD/NVMe |
+
+!!! tip
+    With **3 or more nodes**, make 3 of them controller nodes for a highly available control plane. All nodes are configured to run workloads -- worker nodes are optional.
+
+## Time Estimate
+
+- Stage 1-2 (prep + config): Variable depending on hardware
+- Stage 3 (bootstrap): 10-15 minutes (errors during bootstrap are normal)
+- Stage 4 (verification): 5-10 minutes

--- a/docs/getting-started/post-install.md
+++ b/docs/getting-started/post-install.md
@@ -1,0 +1,92 @@
+# Post-Installation
+
+## Verification
+
+### Check Cilium
+
+```sh
+cilium status
+```
+
+### Check Flux
+
+```sh
+flux check
+flux get sources git flux-system
+flux get ks -A
+flux get hr -A
+```
+
+!!! tip
+    Run `task reconcile` to force Flux to sync immediately.
+
+### Check Connectivity
+
+```sh
+# Test gateway ports (replace variables with actual values)
+nmap -Pn -n -p 443 ${cluster_gateway_addr} ${cloudflare_gateway_addr} -vv
+```
+
+### Check DNS
+
+```sh
+# Should resolve to your Cloudflare gateway address
+dig @${cluster_dns_gateway_addr} echo.${cloudflare_domain}
+```
+
+### Check Certificates
+
+```sh
+kubectl -n network describe certificates
+```
+
+## Configure GitHub Webhook
+
+For push-triggered reconciliation (instead of polling):
+
+1. Get the webhook path:
+
+    ```sh
+    kubectl -n flux-system get receiver github-webhook \
+      --output=jsonpath='{.status.webhookPath}'
+    ```
+
+2. Build the full URL:
+
+    ```
+    https://flux-webhook.${cloudflare_domain}/hook/<webhook-path>
+    ```
+
+3. In GitHub repository settings, go to **Settings > Webhooks > Add webhook**:
+    - **URL**: The full webhook URL from above
+    - **Secret**: Contents of `github-push-token.txt`
+    - **Content type**: `application/json`
+    - **Events**: Just the push event
+
+## Configure Home DNS (Split DNS)
+
+The `k8s_gateway` service provides DNS resolution for cluster services. Configure your home DNS server to forward queries for your domain to `${cluster_dns_gateway_addr}`.
+
+This enables accessing internal services like `grafana.yourdomain.com` from any device on your network.
+
+## Public vs Private Access
+
+| Gateway | Use Case | Configuration |
+|---------|----------|---------------|
+| `envoy-external` | Public internet access | Routes through Cloudflare Tunnel |
+| `envoy-internal` | Private network only | Accessible via split DNS |
+
+By default, only `echo` and `flux-webhook` are publicly accessible. To make additional apps public, set the correct gateway on their HTTPRoute.
+
+## Clean Up Templates
+
+Once the cluster is stable and you no longer need `task configure`:
+
+```sh
+task template:tidy
+git add -A
+git commit -m "chore: tidy up"
+git push
+```
+
+This removes the `templates/` directory and template-related files.

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -1,0 +1,76 @@
+# Prerequisites
+
+## Machine Preparation
+
+1. Go to the [Talos Linux Image Factory](https://factory.talos.dev) and build an image:
+    - Choose **bare-minimum system extensions** only
+    - Start with CPU-specific extensions: `i915`, `intel-ucode`, `mei` (Intel) or `amdgpu`, `amd-ucode` (AMD)
+    - Note the **schematic ID** -- you'll need it later
+
+2. Flash the Talos ISO/RAW image to USB and boot your nodes
+
+3. Verify nodes are reachable:
+
+    ```sh
+    nmap -Pn -n -p 50000 192.168.1.0/24 -vv | grep 'Discovered'
+    ```
+
+## Local Workstation
+
+1. Clone the repository:
+
+    ```sh
+    git clone https://github.com/00o-sh/special-winner.git
+    cd special-winner
+    ```
+
+2. Install [Mise CLI](https://mise.jdx.dev/getting-started.html#installing-mise-cli) and [activate](https://mise.jdx.dev/getting-started.html#activate-mise) it in your shell
+
+3. Install required tools:
+
+    ```sh
+    mise trust
+    pip install pipx
+    mise install
+    ```
+
+    !!! note
+        Having trouble? Try `unset GITHUB_TOKEN` and run again. For Python compilation issues: `mise settings python.compile=0`
+
+4. Logout of GHCR to avoid auth issues:
+
+    ```sh
+    docker logout ghcr.io
+    helm registry logout ghcr.io
+    ```
+
+## Cloudflare Setup
+
+1. Create a Cloudflare API token with:
+    - `Zone - DNS - Edit` permission
+    - `Account - Cloudflare Tunnel - Read` permission
+    - Name it `kubernetes`
+
+2. Create the tunnel:
+
+    ```sh
+    cloudflared tunnel login
+    cloudflared tunnel create --credentials-file cloudflare-tunnel.json kubernetes
+    ```
+
+## Tool Versions
+
+All tools are managed via `.mise.toml`:
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| Python | 3.14.3 | Template rendering |
+| kubectl | 1.34.0 | Kubernetes CLI |
+| Helm | 4.1.1 | Chart management |
+| Flux | 2.7.5 | GitOps CLI |
+| Talos CLI | 1.12.4 | Talos management |
+| Cilium CLI | 0.19.1 | Network management |
+| SOPS | 3.11.0 | Secret encryption |
+| Age | 1.3.1 | Encryption backend |
+| virtctl | 1.7.0 | VM management |
+| k9s | 0.50.18 | Kubernetes TUI |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,42 @@
+# Special Winner
+
+A Kubernetes homelab cluster deployed with [Talos Linux](https://www.talos.dev/) and [Flux CD](https://fluxcd.io/) for GitOps-driven infrastructure management.
+
+Built on the [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template), this cluster uses [makejinja](https://github.com/mirkolenz/makejinja) for configuration templating and delivers a fully declarative, Git-managed infrastructure.
+
+## At a Glance
+
+| Component | Technology | Version |
+|-----------|-----------|---------|
+| OS | Talos Linux | 1.12.4 |
+| Orchestration | Kubernetes | 1.34.0 |
+| GitOps | Flux CD | 2.7.5 |
+| CNI | Cilium | 1.19.0 |
+| Ingress | Envoy Gateway | v1.6.3 |
+| Secrets | SOPS + Age | 3.11.0 / 1.3.1 |
+| Identity | Kanidm | SSO/OAuth2 |
+| Packages | Helm | 4.1.1 (v4) |
+| Database | CloudNative-PG | PostgreSQL 17.7 |
+| Virtualization | KubeVirt | 1.7.0 |
+
+## What's Deployed
+
+**65+ applications** across **17 namespaces** covering:
+
+- **Media** -- Plex, Radarr, Sonarr, Prowlarr, Bazarr, qBittorrent, and more
+- **Virtualization** -- KubeVirt with Debian, Ubuntu, Windows, and FreePBX VMs
+- **Identity** -- Kanidm SSO with OAuth2 integrations
+- **Observability** -- Prometheus, Grafana, Victoria Logs, Gatus, OpenCost
+- **Databases** -- PostgreSQL 17.7 HA cluster (3 instances) + Dragonfly
+- **Networking** -- Cilium, Envoy Gateway, Cloudflare Tunnel, Multus
+- **Storage** -- OpenEBS, VolSync, Garage S3, NFS
+- **CI/CD** -- GitHub Actions runners, Forgejo with CI runners
+- **Utilities** -- Penpot, Homepage, SMTP relay, and more
+
+## Quick Links
+
+- [Getting Started](getting-started/index.md) -- Set up the cluster from scratch
+- [Architecture](architecture.md) -- Understand how everything fits together
+- [Applications](applications/index.md) -- Browse deployed applications
+- [Operations](operations/index.md) -- Day-2 operations and troubleshooting
+- [Development](development/index.md) -- Template system and CI/CD

--- a/docs/infrastructure/certificates-dns.md
+++ b/docs/infrastructure/certificates-dns.md
@@ -1,0 +1,61 @@
+# Certificates & DNS
+
+## cert-manager
+
+[cert-manager](https://cert-manager.io/) automates TLS certificate management:
+
+- Wildcard certificates via Cloudflare DNS-01 challenge
+- Automatic renewal before expiry
+- Certificates stored as Kubernetes Secrets
+
+### Checking Certificates
+
+```sh
+kubectl -n network describe certificates
+kubectl -n cert-manager get clusterissuers
+```
+
+## DNS Architecture
+
+```mermaid
+graph TD
+    Internet[Internet DNS] --> CF[Cloudflare DNS]
+    CF --> Tunnel[Cloudflare Tunnel]
+    Tunnel --> Envoy[Envoy Gateway]
+
+    HomeDNS[Home DNS Server] --> k8sGW[k8s_gateway]
+    k8sGW --> Envoy
+
+    Pods[Cluster Pods] --> CoreDNS[CoreDNS]
+    CoreDNS --> k8sGW
+```
+
+### CoreDNS
+
+Provides in-cluster DNS resolution for pod-to-pod and pod-to-service communication.
+
+### k8s_gateway
+
+Provides DNS resolution for external Kubernetes resources from your home network. Your home DNS server must forward queries for your domain to the k8s_gateway address.
+
+### External-DNS
+
+Automatically creates DNS records in Cloudflare when services are exposed:
+
+- Watches Kubernetes resources for DNS annotations
+- Creates A/CNAME records in Cloudflare
+- Used by VMs for dedicated DNS entries
+
+### Cloudflare DNS
+
+Manages public DNS records:
+
+- `cloudflare-dns` -- DNS record management
+- `cloudflare-tunnel` -- Secure external access without port forwarding
+
+### UniFi DNS
+
+Integration with UniFi network equipment for local DNS management:
+
+- `unifi-dns` -- DNS webhook provider
+- `unifi-toolkit` -- Network management toolkit

--- a/docs/infrastructure/cilium.md
+++ b/docs/infrastructure/cilium.md
@@ -1,0 +1,40 @@
+# Cilium Networking
+
+[Cilium](https://cilium.io/) 1.19.0 provides eBPF-based container networking, replacing the traditional kube-proxy.
+
+## Features
+
+- **eBPF dataplane** for high-performance packet processing
+- **Network policies** with L3/L4/L7 filtering
+- **Service mesh** capabilities (optional)
+- **Hubble** for network observability
+- **Load balancing** with direct server return
+
+## Configuration
+
+Cilium is deployed as a HelmRelease in `kube-system`:
+
+```
+kubernetes/apps/kube-system/cilium/
+├── app/
+│   ├── helmrelease.yaml
+│   ├── ocirepository.yaml
+│   └── kustomization.yaml
+└── ks.yaml
+```
+
+## Checking Status
+
+```sh
+cilium status
+cilium connectivity test    # Full connectivity test
+```
+
+## Hubble (Observability)
+
+If enabled, Hubble provides network flow visibility:
+
+```sh
+hubble status
+hubble observe --follow
+```

--- a/docs/infrastructure/databases.md
+++ b/docs/infrastructure/databases.md
@@ -1,0 +1,69 @@
+# Databases
+
+## CloudNative-PG (PostgreSQL)
+
+[CloudNative-PG](https://cloudnative-pg.io/) runs a **PostgreSQL 17.7** high-availability cluster with 3 instances.
+
+### Architecture
+
+```
+kubernetes/apps/database/cloudnative-pg/
+├── app/                    # Operator deployment
+│   ├── helmrelease.yaml
+│   └── ocirepository.yaml
+├── cluster/               # PostgreSQL cluster definition
+│   ├── cluster.yaml       # Main cluster spec
+│   ├── scheduledbackup.yaml
+│   ├── objectstore.yaml   # S3 backup config
+│   └── externalsecret.yaml
+└── recovery/              # Disaster recovery configs
+    └── cluster.yaml
+```
+
+### Configuration
+
+| Setting | Value |
+|---------|-------|
+| Instances | 3 (HA with pod anti-affinity) |
+| Storage | 20Gi per instance (openebs-hostpath) |
+| Max connections | 200 |
+| Shared buffers | 256MB |
+| Effective cache size | 512MB |
+| Maintenance work mem | 128MB |
+| CPU request | 100m |
+| Memory request | 512Mi |
+| Memory limit | 2Gi |
+
+### Backups
+
+- **WAL archiving** to Garage S3 via barman-cloud plugin
+- **Scheduled backups** with configurable retention
+- **Monitoring** via PodMonitor for Prometheus
+
+### Connecting
+
+Applications connect via the internal service:
+
+```
+postgres-rw.database.svc.cluster.local:5432
+```
+
+### Recovery
+
+A recovery cluster definition exists at `kubernetes/apps/database/cloudnative-pg/recovery/cluster.yaml` for disaster recovery scenarios.
+
+## Dragonfly
+
+[Dragonfly](https://www.dragonflydb.io/) is a modern Redis-compatible in-memory datastore:
+
+- Deploys the Dragonfly Operator for managing instances
+- Higher performance alternative to Redis/Valkey
+- Used by applications requiring fast caching or session storage
+
+## DBGate
+
+[DBGate](https://dbgate.org/) provides a web UI for database management:
+
+- Located in `kubernetes/apps/database/dbgate/`
+- Kanidm SSO integration for authentication
+- Accessible via Envoy Gateway

--- a/docs/infrastructure/envoy-gateway.md
+++ b/docs/infrastructure/envoy-gateway.md
@@ -1,0 +1,90 @@
+# Envoy Gateway
+
+[Envoy Gateway](https://gateway.envoyproxy.io/) v1.6.3 provides HTTP routing and ingress using the Kubernetes Gateway API.
+
+## Architecture
+
+Envoy Gateway deploys Envoy Proxy instances that handle incoming traffic:
+
+- **envoy-internal** -- Private network access (split DNS)
+- **envoy-external** -- Public access via Cloudflare Tunnel
+
+## Configuration
+
+```
+kubernetes/apps/network/envoy-gateway/app/
+├── helmrelease.yaml      # Envoy Gateway operator
+├── ocirepository.yaml    # Chart source
+├── certificate.yaml      # TLS wildcard certificate
+├── envoy.yaml            # Gateway configuration
+├── grafanadashboard.yaml # Monitoring dashboard
+├── podmonitor.yaml       # Prometheus metrics
+└── kustomization.yaml
+```
+
+## Exposing Applications
+
+### Internal Only
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: my-app
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  hostnames:
+    - "my-app.example.com"
+  rules:
+    - backendRefs:
+        - name: my-app
+          port: 80
+```
+
+### Public (via Cloudflare)
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: my-app
+spec:
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+  hostnames:
+    - "my-app.example.com"
+  rules:
+    - backendRefs:
+        - name: my-app
+          port: 80
+```
+
+## SSO Integration
+
+Envoy Gateway supports OIDC SecurityPolicy for Kanidm SSO:
+
+```yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: kanidm-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: <app-route>
+  oidc:
+    provider:
+      issuer: "https://idm.example.com/oauth2/openid/<client>"
+    clientID: "<client-name>"
+    clientSecret:
+      name: "<secret-name>"
+```
+
+## Monitoring
+
+- Grafana dashboard enabled via GrafanaOperator
+- PodMonitor exports metrics to Prometheus

--- a/docs/infrastructure/flux.md
+++ b/docs/infrastructure/flux.md
@@ -1,0 +1,110 @@
+# Flux CD
+
+[Flux CD](https://fluxcd.io/) v2.7.5 provides GitOps continuous delivery, automatically syncing the cluster state from Git.
+
+## Architecture
+
+The cluster uses the **Flux Operator** pattern:
+
+- **flux-operator** (v0.41.1) -- Manages Flux components lifecycle
+- **flux-instance** (v0.41.1) -- Configured Flux deployment with performance tuning
+
+### Performance Tuning
+
+The Flux instance is configured with:
+
+- **10 concurrent workers** for Kustomize and Helm controllers
+- **1Gi memory limits** for controllers
+- **Helm caching** enabled for faster reconciliation
+- **OOM detection** enabled
+- **SOPS decryption** configured for Age keys
+
+## How It Works
+
+```mermaid
+graph TD
+    A[Git Push] --> B[Flux detects change]
+    B --> C[Reconcile Kustomizations]
+    C --> D[Process HelmReleases]
+    D --> E[Apply to Cluster]
+    E --> F[Report Status]
+```
+
+1. Flux watches the Git repository (via webhook or polling)
+2. Kustomizations define which paths to reconcile
+3. HelmReleases deploy applications from OCI registries
+4. SOPS secrets are decrypted automatically
+5. Post-build variable substitution injects cluster secrets
+
+## Key Patterns
+
+### Kustomization
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: <app-name>
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/<namespace>/<app>/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: <namespace>
+  wait: false
+```
+
+### HelmRelease
+
+```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: <app-name>
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: <chart-name>
+  interval: 1h
+  values:
+    # Application-specific values
+```
+
+## Common Operations
+
+### Force Reconciliation
+
+```sh
+task reconcile
+# or
+flux --namespace flux-system reconcile kustomization flux-system --with-source
+```
+
+### Check Status
+
+```sh
+flux check                    # Health check
+flux get sources git -A       # Git sources
+flux get ks -A                # Kustomizations
+flux get hr -A                # HelmReleases
+```
+
+### View Logs
+
+```sh
+flux logs --all-namespaces
+```
+
+### Suspend/Resume
+
+```sh
+flux suspend hr <name> -n <namespace>
+flux resume hr <name> -n <namespace>
+```

--- a/docs/infrastructure/identity.md
+++ b/docs/infrastructure/identity.md
@@ -1,0 +1,75 @@
+# Identity & SSO
+
+## Kanidm
+
+[Kanidm](https://kanidm.com/) provides centralized identity management and OAuth2/OIDC single sign-on for the cluster.
+
+### Architecture
+
+Located in `kubernetes/apps/identity/kanidm/`:
+
+- Deployed via the **Kaniop** Kubernetes operator
+- Single Rust binary with embedded database (no external PostgreSQL needed)
+- ~80 MB RAM footprint
+- Manages users, groups, and OAuth2 clients declaratively via CRDs
+
+### OAuth2 Integrations
+
+Kanidm provides SSO for these applications:
+
+| Application | Namespace | Authentication |
+|-------------|-----------|---------------|
+| DBGate | database | OAuth2/OIDC |
+| Forgejo | utils | OAuth2/OIDC |
+| KubeVirt Manager | kubevirt | OAuth2/OIDC |
+| OpenCost | observability | OAuth2/OIDC |
+| Penpot | utils | OAuth2/OIDC |
+
+Each OAuth2 client is defined as a separate YAML file under `kubernetes/apps/identity/kanidm/app/`.
+
+### Features
+
+- **OAuth2/OIDC** -- Certified provider with mandatory PKCE
+- **Passkeys/WebAuthn** -- Best-in-class (maintains `webauthn-rs`)
+- **RADIUS** -- Built-in for WiFi WPA2-Enterprise
+- **SSH key distribution** -- Cached and direct modes
+- **Unix/PAM integration** -- TPM-backed credential caching
+- **LDAP** -- Read-only gateway
+
+### Adding SSO to a New Application
+
+1. Create a `KanidmOAuth2Client` CRD in `kubernetes/apps/identity/kanidm/app/`
+2. Configure the application with the OIDC provider URL and client credentials
+3. Optionally add an Envoy Gateway `SecurityPolicy` for apps without native OIDC
+
+### Envoy Gateway OIDC Integration
+
+For apps without native OIDC support, use Envoy Gateway's SecurityPolicy:
+
+```yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: app-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: <app-route>
+  oidc:
+    provider:
+      issuer: "https://idm.example.com/oauth2/openid/<client>"
+    clientID: "<client-name>"
+    clientSecret:
+      name: "<secret-name>"
+```
+
+### kGuardian
+
+[kGuardian](https://github.com/kguardian-dev/kguardian) provides eBPF-based security monitoring:
+
+- **Broker** (v1.6.0) -- Message broker for security events
+- **Controller** (v1.7.0) -- Core monitoring engine
+- **Frontend** (v1.6.2) -- Web UI for security insights
+- Uses external CloudNative-PG database
+- Auto-generates NetworkPolicy and seccomp profiles from observed runtime behavior

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -1,0 +1,50 @@
+# Infrastructure
+
+This section covers the core infrastructure components that power the cluster.
+
+## Component Overview
+
+```mermaid
+graph LR
+    subgraph OS["Operating System"]
+        Talos[Talos Linux 1.12.4]
+    end
+    subgraph Network["Networking"]
+        Cilium[Cilium 1.19.0]
+        Envoy[Envoy Gateway v1.6.3]
+        CF[Cloudflare Tunnel]
+    end
+    subgraph Data["Data"]
+        PG[PostgreSQL 17.7]
+        DF[Dragonfly]
+        OEBS[OpenEBS]
+    end
+    subgraph GitOps
+        Flux[Flux CD 2.7.5]
+    end
+    subgraph Security
+        SOPS[SOPS + Age]
+        Kanidm[Kanidm SSO]
+        CM[cert-manager]
+    end
+
+    Talos --> Cilium
+    Cilium --> Envoy
+    Flux --> Network
+    Flux --> Data
+    Flux --> Security
+```
+
+## Pages
+
+| Page | Description |
+|------|-------------|
+| [Talos Linux](talos.md) | Immutable Kubernetes OS configuration and management |
+| [Flux CD](flux.md) | GitOps continuous delivery |
+| [Cilium](cilium.md) | eBPF-based container networking |
+| [Envoy Gateway](envoy-gateway.md) | HTTP routing and ingress |
+| [Storage](storage.md) | OpenEBS, NFS, and backup systems |
+| [Databases](databases.md) | PostgreSQL HA cluster and Dragonfly |
+| [Certificates & DNS](certificates-dns.md) | TLS automation and DNS management |
+| [Secrets](secrets.md) | SOPS, Age, and External Secrets |
+| [Identity & SSO](identity.md) | Kanidm identity provider |

--- a/docs/infrastructure/secrets.md
+++ b/docs/infrastructure/secrets.md
@@ -1,0 +1,84 @@
+# Secrets Management
+
+## Overview
+
+Secrets are managed through two complementary systems:
+
+1. **SOPS + Age** -- Encrypts secrets stored in Git
+2. **External Secrets Operator** -- Pulls secrets from 1Password at runtime
+
+## SOPS + Age
+
+[SOPS](https://github.com/getsops/sops) encrypts YAML files using [Age](https://github.com/FiloSottile/age) keys.
+
+### Encryption Rules (`.sops.yaml`)
+
+| Path Pattern | Encryption Scope |
+|-------------|-----------------|
+| `talos/.*\.sops\.ya?ml` | Full file encryption |
+| `(bootstrap\|kubernetes)/.*\.sops\.ya?ml` | Only `data` and `stringData` fields |
+
+### Encrypting a Secret
+
+```sh
+sops --encrypt --in-place kubernetes/apps/<namespace>/<app>/app/secret.sops.yaml
+```
+
+### Decrypting a Secret
+
+```sh
+sops --decrypt kubernetes/apps/<namespace>/<app>/app/secret.sops.yaml
+```
+
+### Key Management
+
+- Age public key: defined in `.sops.yaml`
+- Age private key: stored in `age.key` (gitignored)
+- Environment variable: `SOPS_AGE_KEY_FILE` points to `age.key`
+
+## External Secrets Operator
+
+[External Secrets Operator](https://external-secrets.io/) v2.0.0 syncs secrets from external providers into Kubernetes.
+
+### 1Password Integration
+
+A `ClusterSecretStore` connects to 1Password:
+
+```
+kubernetes/apps/external-secrets/
+├── external-secrets/    # Operator deployment
+├── onepassword/         # ClusterSecretStore config
+└── discord-webhook/     # Discord integration
+```
+
+Applications reference secrets via `ExternalSecret` resources that pull values from 1Password vaults.
+
+### Creating an ExternalSecret
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: app-secret
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: app-secret
+  data:
+    - secretKey: password
+      remoteRef:
+        key: my-1password-item
+        property: password
+```
+
+## Best Practices
+
+!!! danger "Never commit unencrypted secrets"
+    All sensitive data must be in `*.sops.yaml` files. Verify encryption by checking for `sops:` metadata in the file.
+
+- Use `ExternalSecret` for runtime secrets from 1Password
+- Use `SOPS` for secrets that must exist in Git (bootstrap, cluster config)
+- Always validate that `*.sops.yaml` files are encrypted before pushing
+- Renovate is configured to ignore `**/*.sops.*` files

--- a/docs/infrastructure/storage.md
+++ b/docs/infrastructure/storage.md
@@ -1,0 +1,75 @@
+# Storage
+
+The cluster uses multiple storage backends for different workload requirements.
+
+## Storage Classes
+
+| Class | Backend | Access Modes | Use Case |
+|-------|---------|-------------|----------|
+| `openebs-hostpath` | OpenEBS | RWO | Database volumes, high-performance local storage |
+| `nfs-fast` | CSI Driver NFS | RWX | VM disks, shared media, multi-node access |
+
+## OpenEBS
+
+[OpenEBS](https://openebs.io/) provides cloud-native local storage:
+
+- **hostpath** provisioner for fast local volumes
+- Used by PostgreSQL, Dragonfly, and other stateful workloads
+- CDI scratch space for VM disk imports
+
+```
+kubernetes/apps/openebs-system/openebs/
+├── app/
+│   ├── helmrelease.yaml
+│   ├── ocirepository.yaml
+│   └── kustomization.yaml
+└── ks.yaml
+```
+
+## NFS Storage
+
+CSI Driver NFS provides shared network storage:
+
+- **ReadWriteMany** support for multi-node access
+- Used for VM disks (enables live migration)
+- Used for shared media storage
+- NFS-scaler component prevents pods from crash-looping when NFS is unavailable
+
+## Backup System
+
+### VolSync
+
+[VolSync](https://volsync.readthedocs.io/) handles volume replication and backup:
+
+- Backs up PersistentVolumeClaims to S3-compatible storage
+- Scheduled daily at 2 AM
+- Component available at `kubernetes/components/volsync/`
+
+### Garage
+
+[Garage](https://garagehq.deuxfleurs.fr/) provides S3-compatible storage as the backup destination:
+
+- Self-hosted within the cluster
+- Used by VolSync and CloudNative-PG backups
+
+### Kopia
+
+[Kopia](https://kopia.io/) serves as the backup repository:
+
+- Deduplication and encryption
+- Works with VolSync for volume-level backups
+
+## Snapshot Controller
+
+The [snapshot-controller](https://github.com/kubernetes-csi/external-snapshotter) enables volume snapshots for point-in-time recovery.
+
+## NFS Scaler Component
+
+Located in `kubernetes/components/nfs-scaler/`, this KEDA-based component monitors NFS availability:
+
+- Queries Prometheus for `probe_success{instance=~".+:2049"}` metric
+- Scales deployments 0 → 1 when NFS is available
+- Scales down to 0 when NFS is unavailable
+- Prevents crash-loop storms when NFS is down
+
+Apply to any app that mounts NFS volumes.

--- a/docs/infrastructure/talos.md
+++ b/docs/infrastructure/talos.md
@@ -1,0 +1,101 @@
+# Talos Linux
+
+[Talos Linux](https://www.talos.dev/) is an immutable, minimal OS designed specifically for Kubernetes. Version **1.12.4** is deployed.
+
+## Configuration
+
+Talos configuration is managed through [talhelper](https://budimanjojo.github.io/talhelper/latest/) and Jinja2 templates.
+
+### File Locations
+
+| Path | Purpose |
+|------|---------|
+| `templates/config/talos/talconfig.yaml.j2` | Main Talos config template |
+| `talos/patches/global/` | Patches applied to all nodes |
+| `talos/patches/controller/` | Controller-specific patches |
+| `talos/patches/worker/` | Worker-specific patches |
+| `talos/patches/vm-node/` | KubeVirt VM node patches |
+| `talos/patches/${hostname}/` | Per-node patches |
+| `talos/clusterconfig/` | Generated configs (gitignored) |
+
+### Patch System
+
+Talos uses a layered patch system. Patches are applied in order:
+
+1. Global patches (all nodes)
+2. Role-specific patches (controller or worker)
+3. VM-node patches (KubeVirt nodes)
+4. Per-hostname patches
+
+## Common Operations
+
+### Generate Config
+
+```sh
+task talos:generate-config
+```
+
+### Apply Config to a Node
+
+```sh
+task talos:apply-node IP=10.10.10.10 MODE=auto
+```
+
+Mode options: `auto`, `no-reboot`, `reboot`, `staged`
+
+### Upgrade Talos Version
+
+```sh
+task talos:upgrade-node IP=10.10.10.10
+```
+
+!!! tip
+    Update `talosVersion` in `talenv.yaml` before upgrading.
+
+### Upgrade Kubernetes Version
+
+```sh
+task talos:upgrade-k8s
+```
+
+### Reset Cluster
+
+!!! danger
+    This destroys the entire cluster. Repeated resets may trigger rate limits from DockerHub or Let's Encrypt.
+
+```sh
+task talos:reset
+```
+
+## Adding a New Node
+
+1. Boot the new node with Talos in maintenance mode
+2. Get disk and MAC address info:
+
+    ```sh
+    talosctl get disks -n <ip> --insecure
+    talosctl get links -n <ip> --insecure
+    ```
+
+3. Add the node to `talconfig.yaml`
+4. Generate and apply:
+
+    ```sh
+    task talos:generate-config
+    task talos:apply-node IP=<new-ip>
+    ```
+
+The node joins automatically and begins accepting workloads.
+
+## Debugging
+
+```sh
+# Check cluster membership
+talosctl get members --nodes <ip> --insecure
+
+# View node logs
+talosctl logs --nodes <ip> --insecure
+
+# Check node services
+talosctl services --nodes <ip>
+```

--- a/docs/operations/backup-recovery.md
+++ b/docs/operations/backup-recovery.md
@@ -1,0 +1,103 @@
+# Backup & Recovery
+
+## Backup Architecture
+
+```mermaid
+graph LR
+    PVC[PersistentVolumeClaims] -->|VolSync| Kopia[Kopia Repository]
+    Kopia -->|S3 API| Garage[Garage S3]
+    PG[PostgreSQL WAL] -->|barman-cloud| Garage
+    Git[Git Repository] -->|GitOps| State[Cluster State]
+```
+
+## VolSync
+
+[VolSync](https://volsync.readthedocs.io/) replicates PersistentVolumeClaims to S3-compatible storage.
+
+### Schedule
+
+Backups run **daily at 2 AM** by default.
+
+### Component
+
+The VolSync component is at `kubernetes/components/volsync/`. Apply it to stateful applications:
+
+```yaml
+# In your app's ks.yaml, reference the volsync component
+spec:
+  components:
+    - name: volsync
+```
+
+### Checking Backup Status
+
+```sh
+kubectl get replicationsource -A
+kubectl get replicationdestination -A
+```
+
+## PostgreSQL Backups
+
+CloudNative-PG handles PostgreSQL backups independently:
+
+- **WAL archiving** to Garage S3 via barman-cloud plugin
+- **Scheduled backups** with configurable retention
+- Recovery cluster definition at `kubernetes/apps/database/cloudnative-pg/recovery/`
+
+### Triggering a Manual Backup
+
+```sh
+kubectl -n database create -f - <<EOF
+apiVersion: postgresql.cnpg.io/v1
+kind: Backup
+metadata:
+  name: manual-backup-$(date +%Y%m%d%H%M)
+spec:
+  cluster:
+    name: postgres
+  method: barmanObjectStore
+EOF
+```
+
+### Checking Backup Status
+
+```sh
+kubectl -n database get backups
+kubectl -n database get scheduledbackups
+```
+
+## Disaster Recovery
+
+### Full Cluster Recovery
+
+Since the cluster is GitOps-managed, recovery involves:
+
+1. Bootstrap new Talos nodes
+2. Run `task bootstrap:talos` and `task bootstrap:apps`
+3. Flux restores all application state from Git
+4. VolSync restores PVC data from Garage S3
+5. PostgreSQL recovers from WAL archives
+
+### PostgreSQL Point-in-Time Recovery
+
+Use the recovery cluster definition:
+
+```
+kubernetes/apps/database/cloudnative-pg/recovery/cluster.yaml
+```
+
+### What's Not in Git
+
+These items require manual restoration or are ephemeral:
+
+- Active VM state (VMs restart from disk images)
+- In-memory caches (Dragonfly data)
+- Real-time metrics (Prometheus TSDB rebuilds from scrapes)
+
+## Garage S3
+
+[Garage](https://garagehq.deuxfleurs.fr/) provides the S3-compatible storage backend:
+
+- Self-hosted within the cluster
+- Stores VolSync and PostgreSQL backups
+- Located in `kubernetes/apps/volsync-system/garage/`

--- a/docs/operations/day2.md
+++ b/docs/operations/day2.md
@@ -1,0 +1,102 @@
+# Day-2 Operations
+
+## Flux Reconciliation
+
+Force Flux to pull the latest changes from Git:
+
+```sh
+task reconcile
+```
+
+Check the status of all Flux resources:
+
+```sh
+flux get ks -A       # Kustomizations
+flux get hr -A       # HelmReleases
+flux get sources -A  # All sources
+```
+
+## Talos Operations
+
+### Update Node Configuration
+
+```sh
+# Regenerate configs from templates
+task talos:generate-config
+
+# Apply to a specific node
+task talos:apply-node IP=10.10.10.10 MODE=auto
+```
+
+### Upgrade Talos
+
+1. Update `talosVersion` in `talenv.yaml`
+2. Run:
+
+```sh
+task talos:upgrade-node IP=10.10.10.10
+```
+
+### Upgrade Kubernetes
+
+1. Update `kubernetesVersion` in `talenv.yaml`
+2. Run:
+
+```sh
+task talos:upgrade-k8s
+```
+
+## Application Management
+
+### Suspend an Application
+
+```sh
+flux suspend hr <app-name> -n <namespace>
+```
+
+### Resume an Application
+
+```sh
+flux resume hr <app-name> -n <namespace>
+```
+
+### Force Redeploy
+
+```sh
+flux reconcile hr <app-name> -n <namespace> --force
+```
+
+### Roll Back a HelmRelease
+
+```sh
+# Check history
+helm history <release-name> -n <namespace>
+
+# Rollback
+helm rollback <release-name> <revision> -n <namespace>
+```
+
+## Renovate
+
+Renovate runs on a weekend schedule and creates PRs for dependency updates:
+
+- **Auto-merge**: GitHub Actions (minor/patch), Mise tools (minor/patch)
+- **Manual review**: Helm charts, container images (major versions)
+- **Dashboard**: Check the "Dependency Dashboard" issue in GitHub
+
+## Adding a New Application
+
+Follow the checklist in order:
+
+1. Create directory: `kubernetes/apps/<namespace>/<app-name>/app/`
+2. Create manifests: `helmrelease.yaml`, `ocirepository.yaml`, `kustomization.yaml`
+3. Create `ks.yaml` Flux Kustomization
+4. Update `kubernetes/apps/<namespace>/kustomization.yaml`
+5. Encrypt any secrets with SOPS
+6. Consider Kanidm SSO integration
+7. Add to Homepage dashboard
+8. Add VolSync backup config if stateful
+9. Add monitoring (ServiceMonitor/PodMonitor) if metrics are exposed
+10. Add Discord alerts if critical
+11. Add NFS-scaler if mounting NFS volumes
+12. Update CLAUDE.md with the new application

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,0 +1,25 @@
+# Operations
+
+Guides for managing the cluster day-to-day.
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Force Flux sync | `task reconcile` |
+| List all tasks | `task --list` |
+| Generate Talos config | `task talos:generate-config` |
+| Apply config to node | `task talos:apply-node IP=<ip> MODE=auto` |
+| Upgrade Talos | `task talos:upgrade-node IP=<ip>` |
+| Upgrade Kubernetes | `task talos:upgrade-k8s` |
+| Reset cluster | `task talos:reset` |
+| Validate K8s manifests | `task template:validate-kubernetes-config` |
+| VM console | `task vm:console VM=<name>` |
+| VM start/stop | `task vm:start VM=<name>` / `task vm:stop VM=<name>` |
+
+## Pages
+
+- [Day-2 Operations](day2.md) -- Routine maintenance and upgrades
+- [Backup & Recovery](backup-recovery.md) -- VolSync, Kopia, and disaster recovery
+- [VM Management](vm-management.md) -- KubeVirt virtual machine operations
+- [Troubleshooting](troubleshooting.md) -- Debugging common issues

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,164 @@
+# Troubleshooting
+
+## Flux Issues
+
+### Resources Not Syncing
+
+```sh
+# Check Flux health
+flux check
+
+# Check for failed reconciliations
+flux get ks -A --status-selector ready=false
+flux get hr -A --status-selector ready=false
+
+# View Flux logs
+flux logs --all-namespaces
+
+# Force sync
+task reconcile
+```
+
+### HelmRelease Stuck
+
+```sh
+# Suspend and resume
+flux suspend hr <name> -n <namespace>
+flux resume hr <name> -n <namespace>
+
+# Force reconciliation
+flux reconcile hr <name> -n <namespace> --force
+```
+
+## Template Issues
+
+### Templates Not Rendering
+
+```sh
+task template:validate-schemas    # Check cluster.yaml & nodes.yaml
+task template:render-configs      # Force re-render
+```
+
+## Secret Issues
+
+### Secrets Not Decrypting
+
+```sh
+# Verify age key exists
+test -f age.key && echo "Key exists" || echo "Missing key"
+
+# Verify SOPS can decrypt
+sops --decrypt bootstrap/sops-age.sops.yaml
+
+# Check SOPS_AGE_KEY_FILE is set
+echo $SOPS_AGE_KEY_FILE
+```
+
+### Verifying Encryption
+
+```sh
+# All .sops.yaml files should contain 'sops:' metadata
+grep -l "sops:" kubernetes/**/*.sops.yaml
+```
+
+## Node Issues
+
+### Nodes Not Joining
+
+```sh
+talosctl get members --nodes <ip> --insecure
+talosctl logs --nodes <ip> --insecure
+```
+
+### Node Health
+
+```sh
+kubectl get nodes -o wide
+kubectl describe node <node-name>
+```
+
+## Pod Issues
+
+### General Debugging
+
+```sh
+# List pods in namespace
+kubectl -n <namespace> get pods -o wide
+
+# Check pod logs
+kubectl -n <namespace> logs <pod-name> -f
+
+# Describe pod for events
+kubectl -n <namespace> describe pod <pod-name>
+
+# Check namespace events
+kubectl -n <namespace> get events --sort-by='.metadata.creationTimestamp'
+```
+
+### CrashLoopBackOff
+
+1. Check logs: `kubectl -n <ns> logs <pod> --previous`
+2. Check resource limits: `kubectl -n <ns> describe pod <pod>`
+3. Check if NFS-dependent -- add NFS-scaler component if so
+4. Check if secret is missing: `kubectl -n <ns> get secrets`
+
+### Pending Pods
+
+1. Check events: `kubectl -n <ns> describe pod <pod>`
+2. Check node resources: `kubectl top nodes`
+3. Check PVC binding: `kubectl -n <ns> get pvc`
+4. Check node affinity/taints
+
+## Network Issues
+
+### Cilium
+
+```sh
+cilium status
+cilium connectivity test
+```
+
+### DNS
+
+```sh
+# Test cluster DNS
+kubectl run -it --rm debug --image=busybox -- nslookup kubernetes.default
+
+# Test external DNS resolution
+dig @<k8s-gateway-ip> <app>.<domain>
+```
+
+## Storage Issues
+
+### NFS Unavailable
+
+If NFS is down, pods using NFS volumes will crash-loop. The NFS-scaler component handles this automatically for apps that include it.
+
+Check NFS availability:
+
+```sh
+kubectl -n observability get prometheusrule -l app=blackbox-exporter
+```
+
+### PVC Issues
+
+```sh
+kubectl get pvc -A
+kubectl describe pvc <name> -n <namespace>
+```
+
+## Reset Cluster
+
+!!! danger
+    This destroys everything. Use as last resort.
+
+```sh
+task talos:reset
+```
+
+After reset, re-bootstrap:
+
+```sh
+task bootstrap:talos
+task bootstrap:apps
+```

--- a/docs/operations/vm-management.md
+++ b/docs/operations/vm-management.md
@@ -1,0 +1,136 @@
+# VM Management
+
+## Overview
+
+Virtual machines are managed by [KubeVirt](https://kubevirt.io/) 1.7.0 with VM definitions stored in Git at `kubernetes/apps/kubevirt/virtualmachines/`.
+
+## CLI Operations
+
+### Using virtctl
+
+```sh
+# Access VM console
+virtctl console <vm-name>
+
+# SSH into VM
+virtctl ssh <vm-name>
+
+# Start/stop
+virtctl start <vm-name>
+virtctl stop <vm-name>
+
+# Restart
+virtctl restart <vm-name>
+
+# Live migrate to another node
+virtctl migrate <vm-name>
+
+# Pause/unpause
+virtctl pause vm <vm-name>
+virtctl unpause vm <vm-name>
+```
+
+### Using Task Runner
+
+```sh
+task vm:console VM=<name>
+task vm:start VM=<name>
+task vm:stop VM=<name>
+```
+
+## Web UI
+
+KubeVirt Manager is available at `kubevirt.00o.sh` with Kanidm SSO authentication.
+
+## Creating a New VM
+
+### 1. Create the Manifest
+
+Create a directory under `kubernetes/apps/kubevirt/virtualmachines/<vm-name>/`:
+
+```yaml
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: my-vm
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        cpu:
+          cores: 2
+        memory:
+          guest: 2Gi
+        devices:
+          disks:
+            - name: rootdisk
+              disk:
+                bus: virtio
+          interfaces:
+            - name: default
+              macvtap: {}
+              macAddress: "XX:XX:XX:XX:XX:XX"
+      networks:
+        - name: default
+          multus:
+            networkName: macvtap-net
+      volumes:
+        - name: rootdisk
+          persistentVolumeClaim:
+            claimName: my-vm-disk
+```
+
+### 2. Create Storage
+
+Use CDI DataVolume to import a disk image:
+
+```yaml
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: my-vm-disk
+spec:
+  source:
+    http:
+      url: "https://cloud-images.ubuntu.com/..."
+  storage:
+    accessModes:
+      - ReadWriteMany
+    storageClassName: nfs-fast
+    resources:
+      requests:
+        storage: 50Gi
+```
+
+### 3. Configure Networking
+
+Each VM gets a macvtap interface with a dedicated MAC address for direct L2 network access. Add an external-dns annotation for DNS.
+
+### 4. Add to Kustomization
+
+Reference the new VM in `kubernetes/apps/kubevirt/virtualmachines/kustomization.yaml`.
+
+## Live Migration
+
+VMs using NFS storage (`nfs-fast`) support live migration:
+
+```sh
+virtctl migrate <vm-name>
+```
+
+Requirements:
+
+- ReadWriteMany storage (NFS)
+- LiveMigration feature gate enabled (default)
+- Sufficient resources on target node
+
+## FreePBX VMs
+
+Three FreePBX telephony instances are deployed:
+
+- `freepbx-b1-k3s01`
+- `freepbx-b2-k3s01`
+- `freepbx-b3-k3s01`
+
+Each has dedicated SOPS-encrypted secrets.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -1,0 +1,7 @@
+# Research
+
+Technical research and analysis documents for cluster design decisions.
+
+## Documents
+
+- [SSO Providers](sso-providers.md) -- Comparison of identity providers for the Kubernetes homelab (Authelia, Authentik, Keycloak, Zitadel, Kanidm)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,114 @@
+---
+site_name: Special Winner
+site_description: Kubernetes homelab cluster documentation
+site_url: https://docs.00o.sh
+repo_name: 00o-sh/special-winner
+repo_url: https://github.com/00o-sh/special-winner
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue grey
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue grey
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.copy
+    - content.code.annotate
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - navigation.indexes
+    - search.suggest
+    - search.highlight
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+
+plugins:
+  - search
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/00o-sh/special-winner
+
+nav:
+  - Home:
+      - index.md
+      - Architecture: architecture.md
+  - Getting Started:
+      - getting-started/index.md
+      - Prerequisites: getting-started/prerequisites.md
+      - Configuration: getting-started/configuration.md
+      - Bootstrap: getting-started/bootstrap.md
+      - Post-Install: getting-started/post-install.md
+  - Infrastructure:
+      - infrastructure/index.md
+      - Talos Linux: infrastructure/talos.md
+      - Flux CD: infrastructure/flux.md
+      - Cilium Networking: infrastructure/cilium.md
+      - Envoy Gateway: infrastructure/envoy-gateway.md
+      - Storage: infrastructure/storage.md
+      - Databases: infrastructure/databases.md
+      - Certificates & DNS: infrastructure/certificates-dns.md
+      - Secrets Management: infrastructure/secrets.md
+      - Identity & SSO: infrastructure/identity.md
+  - Applications:
+      - applications/index.md
+      - Media Stack: applications/media.md
+      - Virtualization: applications/virtualization.md
+      - Observability: applications/observability.md
+      - Utilities: applications/utilities.md
+  - Operations:
+      - operations/index.md
+      - Day-2 Operations: operations/day2.md
+      - Backup & Recovery: operations/backup-recovery.md
+      - VM Management: operations/vm-management.md
+      - Troubleshooting: operations/troubleshooting.md
+  - Development:
+      - development/index.md
+      - Template System: development/templates.md
+      - CI/CD Pipelines: development/ci-cd.md
+      - Contributing: development/contributing.md
+  - Research:
+      - research/index.md
+      - SSO Providers: research/sso-providers.md


### PR DESCRIPTION
Add new namespaces (identity, forgejo-runner-system), applications
(Kanidm, Forgejo, Homepage, DBGate, kGuardian, OpenCost, macvtap-cni,
unifi-toolkit), FreePBX VMs, and VM taskfile. Update versions (Talos
1.12.4, Helm 4.1.1), fix PostgreSQL instance count (2→3), add
label-generate workflow, and expand AI guidelines with SSO, Homepage,
Volsync, monitoring, Discord alerts, and NFS-scaler requirements.

https://claude.ai/code/session_012GS3A9n1jcne4xka5scxq7