### PR TITLE
fix(github): split pin updates into per-registry groups

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -56,6 +56,33 @@
       },
     },
     {
+      description: "Group ghcr.io pin dependencies",
+      matchUpdateTypes: ["pin"],
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/^ghcr\\.io\\//"],
+      groupName: "ghcr.io pin dependencies",
+    },
+    {
+      description: "Group quay.io pin dependencies",
+      matchUpdateTypes: ["pin"],
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/^quay\\.io\\//"],
+      groupName: "quay.io pin dependencies",
+    },
+    {
+      description: "Group Docker Hub pin dependencies",
+      matchUpdateTypes: ["pin"],
+      matchDatasources: ["docker"],
+      excludePackageNames: ["/^ghcr\\.io\\//", "/^quay\\.io\\//"],
+      groupName: "docker hub pin dependencies",
+    },
+    {
+      description: "Group GitHub Actions pin dependencies",
+      matchUpdateTypes: ["pin"],
+      matchManagers: ["github-actions"],
+      groupName: "github-actions pin dependencies",
+    },
+    {
       description: "Auto-merge GitHub Actions",
       matchManagers: ["github-actions"],
       automerge: true,

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -73,8 +73,8 @@
       description: "Group Docker Hub pin dependencies",
       matchUpdateTypes: ["pin"],
       matchDatasources: ["docker"],
-      excludePackageNames: ["/^ghcr\\.io\\//", "/^quay\\.io\\//"],
       groupName: "docker hub pin dependencies",
+      matchPackageNames: ["!/^ghcr\\.io\\//", "!/^quay\\.io\\//"],
     },
     {
       description: "Group GitHub Actions pin dependencies",


### PR DESCRIPTION
Renovate groups all pin updates into a single "Pin Dependencies" PR by default. With docker:pinDigests enabled and ~65+ images across multiple registries, this single PR triggers too many concurrent digest lookups and hits Docker Hub's unauthenticated rate limit (100 req/6h), causing "Error obtaining docker token" and "Package lookup failures".

Split pin updates into 4 groups by registry:
- ghcr.io (high rate limits with GITHUB_TOKEN)
- quay.io
- Docker Hub (everything else)
- GitHub Actions (separate manager)

https://claude.ai/code/session_01NKAc5kTscwz9rfY7rrXqGM