### PR TITLE
Add MariaDB cluster support to DBGate

### DIFF
--- a/kubernetes/apps/database/dbgate/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dbgate/app/helmrelease.yaml
@@ -19,7 +19,7 @@ spec:
               repository: dbgate/dbgate
               tag: 7.0.6-alpine
             env:
-              CONNECTIONS: postgres-cluster
+              CONNECTIONS: postgres-cluster,mariadb-cluster
               LABEL_postgres-cluster: Postgres Cluster
               SERVER_postgres-cluster: postgres-rw.database.svc.cluster.local
               USER_postgres-cluster: postgres
@@ -30,6 +30,16 @@ spec:
                     key: password
               PORT_postgres-cluster: "5432"
               ENGINE_postgres-cluster: postgres@dbgate-plugin-postgres
+              LABEL_mariadb-cluster: MariaDB Cluster
+              SERVER_mariadb-cluster: mariadb.database.svc.cluster.local
+              USER_mariadb-cluster: root
+              PASSWORD_mariadb-cluster:
+                valueFrom:
+                  secretKeyRef:
+                    name: mariadb-secret
+                    key: root-password
+              PORT_mariadb-cluster: "3306"
+              ENGINE_mariadb-cluster: mysql@dbgate-plugin-mysql
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/database/dbgate/ks.yaml
+++ b/kubernetes/apps/database/dbgate/ks.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   dependsOn:
     - name: cloudnative-pg
+    - name: mariadb-operator
     - name: kanidm-config
       namespace: identity
     - name: onepassword


### PR DESCRIPTION
## Summary
This PR adds MariaDB cluster connectivity to the DBGate database management interface by configuring a new database connection alongside the existing PostgreSQL cluster.

## Key Changes
- Updated DBGate environment variables to include MariaDB cluster in the `CONNECTIONS` list
- Added MariaDB cluster configuration with:
  - Server endpoint: `mariadb.database.svc.cluster.local`
  - Root user authentication via `mariadb-secret`
  - Port 3306 (standard MySQL/MariaDB port)
  - MySQL plugin engine for DBGate
- Added `mariadb-operator` as a dependency in the Kustomization spec to ensure proper deployment ordering

## Implementation Details
The MariaDB connection follows the same configuration pattern as the existing PostgreSQL cluster, using environment variables prefixed with `LABEL_`, `SERVER_`, `USER_`, `PASSWORD_`, `PORT_`, and `ENGINE_` for the `mariadb-cluster` identifier. The password is sourced from a Kubernetes secret, maintaining security best practices.

https://claude.ai/code/session_01J23pf1sZe9RZdN8LCzTdvV