### PR TITLE
feat(kubernetes): add LibreSpeed backend deployments for speed testing

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -10,3 +10,4 @@ components:
 resources:
   - ./namespace.yaml
   - ./echo/ks.yaml
+  - ./librespeed/ks.yaml

--- a/kubernetes/apps/default/librespeed/app/helmrelease.yaml
+++ b/kubernetes/apps/default/librespeed/app/helmrelease.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: librespeed
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: librespeed
+  interval: 1h
+  values:
+    controllers:
+      speed-cf:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image: &image
+              repository: ghcr.io/librespeed/speedtest
+              tag: 5.5.1
+            env: &env
+              MODE: backend
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /backend/empty.php
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext: &securityContext
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources: &resources
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+      speed-direct:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image: *image
+            env: *env
+            probes:
+              liveness: *probes
+              readiness: *probes
+            securityContext: *securityContext
+            resources: *resources
+    service:
+      speed-cf:
+        controller: speed-cf
+        ports:
+          http:
+            port: *port
+      speed-direct:
+        controller: speed-direct
+        ports:
+          http:
+            port: *port
+    route:
+      speed-cf:
+        hostnames: ["speed-cf.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: speed-cf
+                port: *port
+      speed-direct:
+        annotations:
+          external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+        hostnames: ["speed-direct.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: speed-direct
+                port: *port

--- a/kubernetes/apps/default/librespeed/app/helmrelease.yaml
+++ b/kubernetes/apps/default/librespeed/app/helmrelease.yaml
@@ -52,6 +52,33 @@ spec:
               readiness: *probes
             securityContext: *securityContext
             resources: *resources
+      speed-frontend:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image: *image
+            env:
+              MODE: frontend
+              SERVERS: >-
+                [
+                  {"name": "Cloudflare Proxied", "server": "//speed-cf.${SECRET_DOMAIN}/", "dlURL": "backend/garbage.php", "ulURL": "backend/empty.php", "pingURL": "backend/empty.php", "getIpURL": "backend/getIP.php"},
+                  {"name": "Direct", "server": "//speed-direct.${SECRET_DOMAIN}/", "dlURL": "backend/garbage.php", "ulURL": "backend/empty.php", "pingURL": "backend/empty.php", "getIpURL": "backend/getIP.php"}
+                ]
+            probes:
+              liveness: &frontend-probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *frontend-probes
+            securityContext: *securityContext
+            resources: *resources
     service:
       speed-cf:
         controller: speed-cf
@@ -60,6 +87,11 @@ spec:
             port: *port
       speed-direct:
         controller: speed-direct
+        ports:
+          http:
+            port: *port
+      speed-frontend:
+        controller: speed-frontend
         ports:
           http:
             port: *port
@@ -85,4 +117,13 @@ spec:
         rules:
           - backendRefs:
               - identifier: speed-direct
+                port: *port
+      speed-frontend:
+        hostnames: ["speed.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: speed-frontend
                 port: *port

--- a/kubernetes/apps/default/librespeed/app/kustomization.yaml
+++ b/kubernetes/apps/default/librespeed/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/librespeed/app/ocirepository.yaml
+++ b/kubernetes/apps/default/librespeed/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: librespeed
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/librespeed/ks.yaml
+++ b/kubernetes/apps/default/librespeed/ks.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: librespeed
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/default/librespeed/app
+  postBuild:
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: default
+  wait: false


### PR DESCRIPTION
Two backends: speed-cf (Cloudflare proxied) and speed-direct (DNS-only) for comparing CF HTTP proxy overhead vs tunnel-only performance.

https://claude.ai/code/session_01ABKtUfcXqt1f5KU28P3Jqx