### PR TITLE
fix(database): disable operator required anti-affinity for single-nod…

### DIFF
--- a/kubernetes/apps/database/mariadb-operator/cluster/mariadb.yaml
+++ b/kubernetes/apps/database/mariadb-operator/cluster/mariadb.yaml
@@ -28,11 +28,17 @@ spec:
     storageClassName: openebs-hostpath
 
   affinity:
-    antiAffinityEnabled: true
+    antiAffinityEnabled: false
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
         - weight: 1
           podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                    - mariadb
             topologyKey: kubernetes.io/hostname
 
   podDisruptionBudget:


### PR DESCRIPTION
…e cluster

antiAffinityEnabled: true causes the operator to inject required anti-affinity, preventing multiple MariaDB pods from scheduling on the same node. Set to false and use an explicit preferred anti-affinity rule instead, allowing all replicas to run on a single-node cluster.

https://claude.ai/code/session_01VVrqMZ3trTJBdhKNbthrty