### PR TITLE
feat(database): add MariaDB Operator with Galera cluster

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1037,9 +1037,9 @@ kubernetes/apps/database/mariadb-operator/
 
 **Usage**:
 - Applications can connect to PostgreSQL via the `postgres-rw.database.svc.cluster.local` service.
-- Applications can connect to MariaDB via the `mariadb-galera.database.svc.cluster.local` service.
-- Primary-only connections: `mariadb-galera-primary.database.svc.cluster.local`
-- Read replicas: `mariadb-galera-secondary.database.svc.cluster.local`
+- Applications can connect to MariaDB via the `mariadb.database.svc.cluster.local` service.
+- Primary-only connections: `mariadb-primary.database.svc.cluster.local`
+- Read replicas: `mariadb-secondary.database.svc.cluster.local`
 
 ### Penpot Design Platform
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ This document provides comprehensive guidance for AI assistants working with thi
 - **DNS**: k8s_gateway + CoreDNS + External-DNS
 - **Certificates**: cert-manager with Cloudflare integration
 - **Package Management**: Helm 4.1.1 (Helm v4 for chart management)
-- **Database**: CloudNative-PG (PostgreSQL 17.7) + Dragonfly (Redis-compatible)
+- **Database**: CloudNative-PG (PostgreSQL 17.7) + Dragonfly (Redis-compatible) + MariaDB Operator (MariaDB 11.7 Galera)
 - **Virtualization**: KubeVirt 1.7.0 (virtual machine management)
 - **External Secrets**: External Secrets Operator 2.0.0 + 1Password integration
 
@@ -647,6 +647,7 @@ talosctl logs --nodes <ip> --insecure
 - cloudnative-pg (PostgreSQL operator + PostgreSQL 17.7 HA cluster with 3 instances)
 - dbgate (database management web UI)
 - dragonfly (Redis-compatible in-memory datastore operator)
+- mariadb-operator (MariaDB operator + MariaDB 11.7 Galera cluster with 3 instances)
 
 **default**: Default namespace
 - echo (test application)
@@ -773,6 +774,7 @@ Check `.mise.toml` for exact versions of all tools.
 
 ## Recent Notable Changes
 
+- **2026-02-22**: Added MariaDB Operator with MariaDB 11.7 Galera cluster (3 instances, 20Gi storage, S3 backups to Garage)
 - **2026-02-22**: Documentation audit: fixed SOPS version (3.11.0 → 3.12.1), added docs.yaml and renovate-config.yaml workflows, fixed database app listing, updated architecture namespace map
 - **2026-02-16**: Added error-pages service for Envoy Gateway with responseOverride redirects (403, 404, 500, 502, 503, 504)
 - **2026-02-16**: Added n8n workflow automation platform to utils namespace (PostgreSQL backend, ExternalSecrets)
@@ -1008,7 +1010,36 @@ kubernetes/apps/database/cloudnative-pg/
 - Higher performance alternative to Redis/Valkey
 - Used by applications requiring fast caching or session storage
 
-**Usage**: Applications can connect to PostgreSQL via the `postgres-rw.database.svc.cluster.local` service.
+**MariaDB Operator (MariaDB Galera)**:
+- Kubernetes-native MariaDB operator with Galera multi-master replication
+- Runs MariaDB 11.7 with 3 instances for high availability
+- Uses OpenEBS hostpath storage (20Gi per instance)
+- Pod anti-affinity for distribution across hosts
+- Automated scheduled backups to Garage S3 storage (every 6 hours, 30-day retention)
+- Metrics and ServiceMonitor enabled
+- Tuned for performance: 200 max connections, 256MB innodb_buffer_pool_size
+- Resources: 100m CPU request, 512Mi memory request, 2Gi memory limit
+- CRDs and operator installed via separate HelmReleases from `helm.mariadb.com`
+
+**MariaDB Architecture**:
+```
+kubernetes/apps/database/mariadb-operator/
+├── app/                       # Operator deployment
+│   ├── helmrelease-crds.yaml  # CRDs HelmRelease
+│   ├── helmrelease.yaml       # Operator HelmRelease
+│   └── helmrepository.yaml    # Helm repo source
+├── cluster/                   # MariaDB Galera cluster
+│   ├── mariadb.yaml          # MariaDB CR (Galera)
+│   ├── backup.yaml           # Scheduled S3 backup
+│   └── externalsecret.yaml   # 1Password credentials
+└── ks.yaml                   # Flux Kustomizations
+```
+
+**Usage**:
+- Applications can connect to PostgreSQL via the `postgres-rw.database.svc.cluster.local` service.
+- Applications can connect to MariaDB via the `mariadb-galera.database.svc.cluster.local` service.
+- Primary-only connections: `mariadb-galera-primary.database.svc.cluster.local`
+- Read replicas: `mariadb-galera-secondary.database.svc.cluster.local`
 
 ### Penpot Design Platform
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,7 @@ graph TB
 
         subgraph Data["Data Layer"]
             PG[CloudNative-PG]
+            MDB[MariaDB Galera]
             Dragonfly[Dragonfly]
             OpenEBS[OpenEBS]
             NFS[NFS Storage]
@@ -56,6 +57,7 @@ graph TB
     Envoy --> Apps
     Kanidm --> Apps
     PG --> Apps
+    MDB --> Apps
     Cilium --> Envoy
     Multus --> VMs
 ```
@@ -121,7 +123,7 @@ kubernetes/apps/<namespace>/<app-name>/
 |-----------|---------|----------|
 | `actions-runner-system` | CI/CD runners | Actions Runner Controller |
 | `cert-manager` | TLS certificates | cert-manager |
-| `database` | Database services | CloudNative-PG, Dragonfly, DBGate |
+| `database` | Database services | CloudNative-PG, MariaDB Galera, Dragonfly, DBGate |
 | `default` | Test workloads | echo, LibreSpeed |
 | `external-secrets` | Secret management | External Secrets, 1Password |
 | `flux-system` | GitOps | Flux Operator, Flux Instance |

--- a/docs/infrastructure/databases.md
+++ b/docs/infrastructure/databases.md
@@ -52,6 +52,72 @@ postgres-rw.database.svc.cluster.local:5432
 
 A recovery cluster definition exists at `kubernetes/apps/database/cloudnative-pg/recovery/cluster.yaml` for disaster recovery scenarios.
 
+## MariaDB Operator (MariaDB Galera)
+
+[MariaDB Operator](https://github.com/mariadb-operator/mariadb-operator) runs a **MariaDB 11.7** high-availability Galera cluster with 3 instances.
+
+### Architecture
+
+```
+kubernetes/apps/database/mariadb-operator/
+├── app/                       # Operator deployment
+│   ├── helmrelease-crds.yaml  # CRDs HelmRelease
+│   ├── helmrelease.yaml       # Operator HelmRelease
+│   ├── helmrepository.yaml    # Helm repo source
+│   └── kustomization.yaml
+├── cluster/                   # MariaDB Galera cluster
+│   ├── mariadb.yaml          # MariaDB CR (Galera)
+│   ├── backup.yaml           # Scheduled S3 backup
+│   ├── externalsecret.yaml   # 1Password credentials
+│   └── kustomization.yaml
+└── ks.yaml                   # Flux Kustomizations
+```
+
+### Configuration
+
+| Setting | Value |
+|---------|-------|
+| Instances | 3 (Galera multi-master with pod anti-affinity) |
+| Storage | 20Gi per instance (openebs-hostpath) |
+| Max connections | 200 |
+| InnoDB buffer pool | 256MB |
+| Max allowed packet | 256MB |
+| CPU request | 100m |
+| Memory request | 512Mi |
+| Memory limit | 2Gi |
+
+### Backups
+
+- **Scheduled backups** to Garage S3 every 6 hours (`0 */6 * * *`)
+- **Retention**: 30 days
+- **Compression**: bzip2
+- **S3 bucket**: `mariadb` (prefix `galera`)
+- **Method**: `mysqldump` with `--single-transaction --all-databases`
+
+### Connecting
+
+Applications connect via internal services:
+
+```
+# All instances (load-balanced)
+mariadb-galera.database.svc.cluster.local:3306
+
+# Primary only
+mariadb-galera-primary.database.svc.cluster.local:3306
+
+# Read replicas
+mariadb-galera-secondary.database.svc.cluster.local:3306
+```
+
+### Operator Installation
+
+The operator is installed via two separate HelmReleases from the `helm.mariadb.com` Helm repository:
+
+1. **mariadb-operator-crds** — installs Custom Resource Definitions
+2. **mariadb-operator** — installs the controller (depends on CRDs)
+
+The operator includes Prometheus metrics via ServiceMonitor and cert-manager webhook integration.
+
 ## Dragonfly
 
 [Dragonfly](https://www.dragonflydb.io/) is a modern Redis-compatible in-memory datastore:

--- a/docs/infrastructure/databases.md
+++ b/docs/infrastructure/databases.md
@@ -100,13 +100,13 @@ Applications connect via internal services:
 
 ```
 # All instances (load-balanced)
-mariadb-galera.database.svc.cluster.local:3306
+mariadb.database.svc.cluster.local:3306
 
 # Primary only
-mariadb-galera-primary.database.svc.cluster.local:3306
+mariadb-primary.database.svc.cluster.local:3306
 
 # Read replicas
-mariadb-galera-secondary.database.svc.cluster.local:3306
+mariadb-secondary.database.svc.cluster.local:3306
 ```
 
 ### Operator Installation

--- a/docs/infrastructure/index.md
+++ b/docs/infrastructure/index.md
@@ -16,6 +16,7 @@ graph LR
     end
     subgraph Data["Data"]
         PG[PostgreSQL 17.7]
+        MDB[MariaDB 11.7 Galera]
         DF[Dragonfly]
         OEBS[OpenEBS]
     end
@@ -44,7 +45,7 @@ graph LR
 | [Cilium](cilium.md) | eBPF-based container networking |
 | [Envoy Gateway](envoy-gateway.md) | HTTP routing and ingress |
 | [Storage](storage.md) | OpenEBS, NFS, and backup systems |
-| [Databases](databases.md) | PostgreSQL HA cluster and Dragonfly |
+| [Databases](databases.md) | PostgreSQL HA, MariaDB Galera, and Dragonfly |
 | [Certificates & DNS](certificates-dns.md) | TLS automation and DNS management |
 | [Secrets](secrets.md) | SOPS, Age, and External Secrets |
 | [Identity & SSO](identity.md) | Kanidm identity provider |

--- a/docs/operations/backup-recovery.md
+++ b/docs/operations/backup-recovery.md
@@ -7,6 +7,7 @@ graph LR
     PVC[PersistentVolumeClaims] -->|VolSync| Kopia[Kopia Repository]
     Kopia -->|S3 API| Garage[Garage S3]
     PG[PostgreSQL WAL] -->|barman-cloud| Garage
+    MDB[MariaDB Galera] -->|mysqldump| Garage
     Git[Git Repository] -->|GitOps| State[Cluster State]
 ```
 
@@ -16,6 +17,7 @@ The cluster uses a layered backup strategy:
 |-----------|--------------|-------------|----------|
 | Application config (PVCs) | VolSync + Kopia | Garage S3 | Daily at 2 AM |
 | PostgreSQL databases | barman-cloud (WAL + base backups) | Garage S3 | Continuous WAL + scheduled |
+| MariaDB databases | mysqldump (mariadb-operator Backup CR) | Garage S3 | Every 6 hours |
 | Cluster state | Git repository | GitHub | On every push |
 | Secrets | SOPS-encrypted in Git + 1Password | GitHub + 1Password | On every push |
 
@@ -143,6 +145,42 @@ kubectl -n database describe backup <backup-name>
 kubectl -n database get cluster postgres -o jsonpath='{.status.firstRecoverabilityPoint}'
 ```
 
+## MariaDB Backups
+
+The mariadb-operator handles MariaDB Galera backups via its `Backup` custom resource:
+
+- **Scheduled mysqldump backups** to Garage S3 every 6 hours
+- **Compression**: bzip2
+- **Retention**: 30 days
+- **S3 bucket**: `mariadb` (prefix `galera`)
+- Backup definition at `kubernetes/apps/database/mariadb-operator/cluster/backup.yaml`
+
+### Checking Backup Status
+
+```sh
+# List all MariaDB backups
+kubectl -n database get backups.k8s.mariadb.com
+
+# Check backup details
+kubectl -n database describe backup mariadb-galera-backup
+```
+
+### Restoring from a MariaDB Backup
+
+To restore from S3, create a new MariaDB CR with `bootstrapFrom` referencing the backup:
+
+```yaml
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: mariadb-galera-recovery
+spec:
+  bootstrapFrom:
+    backupRef:
+      name: mariadb-galera-backup
+  # ... same spec as production cluster
+```
+
 ## Disaster Recovery
 
 ### Full Cluster Recovery
@@ -164,7 +202,9 @@ Since the cluster is GitOps-managed, a full recovery follows these steps:
 
 5. **PostgreSQL recovers from WAL archives** — Use the recovery cluster definition (see below)
 
-6. **Verify all services**:
+6. **MariaDB recovers from S3 backups** — Create a recovery MariaDB CR with `bootstrapFrom` (see above)
+
+7. **Verify all services**:
 
     ```sh
     flux get ks -A
@@ -222,8 +262,9 @@ The recovery cluster definition at `kubernetes/apps/database/cloudnative-pg/reco
 |-----------|--------------------------|
 | Application PVCs (via VolSync) | Active VM state (VMs restart from disk images) |
 | PostgreSQL databases (via WAL archiving) | In-memory caches (Dragonfly data) |
-| Cluster manifests (in Git) | Real-time metrics (Prometheus TSDB rebuilds) |
-| Secrets (SOPS in Git + 1Password) | Pod logs (Victoria Logs rebuilds from Fluent Bit) |
+| MariaDB databases (via scheduled mysqldump) | Real-time metrics (Prometheus TSDB rebuilds) |
+| Cluster manifests (in Git) | Pod logs (Victoria Logs rebuilds from Fluent Bit) |
+| Secrets (SOPS in Git + 1Password) | |
 
 ## Garage S3
 

--- a/docs/operations/backup-recovery.md
+++ b/docs/operations/backup-recovery.md
@@ -162,7 +162,7 @@ The mariadb-operator handles MariaDB Galera backups via its `Backup` custom reso
 kubectl -n database get backups.k8s.mariadb.com
 
 # Check backup details
-kubectl -n database describe backup mariadb-galera-backup
+kubectl -n database describe backup mariadb-backup
 ```
 
 ### Restoring from a MariaDB Backup
@@ -173,11 +173,11 @@ To restore from S3, create a new MariaDB CR with `bootstrapFrom` referencing the
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: MariaDB
 metadata:
-  name: mariadb-galera-recovery
+  name: mariadb-recovery
 spec:
   bootstrapFrom:
     backupRef:
-      name: mariadb-galera-backup
+      name: mariadb-backup
   # ... same spec as production cluster
 ```
 

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./cloudnative-pg/ks.yaml
   - ./dbgate/ks.yaml
   - ./dragonfly/ks.yaml
+  - ./mariadb-operator/ks.yaml

--- a/kubernetes/apps/database/mariadb-operator/app/helmrelease-crds.yaml
+++ b/kubernetes/apps/database/mariadb-operator/app/helmrelease-crds.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mariadb-operator-crds
+spec:
+  chart:
+    spec:
+      chart: mariadb-operator-crds
+      version: 25.10.4
+      sourceRef:
+        kind: HelmRepository
+        name: mariadb-operator
+  interval: 1h

--- a/kubernetes/apps/database/mariadb-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/database/mariadb-operator/app/helmrelease.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mariadb-operator
+spec:
+  dependsOn:
+    - name: mariadb-operator-crds
+  chart:
+    spec:
+      chart: mariadb-operator
+      version: 25.10.4
+      sourceRef:
+        kind: HelmRepository
+        name: mariadb-operator
+  interval: 1h
+  values:
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true
+    webhook:
+      certManager:
+        enabled: true
+    resources:
+      requests:
+        cpu: 10m
+        memory: 64Mi
+      limits:
+        memory: 256Mi

--- a/kubernetes/apps/database/mariadb-operator/app/helmrepository.yaml
+++ b/kubernetes/apps/database/mariadb-operator/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: mariadb-operator
+spec:
+  interval: 1h
+  url: https://helm.mariadb.com/mariadb-operator

--- a/kubernetes/apps/database/mariadb-operator/app/kustomization.yaml
+++ b/kubernetes/apps/database/mariadb-operator/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease-crds.yaml
+  - ./helmrelease.yaml
+  - ./helmrepository.yaml

--- a/kubernetes/apps/database/mariadb-operator/cluster/backup.yaml
+++ b/kubernetes/apps/database/mariadb-operator/cluster/backup.yaml
@@ -2,10 +2,10 @@
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: Backup
 metadata:
-  name: mariadb-galera-backup
+  name: mariadb-backup
 spec:
   mariaDbRef:
-    name: mariadb-galera
+    name: mariadb
   schedule:
     cron: "0 */6 * * *"
     suspend: false

--- a/kubernetes/apps/database/mariadb-operator/cluster/backup.yaml
+++ b/kubernetes/apps/database/mariadb-operator/cluster/backup.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Backup
+metadata:
+  name: mariadb-galera-backup
+spec:
+  mariaDbRef:
+    name: mariadb-galera
+  schedule:
+    cron: "0 */6 * * *"
+    suspend: false
+  maxRetention: 720h # 30 days
+  compression: bzip2
+  storage:
+    s3:
+      bucket: mariadb
+      prefix: galera
+      endpoint: garage.volsync-system.svc.cluster.local:3900
+      region: USTX01
+      accessKeyIdSecretKeyRef:
+        name: mariadb-secret
+        key: AWS_ACCESS_KEY_ID
+      secretAccessKeySecretKeyRef:
+        name: mariadb-secret
+        key: AWS_SECRET_ACCESS_KEY
+      tls:
+        enabled: false
+  args:
+    - --single-transaction
+    - --all-databases
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi

--- a/kubernetes/apps/database/mariadb-operator/cluster/externalsecret.yaml
+++ b/kubernetes/apps/database/mariadb-operator/cluster/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mariadb-operator
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: mariadb-secret
+    template:
+      engineVersion: v2
+      data:
+        root-password: "{{ .MARIADB_ROOT_PASSWORD }}"
+        AWS_ACCESS_KEY_ID: "{{ .AWS_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .AWS_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: mariadb-operator

--- a/kubernetes/apps/database/mariadb-operator/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/mariadb-operator/cluster/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./backup.yaml
+  - ./externalsecret.yaml
+  - ./mariadb.yaml

--- a/kubernetes/apps/database/mariadb-operator/cluster/mariadb.yaml
+++ b/kubernetes/apps/database/mariadb-operator/cluster/mariadb.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: mariadb-galera
+spec:
+  rootPasswordSecretKeyRef:
+    name: mariadb-secret
+    key: root-password
+
+  image: docker.io/library/mariadb:11.7
+
+  replicas: 3
+
+  galera:
+    enabled: true
+
+  storage:
+    size: 20Gi
+    storageClassName: openebs-hostpath
+
+  affinity:
+    antiAffinityEnabled: true
+
+  podDisruptionBudget:
+    maxUnavailable: 33%
+
+  updateStrategy:
+    type: ReplicasFirstPrimaryLast
+
+  myCnf: |
+    [mariadb]
+    bind-address=*
+    default_storage_engine=InnoDB
+    binlog_format=row
+    innodb_autoinc_lock_mode=2
+    innodb_buffer_pool_size=256MB
+    max_allowed_packet=256MB
+    max_connections=200
+
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      memory: 2Gi
+
+  metrics:
+    enabled: true
+
+  livenessProbe:
+    periodSeconds: 10
+    timeoutSeconds: 5
+
+  readinessProbe:
+    periodSeconds: 10
+    timeoutSeconds: 5
+
+  startupProbe:
+    failureThreshold: 10
+    periodSeconds: 5
+    timeoutSeconds: 5
+
+  primaryService:
+    type: ClusterIP
+
+  secondaryService:
+    type: ClusterIP
+
+  service:
+    type: ClusterIP

--- a/kubernetes/apps/database/mariadb-operator/cluster/mariadb.yaml
+++ b/kubernetes/apps/database/mariadb-operator/cluster/mariadb.yaml
@@ -2,7 +2,7 @@
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: MariaDB
 metadata:
-  name: mariadb-galera
+  name: mariadb
 spec:
   rootPasswordSecretKeyRef:
     name: mariadb-secret

--- a/kubernetes/apps/database/mariadb-operator/ks.yaml
+++ b/kubernetes/apps/database/mariadb-operator/ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: mariadb-operator
+spec:
+  interval: 1h
+  path: ./kubernetes/apps/database/mariadb-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: mariadb-cluster
+spec:
+  dependsOn:
+    - name: mariadb-operator
+    - name: onepassword
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/database/mariadb-operator/cluster
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  wait: false


### PR DESCRIPTION
Deploy mariadb-operator (v25.10.4) with a 3-instance MariaDB 11.7
Galera cluster matching the existing PostgreSQL HA setup: 20Gi
OpenEBS storage, pod anti-affinity, scheduled S3 backups to Garage
every 6 hours with 30-day retention, and Prometheus metrics.

https://claude.ai/code/session_01VVrqMZ3trTJBdhKNbthrty