### PR TITLE
fix(voip): increase Helm timeout to 15m for FreePBX startup

### DIFF
--- a/kubernetes/apps/voip/freepbx-b1-k3s01/app/helmrelease.yaml
+++ b/kubernetes/apps/voip/freepbx-b1-k3s01/app/helmrelease.yaml
@@ -9,6 +9,7 @@ spec:
     kind: OCIRepository
     name: freepbx-b1-k3s01
   interval: 1h
+  timeout: 15m
   values:
     controllers:
       freepbx-b1-k3s01:

--- a/kubernetes/apps/voip/freepbx-b2-k3s01/app/helmrelease.yaml
+++ b/kubernetes/apps/voip/freepbx-b2-k3s01/app/helmrelease.yaml
@@ -9,6 +9,7 @@ spec:
     kind: OCIRepository
     name: freepbx-b2-k3s01
   interval: 1h
+  timeout: 15m
   values:
     controllers:
       freepbx-b2-k3s01:

--- a/kubernetes/apps/voip/freepbx-b3-k3s01/app/helmrelease.yaml
+++ b/kubernetes/apps/voip/freepbx-b3-k3s01/app/helmrelease.yaml
@@ -9,6 +9,7 @@ spec:
     kind: OCIRepository
     name: freepbx-b3-k3s01
   interval: 1h
+  timeout: 15m
   values:
     controllers:
       freepbx-b3-k3s01:


### PR DESCRIPTION
The readiness probe has initialDelaySeconds: 520 (8.7m) but the default Helm upgrade timeout is only 5m, causing every upgrade to fail with context deadline exceeded and trigger a rollback.

https://claude.ai/code/session_013WY2TMhyVAQDNrohTob4pa