### PR TITLE
fix(kubernetes): fix multi-cluster variable scoping for SOPS_AGE_KEY_…

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -4,8 +4,8 @@
 
 [env]
 _.python.venv = { path = "{{config_root}}/.venv", create = true }
-KUBECONFIG = "{{config_root}}/kubeconfig"
-SOPS_AGE_KEY_FILE = "{{config_root}}/age.key"
+KUBECONFIG = "{{config_root}}/clusters/3226/kubeconfig"
+SOPS_AGE_KEY_FILE = "{{config_root}}/clusters/3226/age.key"
 TALOSCONFIG = "{{config_root}}/talos/clusterconfig/talosconfig"
 
 [tools]

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -17,10 +17,12 @@ vars:
   TALOS_DIR: '{{.ROOT_DIR}}/talos'
   PRIVATE_DIR: '{{.ROOT_DIR}}/.private'
   TALOSCONFIG: '{{.ROOT_DIR}}/talos/clusterconfig/talosconfig'
-
-env:
   KUBECONFIG: '{{.CLUSTER_DIR}}/kubeconfig'
   SOPS_AGE_KEY_FILE: '{{.CLUSTER_DIR}}/age.key'
+
+env:
+  KUBECONFIG: '{{.KUBECONFIG}}'
+  SOPS_AGE_KEY_FILE: '{{.SOPS_AGE_KEY_FILE}}'
   TALOSCONFIG: '{{.TALOSCONFIG}}'
 
 includes:


### PR DESCRIPTION
…FILE and KUBECONFIG

Move SOPS_AGE_KEY_FILE and KUBECONFIG from env-only to vars (with env referencing vars) so {{.SOPS_AGE_KEY_FILE}} template expressions resolve correctly in included subtasks. Update .mise.toml defaults to use clusters/3226/ paths instead of root-level paths.

https://claude.ai/code/session_0172ovxPK3wmDJDiPsyYbbF1