### PR TITLE
chore(kubernetes): group kguardian Renovate PRs

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -61,6 +61,15 @@
       },
     },
     {
+      description: "kGuardian Group",
+      groupName: "kguardian",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/kguardian-dev/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+    },
+    {
       description: "Group ghcr.io pin dependencies",
       matchUpdateTypes: ["pin"],
       matchDatasources: ["docker"],


### PR DESCRIPTION
Adds a packageRule to group all kguardian-dev container images (broker,
controller, frontend) into a single PR instead of separate ones.

https://claude.ai/code/session_01XuznBZLKkHQGsdPgBUiMtW