### PR TITLE
feat(kubernetes): add LibreSpeed backend deployments for speed testing

### DIFF
--- a/kubernetes/apps/default/librespeed/app/helmrelease.yaml
+++ b/kubernetes/apps/default/librespeed/app/helmrelease.yaml
@@ -52,6 +52,33 @@ spec:
               readiness: *probes
             securityContext: *securityContext
             resources: *resources
+      speed-frontend:
+        strategy: RollingUpdate
+        containers:
+          app:
+            image: *image
+            env:
+              MODE: frontend
+              SERVERS: >-
+                [
+                  {"name": "Cloudflare Proxied", "server": "//speed-cf.${SECRET_DOMAIN}/", "dlURL": "backend/garbage.php", "ulURL": "backend/empty.php", "pingURL": "backend/empty.php", "getIpURL": "backend/getIP.php"},
+                  {"name": "Direct", "server": "//speed-direct.${SECRET_DOMAIN}/", "dlURL": "backend/garbage.php", "ulURL": "backend/empty.php", "pingURL": "backend/empty.php", "getIpURL": "backend/getIP.php"}
+                ]
+            probes:
+              liveness: &frontend-probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *frontend-probes
+            securityContext: *securityContext
+            resources: *resources
     service:
       speed-cf:
         controller: speed-cf
@@ -60,6 +87,11 @@ spec:
             port: *port
       speed-direct:
         controller: speed-direct
+        ports:
+          http:
+            port: *port
+      speed-frontend:
+        controller: speed-frontend
         ports:
           http:
             port: *port
@@ -85,4 +117,13 @@ spec:
         rules:
           - backendRefs:
               - identifier: speed-direct
+                port: *port
+      speed-frontend:
+        hostnames: ["speed.${SECRET_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: speed-frontend
                 port: *port


### PR DESCRIPTION
Two backends: speed-cf (Cloudflare proxied) and speed-direct (DNS-only)
for comparing CF HTTP proxy overhead vs tunnel-only performance.

https://claude.ai/code/session_01ABKtUfcXqt1f5KU28P3Jqx