### PR TITLE
Update AWS region configuration from eu-west-1 to USTX01

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/bucket-init/bucket-init.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/bucket-init/bucket-init.yaml
@@ -24,7 +24,7 @@ spec:
                   name: cloudnative-pg-secret
                   key: AWS_SECRET_ACCESS_KEY
             - name: AWS_DEFAULT_REGION
-              value: eu-west-1
+              value: USTX01
           command:
             - /bin/sh
             - -c

--- a/kubernetes/apps/database/cloudnative-pg/cluster/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/externalsecret.yaml
@@ -17,6 +17,7 @@ spec:
         password: "{{ .POSTGRES_SUPER_PASS }}"
         AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
         AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+        AWS_REGION: eu-west-1
   dataFrom:
     - extract:
         key: cloudnative-pg

--- a/kubernetes/apps/database/cloudnative-pg/cluster/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/externalsecret.yaml
@@ -17,7 +17,7 @@ spec:
         password: "{{ .POSTGRES_SUPER_PASS }}"
         AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
         AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
-        AWS_REGION: eu-west-1
+        AWS_REGION: USTX01
   dataFrom:
     - extract:
         key: cloudnative-pg

--- a/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
@@ -14,6 +14,9 @@ spec:
       secretAccessKey:
         name: cloudnative-pg-secret
         key: AWS_SECRET_ACCESS_KEY
+      region:
+        name: cloudnative-pg-secret
+        key: AWS_REGION
     wal:
       compression: bzip2
       maxParallel: 2

--- a/kubernetes/apps/identity/kanidm/instance/cronjob.yaml
+++ b/kubernetes/apps/identity/kanidm/instance/cronjob.yaml
@@ -53,7 +53,7 @@ spec:
                       name: kanidm-s3-secret
                       key: AWS_SECRET_ACCESS_KEY
                 - name: AWS_DEFAULT_REGION
-                  value: eu-west-1
+                  value: USTX01
               resources:
                 requests:
                   cpu: 1m

--- a/kubernetes/apps/volsync-system/garage/app/resources/configuration.toml
+++ b/kubernetes/apps/volsync-system/garage/app/resources/configuration.toml
@@ -10,7 +10,7 @@ rpc_bind_addr = "[::]:3901"
 rpc_public_addr = "127.0.0.1:3901"
 
 [s3_api]
-s3_region = "eu-west-1"
+s3_region = "USTX01"
 api_bind_addr = "[::]:3900"
 root_domain = ".garage-s3.00o.sh"
 


### PR DESCRIPTION
## Summary
This PR updates the AWS region configuration across multiple Kubernetes applications and services from `eu-west-1` to `USTX01`, reflecting a change in the primary S3-compatible storage region.

## Key Changes
- **CloudNative-PG**: Added explicit AWS region configuration to the object store settings via secret reference, and updated the region value in the external secret to `USTX01`
- **Bucket Init Job**: Updated the `AWS_DEFAULT_REGION` environment variable from `eu-west-1` to `USTX01`
- **Kanidm CronJob**: Updated the `AWS_DEFAULT_REGION` environment variable from `eu-west-1` to `USTX01`
- **Garage Configuration**: Updated the S3 API region setting from `eu-west-1` to `USTX01`

## Implementation Details
- The CloudNative-PG cluster now references the AWS region from the `cloudnative-pg-secret` secret (key: `AWS_REGION`), providing centralized credential management
- All environment variable references to `AWS_DEFAULT_REGION` have been consistently updated to the new region value
- The changes maintain the existing secret reference pattern while updating the actual region identifier

https://claude.ai/code/session_01WH5th7KQKtLT5iGCazvY3t