### PR TITLE
fix(kubernetes): increase kaniop HelmRelease timeout for upgrade

### DIFF
--- a/kubernetes/apps/identity/kanidm/app/helmrelease.yaml
+++ b/kubernetes/apps/identity/kanidm/app/helmrelease.yaml
@@ -9,3 +9,4 @@ spec:
     kind: OCIRepository
     name: kaniop
   interval: 1h
+  timeout: 10m


### PR DESCRIPTION
The kaniop 0.4.2 → 0.5.0 upgrade times out at the default 5m due to
a CRD schema change requiring a status field patch. Increase timeout
to 10m to allow the upgrade to complete after patching.

https://claude.ai/code/session_014iqrvtgmQZzAgQx4CCSaZA