### PR TITLE
fix(utils): add missing cache emptyDir for n8n readOnlyRootFilesystem

### DIFF
--- a/kubernetes/apps/utils/n8n/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/n8n/app/helmrelease.yaml
@@ -120,6 +120,12 @@ spec:
                 port: *port
 
     persistence:
+      cache:
+        type: emptyDir
+        advancedMounts:
+          n8n:
+            app:
+              - path: /home/node/.cache
       data:
         type: emptyDir
         advancedMounts:


### PR DESCRIPTION
n8n crashes on startup trying to create /home/node/.cache which fails with readOnlyRootFilesystem: true. Add an emptyDir mount for the path.

https://claude.ai/code/session_01Ucb6S9jkX42x6NeoDuCGeN