### PR TITLE
feat(identity): add Kanidm SSO to 13 remaining apps without auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,7 +652,7 @@ talosctl logs --nodes <ip> --insecure
 - forgejo-runner (Forgejo Actions runner with ScaledJob for on-demand scaling)
 
 **identity**: Identity and SSO
-- kanidm (identity provider with OAuth2 integrations for dbgate, forgejo, kubevirt-manager, opencost, penpot)
+- kanidm (identity provider with OAuth2 integrations for autobrr, bazarr, dbgate, forgejo, grafana, kopia, kubevirt-manager, n8n, opencost, penpot, prowlarr, qbittorrent, qui, radarr, sonarr, tautulli, thelounge, unifi-toolkit)
 
 **kube-system**: Core Kubernetes
 - cilium (CNI)
@@ -760,6 +760,7 @@ Check `.mise.toml` for exact versions of all tools.
 
 ## Recent Notable Changes
 
+- **2026-02-17**: Added Kanidm OAuth2 SSO to 13 additional apps: radarr, sonarr, prowlarr, bazarr, autobrr, tautulli, qbittorrent, qui, thelounge, n8n, kopia, unifi-toolkit, grafana
 - **2026-02-16**: Added error-pages service for Envoy Gateway with responseOverride redirects (403, 404, 500, 502, 503, 504)
 - **2026-02-16**: Added n8n workflow automation platform to utils namespace (PostgreSQL backend, ExternalSecrets)
 - **2026-02-14**: Added Kanidm identity provider with OAuth2 SSO for dbgate, forgejo, kubevirt-manager, opencost, penpot
@@ -1034,11 +1035,24 @@ Located in `kubernetes/apps/identity/kanidm/`, Kanidm provides centralized ident
 - Manages user accounts, groups, and authentication policies
 
 **OAuth2 Integrations**:
+- **Autobrr**: Torrent automation UI authentication
+- **Bazarr**: Subtitle management UI authentication
 - **DBGate**: Database management UI authentication
 - **Forgejo**: Git service authentication
+- **Grafana**: Metrics visualization authentication
+- **Kopia**: Backup repository UI authentication
 - **KubeVirt Manager**: VM management UI authentication
+- **n8n**: Workflow automation authentication
 - **OpenCost**: Cost analysis dashboard authentication
 - **Penpot**: Design platform authentication
+- **Prowlarr**: Indexer manager UI authentication
+- **qBittorrent**: Torrent client UI authentication
+- **Qui**: qBittorrent web UI authentication
+- **Radarr**: Movie management UI authentication
+- **Sonarr**: TV series management UI authentication
+- **Tautulli**: Plex monitoring UI authentication
+- **TheLounge**: IRC client UI authentication
+- **UniFi Toolkit**: Network management UI authentication
 
 **Important**: When adding new applications that have a web UI, always consider whether Kanidm SSO integration should be configured. Each OAuth2 client is defined in a separate YAML file under `kubernetes/apps/identity/kanidm/app/`.
 

--- a/kubernetes/apps/identity/kanidm/config/groups.yaml
+++ b/kubernetes/apps/identity/kanidm/config/groups.yaml
@@ -60,3 +60,133 @@ spec:
   members:
     - all-apps
     - herman
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: radarr-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: sonarr-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: prowlarr-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: bazarr-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: autobrr-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: tautulli-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: qbittorrent-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: qui-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: thelounge-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: n8n-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: kopia-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: unifi-toolkit-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: grafana-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - all-apps

--- a/kubernetes/apps/identity/kanidm/config/kustomization.yaml
+++ b/kubernetes/apps/identity/kanidm/config/kustomization.yaml
@@ -7,8 +7,21 @@ resources:
   - ./externalsecret-s3.yaml
   - ./persons.yaml
   - ./groups.yaml
+  - ./oauth2-autobrr.yaml
+  - ./oauth2-bazarr.yaml
   - ./oauth2-dbgate.yaml
   - ./oauth2-forgejo.yaml
+  - ./oauth2-grafana.yaml
+  - ./oauth2-kopia.yaml
   - ./oauth2-kubevirt-manager.yaml
+  - ./oauth2-n8n.yaml
   - ./oauth2-opencost.yaml
   - ./oauth2-penpot.yaml
+  - ./oauth2-prowlarr.yaml
+  - ./oauth2-qbittorrent.yaml
+  - ./oauth2-qui.yaml
+  - ./oauth2-radarr.yaml
+  - ./oauth2-sonarr.yaml
+  - ./oauth2-tautulli.yaml
+  - ./oauth2-thelounge.yaml
+  - ./oauth2-unifi-toolkit.yaml

--- a/kubernetes/apps/identity/kanidm/config/oauth2-autobrr.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-autobrr.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: autobrr
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: Autobrr
+  origin: "https://autobrr.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://autobrr.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: autobrr-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/oauth2-bazarr.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-bazarr.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: bazarr
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: Bazarr
+  origin: "https://bazarr.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://bazarr.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: bazarr-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/oauth2-grafana.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-grafana.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: grafana
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: Grafana
+  origin: "https://grafana.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://grafana.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: grafana-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/oauth2-kopia.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-kopia.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: kopia
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: Kopia
+  origin: "https://kopia.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://kopia.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: kopia-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/oauth2-n8n.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-n8n.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: n8n
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: n8n
+  origin: "https://n8n.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://n8n.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: n8n-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/oauth2-prowlarr.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-prowlarr.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: prowlarr
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: Prowlarr
+  origin: "https://prowlarr.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://prowlarr.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: prowlarr-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/oauth2-qbittorrent.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-qbittorrent.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: qbittorrent
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: qBittorrent
+  origin: "https://qbittorrent.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://qbittorrent.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: qbittorrent-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/oauth2-qui.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-qui.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: qui
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: Qui
+  origin: "https://qui.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://qui.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: qui-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/oauth2-radarr.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-radarr.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: radarr
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: Radarr
+  origin: "https://radarr.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://radarr.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: radarr-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/oauth2-sonarr.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-sonarr.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: sonarr
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: Sonarr
+  origin: "https://sonarr.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://sonarr.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: sonarr-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/oauth2-tautulli.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-tautulli.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: tautulli
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: Tautulli
+  origin: "https://tautulli.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://tautulli.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: tautulli-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/oauth2-thelounge.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-thelounge.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: thelounge
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: TheLounge
+  origin: "https://thelounge.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://thelounge.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: thelounge-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/identity/kanidm/config/oauth2-unifi-toolkit.yaml
+++ b/kubernetes/apps/identity/kanidm/config/oauth2-unifi-toolkit.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: unifi-toolkit
+spec:
+  kanidmRef:
+    name: kanidm
+  displayname: UniFi Toolkit
+  origin: "https://unifi-toolkit.00o.sh"
+  allowInsecureClientDisablePkce: true
+  redirectUrl:
+    - "https://unifi-toolkit.00o.sh/oauth2/callback"
+  scopeMap:
+    - group: unifi-toolkit-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/media/autobrr/app/externalsecret-oidc.yaml
+++ b/kubernetes/apps/media/autobrr/app/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: autobrr-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: autobrr-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: autobrr-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/media/autobrr/app/kustomization.yaml
+++ b/kubernetes/apps/media/autobrr/app/kustomization.yaml
@@ -4,6 +4,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-oidc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./prometheusrule.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/media/autobrr/app/securitypolicy.yaml
+++ b/kubernetes/apps/media/autobrr/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: autobrr-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: autobrr
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/autobrr"
+    clientID: "autobrr"
+    clientSecret:
+      name: autobrr-oidc-secret
+    redirectURL: "https://autobrr.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/media/bazarr/app/externalsecret-oidc.yaml
+++ b/kubernetes/apps/media/bazarr/app/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: bazarr-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: bazarr-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: bazarr-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/media/bazarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/bazarr/app/kustomization.yaml
@@ -3,5 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret-oidc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/media/bazarr/app/securitypolicy.yaml
+++ b/kubernetes/apps/media/bazarr/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: bazarr-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: bazarr
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/bazarr"
+    clientID: "bazarr"
+    clientSecret:
+      name: bazarr-oidc-secret
+    redirectURL: "https://bazarr.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/media/prowlarr/app/externalsecret-oidc.yaml
+++ b/kubernetes/apps/media/prowlarr/app/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: prowlarr-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: prowlarr-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: prowlarr-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/media/prowlarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/prowlarr/app/kustomization.yaml
@@ -4,5 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-oidc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/media/prowlarr/app/securitypolicy.yaml
+++ b/kubernetes/apps/media/prowlarr/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: prowlarr-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: prowlarr
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/prowlarr"
+    clientID: "prowlarr"
+    clientSecret:
+      name: prowlarr-oidc-secret
+    redirectURL: "https://prowlarr.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/media/qbittorrent/app/externalsecret-oidc.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: qbittorrent-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: qbittorrent-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: qbittorrent-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/media/qbittorrent/app/kustomization.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/kustomization.yaml
@@ -3,5 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret-oidc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/media/qbittorrent/app/securitypolicy.yaml
+++ b/kubernetes/apps/media/qbittorrent/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: qbittorrent-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: qbittorrent
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/qbittorrent"
+    clientID: "qbittorrent"
+    clientSecret:
+      name: qbittorrent-oidc-secret
+    redirectURL: "https://qbittorrent.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/media/qui/app/externalsecret-oidc.yaml
+++ b/kubernetes/apps/media/qui/app/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: qui-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: qui-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: qui-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/media/qui/app/kustomization.yaml
+++ b/kubernetes/apps/media/qui/app/kustomization.yaml
@@ -4,5 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-oidc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/media/qui/app/securitypolicy.yaml
+++ b/kubernetes/apps/media/qui/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: qui-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: qui
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/qui"
+    clientID: "qui"
+    clientSecret:
+      name: qui-oidc-secret
+    redirectURL: "https://qui.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/media/radarr/app/externalsecret-oidc.yaml
+++ b/kubernetes/apps/media/radarr/app/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: radarr-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: radarr-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: radarr-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/media/radarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/radarr/app/kustomization.yaml
@@ -4,5 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-oidc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/media/radarr/app/securitypolicy.yaml
+++ b/kubernetes/apps/media/radarr/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: radarr-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: radarr
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/radarr"
+    clientID: "radarr"
+    clientSecret:
+      name: radarr-oidc-secret
+    redirectURL: "https://radarr.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/media/sonarr/app/externalsecret-oidc.yaml
+++ b/kubernetes/apps/media/sonarr/app/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: sonarr-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: sonarr-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: sonarr-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/media/sonarr/app/kustomization.yaml
+++ b/kubernetes/apps/media/sonarr/app/kustomization.yaml
@@ -4,8 +4,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-oidc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml
 configMapGenerator:
   - name: sonarr-configmap
     files:

--- a/kubernetes/apps/media/sonarr/app/securitypolicy.yaml
+++ b/kubernetes/apps/media/sonarr/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: sonarr-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: sonarr
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/sonarr"
+    clientID: "sonarr"
+    clientSecret:
+      name: sonarr-oidc-secret
+    redirectURL: "https://sonarr.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/media/tautulli/app/externalsecret-oidc.yaml
+++ b/kubernetes/apps/media/tautulli/app/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: tautulli-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: tautulli-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: tautulli-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/media/tautulli/app/kustomization.yaml
+++ b/kubernetes/apps/media/tautulli/app/kustomization.yaml
@@ -4,5 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-oidc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/media/tautulli/app/securitypolicy.yaml
+++ b/kubernetes/apps/media/tautulli/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: tautulli-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: tautulli
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/tautulli"
+    clientID: "tautulli"
+    clientSecret:
+      name: tautulli-oidc-secret
+    redirectURL: "https://tautulli.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/media/thelounge/app/externalsecret-oidc.yaml
+++ b/kubernetes/apps/media/thelounge/app/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: thelounge-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: thelounge-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: thelounge-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/media/thelounge/app/kustomization.yaml
+++ b/kubernetes/apps/media/thelounge/app/kustomization.yaml
@@ -3,5 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret-oidc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/media/thelounge/app/securitypolicy.yaml
+++ b/kubernetes/apps/media/thelounge/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: thelounge-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: thelounge
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/thelounge"
+    clientID: "thelounge"
+    clientSecret:
+      name: thelounge-oidc-secret
+    redirectURL: "https://thelounge.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/network/unifi-toolkit/app/externalsecret-oidc.yaml
+++ b/kubernetes/apps/network/unifi-toolkit/app/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: unifi-toolkit-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: unifi-toolkit-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: unifi-toolkit-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/network/unifi-toolkit/app/kustomization.yaml
+++ b/kubernetes/apps/network/unifi-toolkit/app/kustomization.yaml
@@ -4,5 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-oidc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/network/unifi-toolkit/app/securitypolicy.yaml
+++ b/kubernetes/apps/network/unifi-toolkit/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: unifi-toolkit-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: unifi-toolkit
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/unifi-toolkit"
+    clientID: "unifi-toolkit"
+    clientSecret:
+      name: unifi-toolkit-oidc-secret
+    redirectURL: "https://unifi-toolkit.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/observability/grafana/instance/externalsecret-oidc.yaml
+++ b/kubernetes/apps/observability/grafana/instance/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: grafana-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: grafana-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/observability/grafana/instance/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana/instance/kustomization.yaml
@@ -3,7 +3,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret-oidc.yaml
   - ./grafanadashboard.yaml
   - ./grafanadatasource.yaml
   - ./grafana.yaml
+  - ./securitypolicy.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/observability/grafana/instance/securitypolicy.yaml
+++ b/kubernetes/apps/observability/grafana/instance/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: grafana-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: grafana-route
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/grafana"
+    clientID: "grafana"
+    clientSecret:
+      name: grafana-oidc-secret
+    redirectURL: "https://grafana.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/utils/n8n/app/externalsecret-oidc.yaml
+++ b/kubernetes/apps/utils/n8n/app/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: n8n-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: n8n-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: n8n-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/utils/n8n/app/kustomization.yaml
+++ b/kubernetes/apps/utils/n8n/app/kustomization.yaml
@@ -4,5 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-oidc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/utils/n8n/app/securitypolicy.yaml
+++ b/kubernetes/apps/utils/n8n/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: n8n-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: n8n
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/n8n"
+    clientID: "n8n"
+    clientSecret:
+      name: n8n-oidc-secret
+    redirectURL: "https://n8n.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"

--- a/kubernetes/apps/volsync-system/kopia/app/externalsecret-oidc.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/externalsecret-oidc.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kopia-oidc
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: kubernetes-identity
+  target:
+    name: kopia-oidc-secret
+    template:
+      data:
+        client-secret: "{{ .CLIENT_SECRET }}"
+  data:
+    - secretKey: CLIENT_SECRET
+      remoteRef:
+        key: kopia-kanidm-oauth2-credentials
+        property: CLIENT_SECRET

--- a/kubernetes/apps/volsync-system/kopia/app/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/kustomization.yaml
@@ -4,5 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-oidc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/volsync-system/kopia/app/securitypolicy.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/securitypolicy.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: kopia-oidc
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: kopia
+  oidc:
+    provider:
+      issuer: "https://auth.00o.sh/oauth2/openid/kopia"
+    clientID: "kopia"
+    clientSecret:
+      name: kopia-oidc-secret
+    redirectURL: "https://kopia.00o.sh/oauth2/callback"
+    logoutPath: "/oauth2/sign_out"


### PR DESCRIPTION
Add Envoy Gateway OIDC SecurityPolicy for radarr, sonarr, prowlarr, bazarr, autobrr, tautulli, qbittorrent, qui, thelounge, n8n, kopia, unifi-toolkit, and grafana. Each app gets a KanidmOAuth2Client, KanidmGroup, ExternalSecret for client credentials, and SecurityPolicy targeting its HTTPRoute.

https://claude.ai/code/session_01UXCgHfowZyB61naGK9V2cu