### PR TITLE
Enable binary log function creators in MariaDB operator config

### DIFF
--- a/kubernetes/apps/database/mariadb-operator/cluster/mariadb.yaml
+++ b/kubernetes/apps/database/mariadb-operator/cluster/mariadb.yaml
@@ -56,6 +56,7 @@ spec:
     innodb_buffer_pool_size=256MB
     max_allowed_packet=256MB
     max_connections=200
+    log_bin_trust_function_creators=1
 
   resources:
     requests:


### PR DESCRIPTION
## Summary
Added configuration to enable binary log function creators in the MariaDB operator cluster settings.

## Key Changes
- Added `log_bin_trust_function_creators=1` to the MariaDB configuration parameters
  - This allows stored functions and triggers to be created and replicated when binary logging is enabled
  - Necessary for environments that rely on binary logging for replication or point-in-time recovery

## Implementation Details
The configuration parameter was added to the `spec.myCnf` section of the MariaDB cluster resource, alongside other critical settings like `innodb_buffer_pool_size`, `max_allowed_packet`, and `max_connections`.

https://claude.ai/code/session_01FKzonntam2w8k4khqB8Sv4