### PR TITLE
Add FreePBX VoIP telephony platform deployment

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -139,6 +139,11 @@ area/utils:
       - any-glob-to-any-file:
           - kubernetes/apps/utils/**/*
 
+area/voip:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/apps/voip/**/*
+
 area/volsync-system:
   - changed-files:
       - any-glob-to-any-file:
@@ -464,6 +469,11 @@ app/smtp-relay:
   - changed-files:
       - any-glob-to-any-file:
           - kubernetes/apps/utils/smtp-relay/**/*
+
+app/freepbx:
+  - changed-files:
+      - any-glob-to-any-file:
+          - kubernetes/apps/voip/freepbx/**/*
 
 app/garage:
   - changed-files:

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -84,6 +84,9 @@
 - name: area/utils
   color: "1d76db"
   description: "utils namespace"
+- name: area/voip
+  color: "1d76db"
+  description: "voip namespace"
 - name: area/volsync-system
   color: "1d76db"
   description: "volsync-system namespace"
@@ -281,6 +284,9 @@
 - name: app/smtp-relay
   color: "6f42c1"
   description: "smtp-relay in utils"
+- name: app/freepbx
+  color: "6f42c1"
+  description: "freepbx in voip"
 - name: app/garage
   color: "6f42c1"
   description: "garage in volsync-system"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -734,6 +734,9 @@ talosctl logs --nodes <ip> --insecure
 - penpot (open-source design and prototyping platform)
 - smtp-relay (SMTP relay for outbound email using Maddy)
 
+**voip**: VoIP and telephony
+- freepbx (containerized FreePBX telephony platform with MariaDB backend)
+
 **volsync-system**: Backup and replication
 - garage (S3-compatible storage backend)
 - kopia (backup repository)
@@ -774,6 +777,7 @@ Check `.mise.toml` for exact versions of all tools.
 
 ## Recent Notable Changes
 
+- **2026-02-22**: Added containerized FreePBX telephony platform to voip namespace (MariaDB backend, ExternalSecrets, Envoy Gateway ingress)
 - **2026-02-22**: Added MariaDB Operator with MariaDB 11.7 Galera cluster (3 instances, 20Gi storage, S3 backups to Garage)
 - **2026-02-22**: Documentation audit: fixed SOPS version (3.11.0 → 3.12.1), added docs.yaml and renovate-config.yaml workflows, fixed database app listing, updated architecture namespace map
 - **2026-02-16**: Added error-pages service for Envoy Gateway with responseOverride redirects (403, 404, 500, 502, 503, 504)

--- a/docs/applications/freepbx.md
+++ b/docs/applications/freepbx.md
@@ -1,0 +1,161 @@
+# FreePBX
+
+[FreePBX](https://www.freepbx.org/) is a containerized telephony platform deployed in the `voip` namespace with a MariaDB database backend.
+
+## Architecture
+
+FreePBX runs as two complementary deployment models:
+
+1. **Containerized instance** (`b1-k3s01`) -- Kubernetes-native deployment via Helm chart in the `voip` namespace
+2. **KubeVirt VM instances** (`b1-k3s01`, `b2-k3s01`, `b3-k3s01`) -- Full Debian 12 VMs running FreePBX with Cloudflare Tunnel access
+
+### Container Deployment
+
+```
+kubernetes/apps/voip/freepbx/
+├── app/
+│   ├── helmrelease.yaml       # FreePBX container deployment
+│   ├── ocirepository.yaml     # OCI chart source (app-template)
+│   ├── externalsecret.yaml    # 1Password DB credentials
+│   └── kustomization.yaml
+├── database/
+│   ├── database.yaml          # MariaDB databases (b1_asterisk, b1_asteriskcdrdb)
+│   ├── user.yaml              # MariaDB user (freepbx)
+│   ├── grant.yaml             # Database permissions
+│   ├── externalsecret.yaml    # DB password from 1Password
+│   └── kustomization.yaml
+└── ks.yaml                    # Flux Kustomizations
+```
+
+### Configuration
+
+| Setting | Value |
+|---------|-------|
+| Image | `ghcr.io/00o-sh/fpbx-docker:latest` |
+| Helm chart | `bjw-s-labs/app-template` (OCI, v4.6.2) |
+| CPU request | 100m |
+| Memory request | 512Mi |
+| Memory limit | 2Gi |
+| URL | `freepbx.00o.sh` |
+
+### Service Ports
+
+| Port | Protocol | Purpose |
+|------|----------|---------|
+| 80 | HTTP | Web interface |
+| 443 | HTTPS | Secure web interface |
+| 8001 | HTTP | Unified Communications Portal (UCP) |
+| 8003 | HTTP | Admin interface |
+
+### Persistence
+
+| Mount | Size | Storage Class |
+|-------|------|---------------|
+| `/etc/asterisk` | 1Gi | openebs-hostpath |
+| `/var/lib/asterisk` | 5Gi | openebs-hostpath |
+| `/var/spool/asterisk` | 5Gi | openebs-hostpath |
+| `/var/log/asterisk` | emptyDir | -- |
+
+## Database
+
+FreePBX uses the MariaDB Galera cluster in the `database` namespace. Database resources are managed via MariaDB Operator CRs.
+
+### Databases
+
+| Database | Purpose |
+|----------|---------|
+| `b1_asterisk` | Main Asterisk configuration |
+| `b1_asteriskcdrdb` | Call Detail Records (CDR) |
+
+Both databases use `utf8mb4` character set with `utf8mb4_unicode_ci` collation.
+
+### Connection Details
+
+```
+Host: mariadb-primary.database.svc.cluster.local
+Port: 3306
+User: freepbx
+Max connections: 100
+```
+
+### Managed Resources
+
+The database setup uses MariaDB Operator custom resources:
+
+- **Database** -- creates `b1_asterisk` and `b1_asteriskcdrdb`
+- **User** -- creates the `freepbx` user with password from 1Password
+- **Grant** -- grants `ALL PRIVILEGES` on both databases
+
+All resources have `cleanupPolicy: Skip` to prevent accidental data loss on removal.
+
+## KubeVirt VM Instances
+
+Three FreePBX VMs run on KubeVirt for full-OS telephony deployments with Cloudflare Tunnel access.
+
+```
+kubernetes/apps/kubevirt/virtualmachines/freepbx/
+├── b1-k3s01/       # Instance 1
+├── b2-k3s01/       # Instance 2
+└── b3-k3s01/       # Instance 3
+```
+
+### VM Specifications
+
+| Instance | IP | MAC | CPU | RAM | Storage |
+|----------|----|-----|-----|-----|---------|
+| b1-k3s01 | 192.168.57.14 | 52:54:00:57:00:14 | 2 | 4Gi | 50Gi NFS |
+| b2-k3s01 | 192.168.57.15 | 52:54:00:57:00:15 | 2 | 4Gi | 50Gi NFS |
+| b3-k3s01 | 192.168.57.16 | 52:54:00:57:00:16 | 2 | 4Gi | 50Gi NFS |
+
+### VM Features
+
+- **Base image**: Debian 12 (containerdisks)
+- **Network**: Macvtap with static IP (direct L2 access)
+- **Live migration**: Enabled (NFS storage + evictionStrategy)
+- **DNS**: `{instance}.00o.sh` via external-dns
+- **Cloud-init provisioning**:
+    - FreePBX installation via `sng_freepbx_debian_install.sh`
+    - Cloudflare Tunnel (`cloudflared`) for secure external access
+    - SSH key and user account setup
+    - qemu-guest-agent for VM management
+
+### VM Management
+
+```sh
+# Via virtctl
+virtctl console freepbx-b1-k3s01
+virtctl start freepbx-b1-k3s01
+virtctl stop freepbx-b1-k3s01
+virtctl migrate freepbx-b1-k3s01
+
+# Via task runner
+task vm:console VM=freepbx-b1-k3s01
+task vm:start VM=freepbx-b1-k3s01
+task vm:stop VM=freepbx-b1-k3s01
+```
+
+## Dependencies
+
+### Container Deployment
+
+- MariaDB Galera cluster (`mariadb-cluster` Kustomization)
+- 1Password ExternalSecrets (`onepassword` Kustomization)
+- Envoy Gateway (`envoy-external` in network namespace)
+
+### VM Deployment
+
+- KubeVirt operator and CDI
+- Macvtap CNI plugin (network namespace)
+- 1Password ExternalSecrets (Cloudflare Tunnel token)
+
+## Flux Dependency Chain
+
+```mermaid
+graph TD
+    A[mariadb-cluster] --> B[freepbx-database]
+    C[onepassword] --> B
+    B --> D[freepbx app]
+    C --> D
+```
+
+The database resources are created in the `database` namespace first, then the FreePBX container deploys in the `voip` namespace once the databases are ready.

--- a/docs/applications/index.md
+++ b/docs/applications/index.md
@@ -22,6 +22,12 @@ All applications are deployed via Flux CD from manifests in `kubernetes/apps/`.
 | [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) | Cloudflare bypass | media |
 | [TheLounge](https://thelounge.chat/) | IRC client | media |
 
+### VoIP & Telephony
+
+| App | Description | Namespace |
+|-----|-------------|-----------|
+| [FreePBX](https://www.freepbx.org/) | Telephony platform (container + VMs) | voip |
+
 ### Networking & Testing
 
 | App | Description | Namespace |
@@ -69,6 +75,7 @@ All applications are deployed via Flux CD from manifests in `kubernetes/apps/`.
 See the detailed pages for more on each category:
 
 - [Media Stack](media.md)
+- [FreePBX](freepbx.md)
 - [Virtualization](virtualization.md)
 - [Observability](observability.md)
 - [Utilities](utilities.md)

--- a/docs/applications/virtualization.md
+++ b/docs/applications/virtualization.md
@@ -28,9 +28,9 @@
 | debian-server | Debian 13 headless | 1 | 1Gi | 50Gi NFS |
 | ubuntu-server | Ubuntu | 1 | 1Gi | varies |
 | windows-server | Windows Server 2022 | 2 | 2Gi | 60Gi NFS |
-| freepbx-b1-k3s01 | FreePBX | varies | varies | NFS |
-| freepbx-b2-k3s01 | FreePBX | varies | varies | NFS |
-| freepbx-b3-k3s01 | FreePBX | varies | varies | NFS |
+| freepbx-b1-k3s01 | Debian 12 + [FreePBX](freepbx.md) | 2 | 4Gi | 50Gi NFS |
+| freepbx-b2-k3s01 | Debian 12 + [FreePBX](freepbx.md) | 2 | 4Gi | 50Gi NFS |
+| freepbx-b3-k3s01 | Debian 12 + [FreePBX](freepbx.md) | 2 | 4Gi | 50Gi NFS |
 
 ## Storage
 

--- a/docs/infrastructure/databases.md
+++ b/docs/infrastructure/databases.md
@@ -118,6 +118,17 @@ The operator is installed via two separate HelmReleases from the `helm.mariadb.c
 
 The operator includes Prometheus metrics via ServiceMonitor and cert-manager webhook integration.
 
+### FreePBX Databases
+
+The MariaDB cluster hosts [FreePBX](../applications/freepbx.md) databases managed via operator CRs in `kubernetes/apps/voip/freepbx/database/`:
+
+| Resource | Name | Purpose |
+|----------|------|---------|
+| Database | `b1_asterisk` | Main Asterisk configuration |
+| Database | `b1_asteriskcdrdb` | Call Detail Records |
+| User | `freepbx` | Application user (max 100 connections) |
+| Grant | `ALL PRIVILEGES` | Full access on both databases |
+
 ## Dragonfly
 
 [Dragonfly](https://www.dragonflydb.io/) is a modern Redis-compatible in-memory datastore:

--- a/kubernetes/apps/voip/freepbx/app/externalsecret.yaml
+++ b/kubernetes/apps/voip/freepbx/app/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: freepbx
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: freepbx-secret
+    template:
+      data:
+        DB_PASS: "{{ .FREEPBX_DB_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: freepbx

--- a/kubernetes/apps/voip/freepbx/app/helmrelease.yaml
+++ b/kubernetes/apps/voip/freepbx/app/helmrelease.yaml
@@ -23,8 +23,8 @@ spec:
               DB_HOST: mariadb-primary.database.svc.cluster.local
               DB_PORT: "3306"
               DB_USER: freepbx
-              DB_NAME: asterisk
-              DB_CDR_NAME: asteriskcdrdb
+              DB_NAME: b1_asterisk
+              DB_CDR_NAME: b1_asteriskcdrdb
               DB_PASS:
                 valueFrom:
                   secretKeyRef:

--- a/kubernetes/apps/voip/freepbx/app/helmrelease.yaml
+++ b/kubernetes/apps/voip/freepbx/app/helmrelease.yaml
@@ -1,0 +1,128 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: freepbx
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: freepbx
+  interval: 1h
+  values:
+    controllers:
+      freepbx:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/00o-sh/fpbx-docker
+              tag: latest
+            env:
+              DB_HOST: mariadb-primary.database.svc.cluster.local
+              DB_PORT: "3306"
+              DB_USER: freepbx
+              DB_NAME: asterisk
+              DB_CDR_NAME: asteriskcdrdb
+              DB_PASS:
+                valueFrom:
+                  secretKeyRef:
+                    name: freepbx-secret
+                    key: DB_PASS
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 80
+                  initialDelaySeconds: 120
+                  periodSeconds: 30
+                  timeoutSeconds: 10
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: 80
+                  initialDelaySeconds: 120
+                  periodSeconds: 10
+                  timeoutSeconds: 10
+                  failureThreshold: 5
+            resources:
+              requests:
+                cpu: 100m
+                memory: 512Mi
+              limits:
+                memory: 2Gi
+
+    service:
+      app:
+        controller: freepbx
+        ports:
+          http:
+            port: 80
+          https:
+            port: 443
+          ucp:
+            port: 8001
+          admin:
+            port: 8003
+
+    route:
+      app:
+        annotations:
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: VoIP
+          gethomepage.dev/name: FreePBX
+          gethomepage.dev/icon: freepbx.png
+          gethomepage.dev/description: Telephony Platform
+          gethomepage.dev/href: "https://freepbx.00o.sh"
+        hostnames:
+          - freepbx.00o.sh
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 80
+
+    persistence:
+      asterisk-etc:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        storageClass: openebs-hostpath
+        advancedMounts:
+          freepbx:
+            app:
+              - path: /etc/asterisk
+      asterisk-lib:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        storageClass: openebs-hostpath
+        advancedMounts:
+          freepbx:
+            app:
+              - path: /var/lib/asterisk
+      asterisk-spool:
+        type: persistentVolumeClaim
+        accessMode: ReadWriteOnce
+        size: 5Gi
+        storageClass: openebs-hostpath
+        advancedMounts:
+          freepbx:
+            app:
+              - path: /var/spool/asterisk
+      asterisk-log:
+        type: emptyDir
+        advancedMounts:
+          freepbx:
+            app:
+              - path: /var/log/asterisk

--- a/kubernetes/apps/voip/freepbx/app/kustomization.yaml
+++ b/kubernetes/apps/voip/freepbx/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/voip/freepbx/app/ocirepository.yaml
+++ b/kubernetes/apps/voip/freepbx/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: freepbx
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/voip/freepbx/database/database.yaml
+++ b/kubernetes/apps/voip/freepbx/database/database.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Database
+metadata:
+  name: freepbx-asterisk
+spec:
+  mariaDbRef:
+    name: mariadb
+  name: asterisk
+  characterSet: utf8mb4
+  collate: utf8mb4_unicode_ci
+  cleanupPolicy: Skip
+  requeueInterval: 30s
+  retryInterval: 5s
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Database
+metadata:
+  name: freepbx-asteriskcdrdb
+spec:
+  mariaDbRef:
+    name: mariadb
+  name: asteriskcdrdb
+  characterSet: utf8mb4
+  collate: utf8mb4_unicode_ci
+  cleanupPolicy: Skip
+  requeueInterval: 30s
+  retryInterval: 5s

--- a/kubernetes/apps/voip/freepbx/database/database.yaml
+++ b/kubernetes/apps/voip/freepbx/database/database.yaml
@@ -2,11 +2,11 @@
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
-  name: freepbx-asterisk
+  name: freepbx-b1-asterisk
 spec:
   mariaDbRef:
     name: mariadb
-  name: asterisk
+  name: b1_asterisk
   characterSet: utf8mb4
   collate: utf8mb4_unicode_ci
   cleanupPolicy: Skip
@@ -16,11 +16,11 @@ spec:
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
-  name: freepbx-asteriskcdrdb
+  name: freepbx-b1-asteriskcdrdb
 spec:
   mariaDbRef:
     name: mariadb
-  name: asteriskcdrdb
+  name: b1_asteriskcdrdb
   characterSet: utf8mb4
   collate: utf8mb4_unicode_ci
   cleanupPolicy: Skip

--- a/kubernetes/apps/voip/freepbx/database/externalsecret.yaml
+++ b/kubernetes/apps/voip/freepbx/database/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: freepbx-db
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: freepbx-db-secret
+    template:
+      data:
+        password: "{{ .FREEPBX_DB_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: freepbx

--- a/kubernetes/apps/voip/freepbx/database/grant.yaml
+++ b/kubernetes/apps/voip/freepbx/database/grant.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Grant
+metadata:
+  name: freepbx-asterisk
+spec:
+  mariaDbRef:
+    name: mariadb
+  privileges:
+    - "ALL PRIVILEGES"
+  database: asterisk
+  table: "*"
+  username: freepbx
+  host: "%"
+  grantOption: false
+  cleanupPolicy: Skip
+  requeueInterval: 30s
+  retryInterval: 5s
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Grant
+metadata:
+  name: freepbx-asteriskcdrdb
+spec:
+  mariaDbRef:
+    name: mariadb
+  privileges:
+    - "ALL PRIVILEGES"
+  database: asteriskcdrdb
+  table: "*"
+  username: freepbx
+  host: "%"
+  grantOption: false
+  cleanupPolicy: Skip
+  requeueInterval: 30s
+  retryInterval: 5s

--- a/kubernetes/apps/voip/freepbx/database/grant.yaml
+++ b/kubernetes/apps/voip/freepbx/database/grant.yaml
@@ -2,13 +2,13 @@
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
-  name: freepbx-asterisk
+  name: freepbx-b1-asterisk
 spec:
   mariaDbRef:
     name: mariadb
   privileges:
     - "ALL PRIVILEGES"
-  database: asterisk
+  database: b1_asterisk
   table: "*"
   username: freepbx
   host: "%"
@@ -20,13 +20,13 @@ spec:
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
-  name: freepbx-asteriskcdrdb
+  name: freepbx-b1-asteriskcdrdb
 spec:
   mariaDbRef:
     name: mariadb
   privileges:
     - "ALL PRIVILEGES"
-  database: asteriskcdrdb
+  database: b1_asteriskcdrdb
   table: "*"
   username: freepbx
   host: "%"

--- a/kubernetes/apps/voip/freepbx/database/kustomization.yaml
+++ b/kubernetes/apps/voip/freepbx/database/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./database.yaml
+  - ./user.yaml
+  - ./grant.yaml

--- a/kubernetes/apps/voip/freepbx/database/user.yaml
+++ b/kubernetes/apps/voip/freepbx/database/user.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: User
+metadata:
+  name: freepbx
+spec:
+  mariaDbRef:
+    name: mariadb
+  name: freepbx
+  passwordSecretKeyRef:
+    name: freepbx-db-secret
+    key: password
+  maxUserConnections: 100
+  host: "%"
+  cleanupPolicy: Skip
+  requeueInterval: 30s
+  retryInterval: 5s

--- a/kubernetes/apps/voip/freepbx/ks.yaml
+++ b/kubernetes/apps/voip/freepbx/ks.yaml
@@ -1,0 +1,49 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: freepbx-database
+  namespace: flux-system
+spec:
+  targetNamespace: database
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: freepbx
+  dependsOn:
+    - name: mariadb-cluster
+      namespace: database
+    - name: onepassword
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/voip/freepbx/database
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app freepbx
+  namespace: flux-system
+spec:
+  targetNamespace: voip
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: freepbx-database
+    - name: onepassword
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/voip/freepbx/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/voip/kustomization.yaml
+++ b/kubernetes/apps/voip/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: voip
+
+components:
+  - ../../components/alerts
+
+resources:
+  - ./namespace.yaml
+  - ./freepbx/ks.yaml

--- a/kubernetes/apps/voip/namespace.yaml
+++ b/kubernetes/apps/voip/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: voip
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
   - Applications:
       - Overview: applications/index.md
       - Media Stack: applications/media.md
+      - FreePBX: applications/freepbx.md
       - Virtualization: applications/virtualization.md
       - Observability: applications/observability.md
       - Utilities: applications/utilities.md


### PR DESCRIPTION
## Summary
This PR adds a complete FreePBX deployment to the Kubernetes cluster, including the VoIP application namespace, database setup, and Helm-based application configuration.

## Key Changes
- **New VoIP namespace**: Created `kubernetes/apps/voip/` directory structure with namespace definition and kustomization
- **FreePBX application**: Deployed FreePBX using Helm with the `app-template` chart, configured with:
  - HTTP/HTTPS and UCP/Admin ports exposed via Kubernetes Gateway API
  - Health checks (liveness and readiness probes)
  - Resource requests/limits (100m CPU, 512Mi-2Gi memory)
  - Homepage integration for dashboard visibility
- **Database infrastructure**: Set up MariaDB integration with:
  - Two databases (`asterisk` and `asteriskcdrdb`) with UTF-8 character set
  - Dedicated `freepbx` user with appropriate grants on both databases
  - External Secrets integration for secure password management
- **Flux CD configuration**: Added Kustomization resources with proper dependency ordering:
  - Database setup depends on MariaDB cluster and External Secrets
  - Application deployment depends on database setup
- **GitHub automation**: Updated labeler and labels configuration to support `area/voip` and `app/freepbx` labels

## Implementation Details
- Uses `ghcr.io/00o-sh/fpbx-docker:latest` container image
- Persistent volumes for Asterisk configuration, libraries, and spool directories (OpenEBS hostpath storage)
- EmptyDir for logs (non-persistent)
- Database credentials sourced from 1Password via External Secrets operator
- Ingress configured for `freepbx.00o.sh` via Envoy external gateway

https://claude.ai/code/session_01WJ6i3CJq1kNwLgDFvFoEXh