### PR TITLE
docs: update SOPS version and fix documentation accuracy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ This document provides comprehensive guidance for AI assistants working with thi
 - **GitOps**: Flux CD 2.7.5 (declarative continuous delivery)
 - **CNI**: Cilium 1.19.0 (eBPF-based networking)
 - **Ingress**: Envoy Gateway v1.6.3 (HTTP routing)
-- **Secrets**: SOPS 3.11.0 + Age 1.3.1 encryption
+- **Secrets**: SOPS 3.12.1 + Age 1.3.1 encryption
 - **Identity**: Kanidm (SSO/OAuth2 identity provider)
 - **DNS**: k8s_gateway + CoreDNS + External-DNS
 - **Certificates**: cert-manager with Cloudflare integration
@@ -563,6 +563,19 @@ Generates label configuration from repository structure:
 - Automates `.github/labels.yaml` and `.github/labeler.yaml` updates
 - Ensures labels stay in sync with namespace and directory changes
 
+### docs.yaml
+Documentation site build and publish:
+- Builds MkDocs Material site from `docs/` directory
+- Publishes to Cloudflare Pages (`special-winner-docs` project)
+- Triggered on pushes to main when `docs/**` or `mkdocs.yml` change
+- Also supports manual workflow dispatch
+
+### renovate-config.yaml
+Renovate configuration validation:
+- Validates `.renovaterc.json5` on pull requests
+- Runs `renovate-config-validator --strict` to catch config errors
+- Only triggers when `.renovaterc.json5` is modified
+
 ## Template System Details
 
 ### Custom Jinja2 Filters
@@ -631,9 +644,8 @@ talosctl logs --nodes <ip> --insecure
 - cert-manager
 
 **database**: Database infrastructure
-- cloudnative-pg (PostgreSQL operator)
+- cloudnative-pg (PostgreSQL operator + PostgreSQL 17.7 HA cluster with 3 instances)
 - dbgate (database management web UI)
-- postgres-cluster (PostgreSQL 17.7 HA cluster with 3 instances)
 - dragonfly (Redis-compatible in-memory datastore operator)
 
 **default**: Default namespace
@@ -761,6 +773,7 @@ Check `.mise.toml` for exact versions of all tools.
 
 ## Recent Notable Changes
 
+- **2026-02-22**: Documentation audit: fixed SOPS version (3.11.0 → 3.12.1), added docs.yaml and renovate-config.yaml workflows, fixed database app listing, updated architecture namespace map
 - **2026-02-16**: Added error-pages service for Envoy Gateway with responseOverride redirects (403, 404, 500, 502, 503, 504)
 - **2026-02-16**: Added n8n workflow automation platform to utils namespace (PostgreSQL backend, ExternalSecrets)
 - **2026-02-14**: Added Kanidm identity provider with OAuth2 SSO for dbgate, forgejo, kubevirt-manager, opencost, penpot
@@ -1086,5 +1099,5 @@ Located in `kubernetes/apps/utils/homepage/`, Homepage provides a unified dashbo
 
 ---
 
-**Last Updated**: 2026-02-16
+**Last Updated**: 2026-02-22
 **Template Source**: [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 - [cert-manager](https://github.com/cert-manager/cert-manager) - TLS certificate automation
 - [External Secrets Operator](https://external-secrets.io/) - External secret management
 - [1Password](https://1password.com/) - Secret storage backend
-- [SOPS](https://github.com/getsops/sops) 3.11.0 - Encrypted secrets in Git
+- [SOPS](https://github.com/getsops/sops) 3.12.1 - Encrypted secrets in Git
 
 **Storage:**
 - [OpenEBS](https://github.com/openebs/openebs) - Cloud-native storage
@@ -669,7 +669,7 @@ If this repo is too hot to handle or too cold to hold check out these following 
 | **Template Source** | [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template) |
 | **Infrastructure** | GitOps with Flux CD + Talos Linux |
 | **Documentation** | [docs.00o.sh](https://docs.00o.sh) |
-| **Last Updated** | 2026-02-16 |
+| **Last Updated** | 2026-02-22 |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,7 +122,7 @@ kubernetes/apps/<namespace>/<app-name>/
 | `actions-runner-system` | CI/CD runners | Actions Runner Controller |
 | `cert-manager` | TLS certificates | cert-manager |
 | `database` | Database services | CloudNative-PG, Dragonfly, DBGate |
-| `default` | Test workloads | echo |
+| `default` | Test workloads | echo, LibreSpeed |
 | `external-secrets` | Secret management | External Secrets, 1Password |
 | `flux-system` | GitOps | Flux Operator, Flux Instance |
 | `forgejo-runner-system` | Forgejo CI/CD | Forgejo Runner (ScaledJob) |

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -71,6 +71,14 @@ Documentation site publishing:
 - Publishes to Cloudflare Pages (`special-winner-docs` project)
 - Triggered on docs/ or mkdocs.yml changes
 
+### renovate-config.yaml
+
+Renovate configuration validation:
+
+- Validates `.renovaterc.json5` on pull requests
+- Runs `renovate-config-validator --strict`
+- Only triggers when `.renovaterc.json5` is modified
+
 ### release.yaml
 
 Repository release management.

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -70,7 +70,7 @@ All tools are managed via `.mise.toml`:
 | Flux | 2.7.5 | GitOps CLI |
 | Talos CLI | 1.12.4 | Talos management |
 | Cilium CLI | 0.19.1 | Network management |
-| SOPS | 3.11.0 | Secret encryption |
+| SOPS | 3.12.1 | Secret encryption |
 | Age | 1.3.1 | Encryption backend |
 | virtctl | 1.7.0 | VM management |
 | k9s | 0.50.18 | Kubernetes TUI |

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ Built on the [onedr0p/cluster-template](https://github.com/onedr0p/cluster-templ
 | GitOps | Flux CD | 2.7.5 |
 | CNI | Cilium | 1.19.0 |
 | Ingress | Envoy Gateway | v1.6.3 |
-| Secrets | SOPS + Age | 3.11.0 / 1.3.1 |
+| Secrets | SOPS + Age | 3.12.1 / 1.3.1 |
 | Identity | Kanidm | SSO/OAuth2 |
 | Packages | Helm | 4.1.1 (v4) |
 | Database | CloudNative-PG | PostgreSQL 17.7 |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,7 +73,7 @@ extra:
 
 nav:
   - Home:
-      - index.md
+      - Overview: index.md
       - Architecture: architecture.md
   - Getting Started:
       - getting-started/index.md


### PR DESCRIPTION
- Fix SOPS version 3.11.0 → 3.12.1 across all docs (README, CLAUDE.md,
  docs/index.md, docs/getting-started/prerequisites.md) to match .mise.toml
- Add missing docs.yaml and renovate-config.yaml workflows to CLAUDE.md
  CI/CD section and docs/development/ci-cd.md
- Fix database namespace listing: postgres-cluster is a subdirectory of
  cloudnative-pg, not a standalone app
- Add LibreSpeed to default namespace in docs/architecture.md namespace map
- Update Last Updated dates to 2026-02-22

https://claude.ai/code/session_013PX3JNbqKQr31yQ2vvVJaP