### PR TITLE
Add n8n workflow automation platform to utils namespace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -716,6 +716,7 @@ talosctl logs --nodes <ip> --insecure
 **utils**: Utility services
 - forgejo (self-hosted Git repository service)
 - homepage (cluster dashboard)
+- n8n (workflow automation platform)
 - penpot (open-source design and prototyping platform)
 - smtp-relay (SMTP relay for outbound email using Maddy)
 
@@ -759,6 +760,7 @@ Check `.mise.toml` for exact versions of all tools.
 
 ## Recent Notable Changes
 
+- **2026-02-16**: Added n8n workflow automation platform to utils namespace (PostgreSQL backend, ExternalSecrets)
 - **2026-02-14**: Added Kanidm identity provider with OAuth2 SSO for dbgate, forgejo, kubevirt-manager, opencost, penpot
 - **2026-02-14**: Added Forgejo self-hosted Git service and Forgejo runner system
 - **2026-02-14**: Added Homepage cluster dashboard to utils namespace

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 - [GitHub Actions Runner Controller](https://github.com/actions/actions-runner-controller) - Self-hosted GitHub Actions runners
 - [Forgejo](https://forgejo.org/) - Self-hosted Git repository service with CI/CD runners
 - [SMTP Relay](https://github.com/foxcpp/maddy) - Outbound email relay using Maddy
+- [n8n](https://n8n.io/) - Workflow automation platform
 - [Penpot](https://penpot.app/) - Open-source design and prototyping platform
 - [Homepage](https://gethomepage.dev/) - Cluster dashboard for all services
 

--- a/docs/applications/index.md
+++ b/docs/applications/index.md
@@ -28,6 +28,7 @@ All applications are deployed via Flux CD from manifests in `kubernetes/apps/`.
 |-----|-------------|-----------|
 | [Forgejo](https://forgejo.org/) | Self-hosted Git | utils |
 | [Homepage](https://gethomepage.dev/) | Cluster dashboard | utils |
+| [n8n](https://n8n.io/) | Workflow automation | utils |
 | [Penpot](https://penpot.app/) | Design platform | utils |
 | [SMTP Relay](https://github.com/foxcpp/maddy) | Email relay (Maddy) | utils |
 | [DBGate](https://dbgate.org/) | Database web UI | database |

--- a/docs/applications/utilities.md
+++ b/docs/applications/utilities.md
@@ -20,6 +20,20 @@
 !!! note
     When adding new applications, always add them to the Homepage configuration.
 
+## n8n
+
+[n8n](https://n8n.io/) is a workflow automation platform:
+
+- Located in `kubernetes/apps/utils/n8n/`
+- PostgreSQL database via CloudNative-PG
+- Exposed at `n8n.00o.sh`
+- Automatic execution data pruning (168 hours / 50k max)
+
+### Dependencies
+
+- CloudNative-PG postgres-cluster
+- 1Password for secrets (encryption key, database credentials)
+
 ## Penpot
 
 [Penpot](https://penpot.app/) is an open-source design and prototyping platform:

--- a/kubernetes/apps/utils/kustomization.yaml
+++ b/kubernetes/apps/utils/kustomization.yaml
@@ -11,5 +11,6 @@ resources:
   - ./namespace.yaml
   - ./forgejo/ks.yaml
   - ./homepage/ks.yaml
+  - ./n8n/ks.yaml
   - ./penpot/ks.yaml
   - ./smtp-relay/ks.yaml

--- a/kubernetes/apps/utils/n8n/app/externalsecret.yaml
+++ b/kubernetes/apps/utils/n8n/app/externalsecret.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: n8n
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: n8n-secret
+    template:
+      engineVersion: v2
+      data:
+        INIT_POSTGRES_DBNAME: "{{ .N8N_POSTGRES_DB }}"
+        INIT_POSTGRES_HOST: postgres-rw.database.svc.cluster.local
+        INIT_POSTGRES_PORT: "5432"
+        INIT_POSTGRES_USER: "{{ .N8N_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .N8N_POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        N8N_ENCRYPTION_KEY: "{{ .N8N_ENCRYPTION_KEY }}"
+  dataFrom:
+    - extract:
+        key: n8n
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/utils/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/n8n/app/helmrelease.yaml
@@ -1,0 +1,134 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: n8n
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: n8n
+  interval: 1h
+  values:
+    controllers:
+      n8n:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18@sha256:ae89578925b480f5972f237dda2f7a37efe36aff500d3e7bd1d3a6a3181e4191
+            envFrom:
+              - secretRef:
+                  name: n8n-secret
+        containers:
+          app:
+            image:
+              repository: docker.n8n.io/n8nio/n8n
+              tag: 2.8.2
+            env:
+              GENERIC_TIMEZONE: America/New_York
+              N8N_HOST: n8n.00o.sh
+              N8N_PROTOCOL: https
+              N8N_PORT: &port 5678
+              N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS: "false"
+              DB_TYPE: postgresdb
+              DB_POSTGRESDB_HOST: postgres-rw.database.svc.cluster.local
+              DB_POSTGRESDB_PORT: "5432"
+              DB_POSTGRESDB_DATABASE:
+                valueFrom:
+                  secretKeyRef:
+                    name: n8n-secret
+                    key: INIT_POSTGRES_DBNAME
+              DB_POSTGRESDB_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: n8n-secret
+                    key: INIT_POSTGRES_USER
+              DB_POSTGRESDB_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: n8n-secret
+                    key: INIT_POSTGRES_PASS
+              N8N_ENCRYPTION_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: n8n-secret
+                    key: N8N_ENCRYPTION_KEY
+              N8N_LOG_LEVEL: info
+              N8N_LOG_OUTPUT: console
+              EXECUTIONS_DATA_PRUNE: "true"
+              EXECUTIONS_DATA_MAX_AGE: "168"
+              EXECUTIONS_DATA_PRUNE_MAX_COUNT: "50000"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: *port
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 5
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    service:
+      app:
+        controller: n8n
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Utilities
+          gethomepage.dev/name: n8n
+          gethomepage.dev/icon: n8n.png
+          gethomepage.dev/description: Workflow Automation
+          gethomepage.dev/href: "https://n8n.00o.sh"
+        hostnames:
+          - n8n.00o.sh
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+
+    persistence:
+      data:
+        type: emptyDir
+        advancedMounts:
+          n8n:
+            app:
+              - path: /home/node/.n8n
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          n8n:
+            app:
+              - path: /tmp

--- a/kubernetes/apps/utils/n8n/app/kustomization.yaml
+++ b/kubernetes/apps/utils/n8n/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/utils/n8n/app/ocirepository.yaml
+++ b/kubernetes/apps/utils/n8n/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: n8n
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/utils/n8n/ks.yaml
+++ b/kubernetes/apps/utils/n8n/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app n8n
+  namespace: flux-system
+spec:
+  targetNamespace: utils
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: postgres-cluster
+      namespace: database
+    - name: onepassword
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/utils/n8n/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## Summary
This PR adds n8n, an open-source workflow automation platform, to the cluster's utils namespace. The deployment includes all necessary Kubernetes manifests for running n8n with PostgreSQL backend integration and secure credential management.

## Key Changes
- **HelmRelease configuration** (`helmrelease.yaml`): Deploys n8n 2.8.2 using the bjw-s app-template Helm chart with:
  - PostgreSQL database backend integration
  - Health checks (liveness and readiness probes)
  - Security hardening (non-root user, read-only filesystem, dropped capabilities)
  - Resource limits (256Mi request, 1Gi limit)
  - Execution data pruning configured for automatic cleanup
  - Ingress routing via Envoy with external hostname `n8n.00o.sh`

- **External Secrets integration** (`externalsecret.yaml`): Retrieves n8n credentials from 1Password including:
  - PostgreSQL connection details
  - n8n encryption key
  - Database initialization parameters

- **OCIRepository configuration** (`ocirepository.yaml`): References the bjw-s app-template Helm chart (v4.6.2) from GHCR

- **Kustomization manifests**: 
  - `ks.yaml`: Flux Kustomization with dependencies on postgres-cluster and onepassword
  - `kustomization.yaml`: Local resource aggregation

- **Documentation**: Updated CLAUDE.md to list n8n in the utils services section

## Notable Implementation Details
- Uses init container for PostgreSQL database initialization
- Configured with timezone (America/New_York) and HTTPS protocol
- Implements pod security context with fsGroup for proper file permissions
- Ephemeral storage for `/home/node/.n8n` and `/tmp` directories
- Integrated with Homepage dashboard for cluster visibility
- Auto-reload annotations for configuration changes via Stakater Reloader

https://claude.ai/code/session_01Ucb6S9jkX42x6NeoDuCGeN