### PR TITLE
fix(github): disable digest pinning for all Flux OCIRepository resources

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -31,9 +31,8 @@
   },
   packageRules: [
     {
-      description: "Disable digest pinning for quay.io Flux charts (unsupported tag@sha256 format)",
+      description: "Disable digest pinning for Flux OCIRepository (inline tag@sha256 format not supported by Flux CRD)",
       matchManagers: ["flux"],
-      matchPackageNames: ["/^quay\\.io\\//"],
       pinDigests: false,
     },
     {


### PR DESCRIPTION
Renovate's docker:pinDigests uses inline tag@sha256:hash format which is
incompatible with Flux OCIRepository CRD (expects separate ref.digest field).
Broadens the existing quay.io-only rule to all Flux-managed packages.

https://claude.ai/code/session_01AgtvEGFiLYUMAUZQSWJYRL