### PR TITLE
Enable Docker image digest pinning in Renovate config

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -3,6 +3,7 @@
   extends: [
     "config:recommended",
     "docker:enableMajor",
+    "docker:pinDigests",
     "helpers:pinGitHubActionDigests",
     ":automergeBranch",
     ":dependencyDashboard",


### PR DESCRIPTION
## Summary
Updated the Renovate configuration to enable automatic pinning of Docker image digests alongside the existing major version update and GitHub Actions digest pinning features.

## Changes
- Added `"docker:pinDigests"` preset to the Renovate extends configuration

## Details
This change enhances the Renovate dependency management strategy by enabling digest pinning for Docker images. Combined with the existing `"docker:enableMajor"` preset, Renovate will now:
- Allow major version updates for Docker images
- Pin Docker images to their exact digest for improved reproducibility and security

This aligns with the existing practice of pinning GitHub Actions to their digests via the `"helpers:pinGitHubActionDigests"` preset, extending the same security and reproducibility benefits to Docker dependencies.

https://claude.ai/code/session_01LcHfuLs9XLcrAD4LRKFYGv