### PR TITLE
chore: add support for pin update type in renovate config

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -60,7 +60,7 @@
       matchManagers: ["github-actions"],
       automerge: true,
       automergeType: "branch",
-      matchUpdateTypes: ["minor", "patch", "digest"],
+      matchUpdateTypes: ["minor", "patch", "digest", "pin"],
       minimumReleaseAge: "3 days",
       ignoreTests: true,
     },
@@ -100,6 +100,11 @@
       matchUpdateTypes: ["digest"],
       semanticCommitType: "chore",
       commitMessageExtra: "( {{currentDigestShort}} ➔ {{newDigestShort}} )",
+    },
+    {
+      matchUpdateTypes: ["pin"],
+      semanticCommitType: "chore",
+      commitMessageExtra: "",
     },
     {
       matchDatasources: ["docker"],
@@ -162,6 +167,10 @@
     {
       matchUpdateTypes: ["digest"],
       labels: ["type/digest"],
+    },
+    {
+      matchUpdateTypes: ["pin"],
+      labels: ["type/pin"],
     },
   ],
   customManagers: [


### PR DESCRIPTION
## Summary
This PR extends the Renovate configuration to properly handle "pin" update types, which occur when dependencies are pinned to specific versions. The changes ensure that pin updates are automatically merged and labeled appropriately.

## Key Changes
- Added "pin" to the `matchUpdateTypes` array in the GitHub Actions automerge configuration, enabling automatic merging of pinned dependency updates
- Created a new commit message configuration rule for pin updates with semantic commit type "chore" and no additional message suffix
- Added a new labeling rule to tag pin updates with the "type/pin" label for better issue/PR organization

## Implementation Details
These changes follow the existing pattern used for other update types (minor, patch, digest) and ensure consistent handling of pin updates across the Renovate workflow. Pin updates will now be automatically merged after the minimum release age requirement is met, similar to other update types.

https://claude.ai/code/session_01NKAc5kTscwz9rfY7rrXqGM