### PR TITLE
Add GitHub Actions workflow to validate Renovate configuration

### DIFF
--- a/.github/workflows/renovate-config.yaml
+++ b/.github/workflows/renovate-config.yaml
@@ -1,0 +1,30 @@
+---
+# Validates Renovate configuration on pull requests.
+# Only triggers when .renovaterc.json5 or related config files are modified.
+name: "Renovate Config"
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - ".renovaterc.json5"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate Renovate Config
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version: 22
+
+      - name: Validate Renovate Config
+        run: npx --yes --package renovate -- renovate-config-validator --strict


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automatically validates the Renovate configuration file whenever it's modified in pull requests.

## Key Changes
- Added `.github/workflows/renovate-config.yaml` workflow file that:
  - Triggers on pull requests to `main` branch when `.renovaterc.json5` is modified
  - Uses concurrency controls to cancel in-progress runs for the same PR/ref
  - Checks out the repository code
  - Sets up Node.js 22 runtime environment
  - Runs `renovate-config-validator` in strict mode to validate the Renovate configuration

## Implementation Details
- The workflow uses pinned action versions for reproducibility and security
- Path filtering ensures the workflow only runs when Renovate configuration files are actually changed, reducing unnecessary CI runs
- The `--strict` flag ensures strict validation of the Renovate configuration to catch potential issues early

https://claude.ai/code/session_016e432SjBs2uSnsMJbcPvCL