### PR TITLE
Add error-pages service to Envoy Gateway

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -688,7 +688,7 @@ talosctl logs --nodes <ip> --insecure
 **network**: Network infrastructure
 - cloudflare-dns
 - cloudflare-tunnel (external access)
-- envoy-gateway (ingress)
+- envoy-gateway (ingress, with error-pages for custom error responses)
 - k8s-gateway (internal DNS)
 - macvtap-cni (macvtap CNI plugin for direct VM network access)
 - multus (multi-network CNI)
@@ -759,6 +759,7 @@ Check `.mise.toml` for exact versions of all tools.
 
 ## Recent Notable Changes
 
+- **2026-02-16**: Added error-pages service for Envoy Gateway with responseOverride redirects (403, 404, 500, 502, 503, 504)
 - **2026-02-14**: Added Kanidm identity provider with OAuth2 SSO for dbgate, forgejo, kubevirt-manager, opencost, penpot
 - **2026-02-14**: Added Forgejo self-hosted Git service and Forgejo runner system
 - **2026-02-14**: Added Homepage cluster dashboard to utils namespace
@@ -1082,5 +1083,5 @@ Located in `kubernetes/apps/utils/homepage/`, Homepage provides a unified dashbo
 
 ---
 
-**Last Updated**: 2026-02-14
+**Last Updated**: 2026-02-16
 **Template Source**: [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 - [Cilium](https://github.com/cilium/cilium) 1.19.0 - eBPF-based CNI
 - [CoreDNS](https://coredns.io/) - Cluster DNS
 - [Envoy Gateway](https://github.com/envoyproxy/gateway) - HTTP routing and ingress
+- [Error Pages](https://github.com/tarampampam/error-pages) - Custom error pages for Envoy Gateway
 - [k8s_gateway](https://github.com/ori-edge/k8s_gateway) - Internal DNS for cluster services
 - [Cloudflare Tunnel](https://github.com/cloudflare/cloudflared) - Secure external access
 - [Multus CNI](https://github.com/k8snetworkplumbingwg/multus-cni) - Multi-network support
@@ -667,7 +668,7 @@ If this repo is too hot to handle or too cold to hold check out these following 
 | **Template Source** | [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template) |
 | **Infrastructure** | GitOps with Flux CD + Talos Linux |
 | **Documentation** | [docs.00o.sh](https://docs.00o.sh) |
-| **Last Updated** | 2026-02-15 |
+| **Last Updated** | 2026-02-16 |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,7 +130,7 @@ kubernetes/apps/<namespace>/<app-name>/
 | `kube-system` | Core services | Cilium, CoreDNS, Spegel, kGuardian |
 | `kubevirt` | Virtualization | KubeVirt, CDI, VMs |
 | `media` | Media apps | Plex, *arr stack, qBittorrent |
-| `network` | Network infra | Envoy Gateway, Cloudflare, Multus |
+| `network` | Network infra | Envoy Gateway, Error Pages, Cloudflare, Multus |
 | `observability` | Monitoring | Prometheus, Grafana, Victoria Logs |
 | `openebs-system` | Block storage | OpenEBS |
 | `system-upgrade` | Upgrades | Tuppr |
@@ -140,7 +140,7 @@ kubernetes/apps/<namespace>/<app-name>/
 ## Network Architecture
 
 - **Cilium** provides eBPF-based CNI with advanced network policies
-- **Envoy Gateway** handles HTTP routing with internal and external gateways
+- **Envoy Gateway** handles HTTP routing with internal and external gateways, with custom error pages via responseOverride redirects
 - **Cloudflare Tunnel** provides secure external access without port forwarding
 - **Multus + Macvtap** gives VMs direct network access with dedicated MAC addresses
 - **k8s_gateway** provides split-horizon DNS for internal service resolution

--- a/docs/infrastructure/envoy-gateway.md
+++ b/docs/infrastructure/envoy-gateway.md
@@ -12,14 +12,20 @@ Envoy Gateway deploys Envoy Proxy instances that handle incoming traffic:
 ## Configuration
 
 ```
-kubernetes/apps/network/envoy-gateway/app/
-├── helmrelease.yaml      # Envoy Gateway operator
-├── ocirepository.yaml    # Chart source
-├── certificate.yaml      # TLS wildcard certificate
-├── envoy.yaml            # Gateway configuration
-├── grafanadashboard.yaml # Monitoring dashboard
-├── podmonitor.yaml       # Prometheus metrics
-└── kustomization.yaml
+kubernetes/apps/network/envoy-gateway/
+├── app/
+│   ├── helmrelease.yaml      # Envoy Gateway operator
+│   ├── ocirepository.yaml    # Chart source
+│   ├── certificate.yaml      # TLS wildcard certificate
+│   ├── envoy.yaml            # Gateway config, policies, responseOverride
+│   ├── grafanadashboard.yaml # Monitoring dashboard
+│   ├── podmonitor.yaml       # Prometheus metrics
+│   └── kustomization.yaml
+├── error-pages/
+│   ├── helmrelease.yaml      # Error pages service (app-template)
+│   ├── ocirepository.yaml    # Chart source
+│   └── kustomization.yaml
+└── ks.yaml                   # Flux Kustomizations (gateway + error-pages)
 ```
 
 ## Exposing Applications
@@ -83,6 +89,33 @@ spec:
     clientSecret:
       name: "<secret-name>"
 ```
+
+## Custom Error Pages
+
+[Error Pages](https://github.com/tarampampam/error-pages) provides styled error responses for all routes behind both gateways. When a backend returns an error, the `BackendTrafficPolicy` `responseOverride` redirects the client to the error-pages service.
+
+**Handled status codes:** 403, 404, 500, 502, 503, 504
+
+The `responseOverride` in the `BackendTrafficPolicy` (in `envoy.yaml`) uses redirect rules:
+
+```yaml
+responseOverride:
+  - match:
+      statusCodes:
+        - type: Value
+          value: 404
+    redirect:
+      scheme: https
+      hostname: error.example.com
+      path:
+        type: ReplaceFullPath
+        replaceFullPath: /404.html
+      statusCode: 302
+```
+
+This applies globally to all routes behind `envoy-internal` and `envoy-external` since the policy targets all Gateways via `targetSelectors`.
+
+**Template:** The error-pages service uses the "connection" template with `SHOW_DETAILS=false`.
 
 ## Monitoring
 

--- a/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/app/envoy.yaml
@@ -111,6 +111,63 @@ spec:
     - type: Gzip
   connection:
     bufferLimit: 8Mi
+  responseOverride:
+    - match:
+        statusCodes:
+          - type: Value
+            value: 403
+      redirect: &redirect
+        scheme: https
+        hostname: error.${SECRET_DOMAIN}
+        path:
+          type: &pathType ReplaceFullPath
+          replaceFullPath: /403.html
+        statusCode: 302
+    - match:
+        statusCodes:
+          - type: Value
+            value: 404
+      redirect:
+        <<: *redirect
+        path:
+          type: *pathType
+          replaceFullPath: /404.html
+    - match:
+        statusCodes:
+          - type: Value
+            value: 500
+      redirect:
+        <<: *redirect
+        path:
+          type: *pathType
+          replaceFullPath: /500.html
+    - match:
+        statusCodes:
+          - type: Value
+            value: 502
+      redirect:
+        <<: *redirect
+        path:
+          type: *pathType
+          replaceFullPath: /502.html
+    - match:
+        statusCodes:
+          - type: Value
+            value: 503
+      redirect:
+        <<: *redirect
+        path:
+          type: *pathType
+          replaceFullPath: /503.html
+    - match:
+        statusCodes:
+          - type: Value
+            value: 504
+      redirect:
+        <<: *redirect
+        path:
+          type: *pathType
+          replaceFullPath: /504.html
   targetSelectors:
     - group: gateway.networking.k8s.io
       kind: Gateway

--- a/kubernetes/apps/network/envoy-gateway/error-pages/helmrelease.yaml
+++ b/kubernetes/apps/network/envoy-gateway/error-pages/helmrelease.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: error-pages
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: error-pages
+  interval: 1h
+  values:
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+
+    controllers:
+      error-pages:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/tarampampam/error-pages
+              tag: 3.8.0@sha256:6fda7ff61de68b3b188538221f718d834fd9aa6ddaf0c13044febc6100515fd1
+            env:
+              TEMPLATE_NAME: connection
+              SHOW_DETAILS: "false"
+              LISTEN_PORT: &port 8080
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+            resources:
+              requests:
+                cpu: 5m
+                memory: 16M
+              limits:
+                memory: 32M
+            securityContext:
+              readOnlyRootFilesystem: true
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+
+    service:
+      app:
+        controller: error-pages
+        ports:
+          http:
+            port: *port
+
+    route:
+      internal: &route
+        hostnames:
+          - error.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+      external:
+        <<: *route
+        parentRefs:
+          - name: envoy-external
+            namespace: network

--- a/kubernetes/apps/network/envoy-gateway/error-pages/kustomization.yaml
+++ b/kubernetes/apps/network/envoy-gateway/error-pages/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/network/envoy-gateway/error-pages/ocirepository.yaml
+++ b/kubernetes/apps/network/envoy-gateway/error-pages/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: error-pages
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/network/envoy-gateway/ks.yaml
+++ b/kubernetes/apps/network/envoy-gateway/ks.yaml
@@ -17,3 +17,24 @@ spec:
     namespace: flux-system
   targetNamespace: network
   wait: false
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: envoy-gateway-error-pages
+spec:
+  dependsOn:
+    - name: envoy-gateway
+  interval: 1h
+  path: ./kubernetes/apps/network/envoy-gateway/error-pages
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: network
+  wait: false


### PR DESCRIPTION
## Summary
This PR adds a new error-pages service to the Envoy Gateway deployment, providing custom error page handling for both internal and external traffic.

## Key Changes
- **New error-pages HelmRelease**: Deployed using the app-template Helm chart with the `tarampampam/error-pages` container image (v3.8.0)
- **OCIRepository configuration**: Added source reference for the app-template Helm chart (v4.6.2) from bjw-s-labs
- **Kustomization setup**: Created new Kustomization resource for error-pages with proper dependency ordering (depends on envoy-gateway)
- **Dual routing**: Configured HTTPRoutes for both internal and external Envoy Gateway instances, accessible at `error.${SECRET_DOMAIN}`
- **Security hardening**: Applied pod security context (non-root user 1000, read-only filesystem, dropped all capabilities)
- **Resource constraints**: Set minimal resource requests (5m CPU, 16M memory) with 32M memory limit

## Notable Implementation Details
- Uses the "connection" error template with details disabled
- Listens on port 8080 with liveness, readiness, and startup probes enabled
- Shares route configuration between internal and external gateways using YAML anchors
- Integrated into the existing Envoy Gateway namespace with proper Flux dependency management

https://claude.ai/code/session_01T6twDgb12ZLvJkJ17Zrhyj