### PR TITLE
fix(kubernetes): remove postBuild substituteFrom to fix envsubst chic…

### DIFF
--- a/kubernetes/apps/forgejo-runner-system/forgejo-runner/app/scaledjob.yaml
+++ b/kubernetes/apps/forgejo-runner-system/forgejo-runner/app/scaledjob.yaml
@@ -80,7 +80,6 @@ spec:
     - type: forgejo-runner
       metadata:
         name: "forgejo-runner"
-        address: "${FORGEJO_INSTANCE_URL}"
         global: "true"
         labels: "ubuntu-latest"
       authenticationRef:

--- a/kubernetes/apps/forgejo-runner-system/forgejo-runner/app/triggerauthentication.yaml
+++ b/kubernetes/apps/forgejo-runner-system/forgejo-runner/app/triggerauthentication.yaml
@@ -9,3 +9,6 @@ spec:
     - parameter: token
       name: forgejo-runner-secret
       key: API_TOKEN
+    - parameter: address
+      name: forgejo-runner-secret
+      key: FORGEJO_INSTANCE_URL

--- a/kubernetes/apps/forgejo-runner-system/forgejo-runner/ks.yaml
+++ b/kubernetes/apps/forgejo-runner-system/forgejo-runner/ks.yaml
@@ -12,11 +12,6 @@ spec:
       namespace: observability
   interval: 1h
   path: ./kubernetes/apps/forgejo-runner-system/forgejo-runner/app
-  postBuild:
-    substituteFrom:
-      - kind: Secret
-        name: forgejo-runner-secret
-        optional: true
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
…ken-and-egg

Using `forgejo-runner-secret` in `postBuild.substituteFrom` causes Flux to load all secret keys as env vars for envsubst. The hyphenated key `api-token` is invalid, and even after renaming, the existing cluster secret blocks reconciliation (chicken-and-egg).

Fix by moving the KEDA trigger `address` from envsubst substitution into the TriggerAuthentication (sourced directly from the secret), and removing `postBuild` entirely since no Flux envsubst is needed.

https://claude.ai/code/session_01DCAvMJ3ZPcFxbR3kb5iKRe