### PR TITLE
fix(database): add Galera config storageClass and prefer soft anti-af…

### DIFF
--- a/kubernetes/apps/database/mariadb-operator/cluster/mariadb.yaml
+++ b/kubernetes/apps/database/mariadb-operator/cluster/mariadb.yaml
@@ -14,6 +14,14 @@ spec:
 
   galera:
     enabled: true
+    config:
+      volumeClaimTemplate:
+        storageClassName: openebs-hostpath
+        resources:
+          requests:
+            storage: 1Gi
+        accessModes:
+          - ReadWriteOnce
 
   storage:
     size: 20Gi
@@ -21,6 +29,11 @@ spec:
 
   affinity:
     antiAffinityEnabled: true
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          podAffinityTerm:
+            topologyKey: kubernetes.io/hostname
 
   podDisruptionBudget:
     maxUnavailable: 33%


### PR DESCRIPTION
…finity

- Galera config PVCs were created without a storageClass, causing them to stay Pending. Add explicit volumeClaimTemplate with openebs-hostpath.
- Switch anti-affinity to preferred so all 3 replicas can schedule on a single node when needed.

https://claude.ai/code/session_01VVrqMZ3trTJBdhKNbthrty