### PR TITLE
fix(kubernetes): add service aliases for UI Bakery internal nginx ups…

### DIFF
--- a/kubernetes/apps/ui-bakery/ui-bakery/app/helmrelease.yaml
+++ b/kubernetes/apps/ui-bakery/ui-bakery/app/helmrelease.yaml
@@ -22,7 +22,7 @@ spec:
             env:
               UI_BAKERY_APP_SERVER_NAME: https://uibakery.00o.sh
               UI_BAKERY_DB_HOST: mariadb-primary.database.svc.cluster.local
-              UI_BAKERY_INTERNAL_API_URL: http://ui-bakery-backend:8080
+              UI_BAKERY_INTERNAL_API_URL: http://bakery-back:8080
             envFrom:
               - secretRef:
                   name: ui-bakery-secret
@@ -53,7 +53,7 @@ spec:
             env:
               UI_BAKERY_APP_SERVER_NAME: https://uibakery.00o.sh
               UI_BAKERY_DB_HOST: mariadb-primary.database.svc.cluster.local
-              UI_BAKERY_INTERNAL_API_URL: http://ui-bakery-backend:8080
+              UI_BAKERY_INTERNAL_API_URL: http://bakery-back:8080
             envFrom:
               - secretRef:
                   name: ui-bakery-secret
@@ -93,7 +93,7 @@ spec:
             env:
               UI_BAKERY_APP_SERVER_NAME: https://uibakery.00o.sh
               UI_BAKERY_DB_HOST: mariadb-primary.database.svc.cluster.local
-              UI_BAKERY_INTERNAL_API_URL: http://ui-bakery-backend:8080
+              UI_BAKERY_INTERNAL_API_URL: http://bakery-back:8080
             envFrom:
               - secretRef:
                   name: ui-bakery-secret
@@ -133,7 +133,7 @@ spec:
             env:
               UI_BAKERY_APP_SERVER_NAME: https://uibakery.00o.sh
               UI_BAKERY_DB_HOST: mariadb-primary.database.svc.cluster.local
-              UI_BAKERY_INTERNAL_API_URL: http://ui-bakery-backend:8080
+              UI_BAKERY_INTERNAL_API_URL: http://bakery-back:8080
             envFrom:
               - secretRef:
                   name: ui-bakery-secret
@@ -164,7 +164,7 @@ spec:
             env:
               UI_BAKERY_APP_SERVER_NAME: https://uibakery.00o.sh
               UI_BAKERY_DB_HOST: mariadb-primary.database.svc.cluster.local
-              UI_BAKERY_INTERNAL_API_URL: http://ui-bakery-backend:8080
+              UI_BAKERY_INTERNAL_API_URL: http://bakery-back:8080
             envFrom:
               - secretRef:
                   name: ui-bakery-secret
@@ -204,7 +204,7 @@ spec:
             env:
               UI_BAKERY_APP_SERVER_NAME: https://uibakery.00o.sh
               UI_BAKERY_DB_HOST: mariadb-primary.database.svc.cluster.local
-              UI_BAKERY_INTERNAL_API_URL: http://ui-bakery-backend:8080
+              UI_BAKERY_INTERNAL_API_URL: http://bakery-back:8080
             envFrom:
               - secretRef:
                   name: ui-bakery-secret
@@ -235,7 +235,7 @@ spec:
             env:
               UI_BAKERY_APP_SERVER_NAME: https://uibakery.00o.sh
               UI_BAKERY_DB_HOST: mariadb-primary.database.svc.cluster.local
-              UI_BAKERY_INTERNAL_API_URL: http://ui-bakery-backend:8080
+              UI_BAKERY_INTERNAL_API_URL: http://bakery-back:8080
             envFrom:
               - secretRef:
                   name: ui-bakery-secret

--- a/kubernetes/apps/ui-bakery/ui-bakery/app/kustomization.yaml
+++ b/kubernetes/apps/ui-bakery/ui-bakery/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./externalsecret.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml
+  - ./services.yaml

--- a/kubernetes/apps/ui-bakery/ui-bakery/app/services.yaml
+++ b/kubernetes/apps/ui-bakery/ui-bakery/app/services.yaml
@@ -1,0 +1,62 @@
+---
+# Alias services mapping UI Bakery's original service names to app-template generated names.
+# The gateway container (nginx) has these names hardcoded in its config.
+apiVersion: v1
+kind: Service
+metadata:
+  name: bakery-back
+spec:
+  type: ExternalName
+  externalName: ui-bakery-backend.ui-bakery.svc.cluster.local
+  ports:
+    - port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: automation
+spec:
+  type: ExternalName
+  externalName: ui-bakery-automation.ui-bakery.svc.cluster.local
+  ports:
+    - port: 4000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: datasource
+spec:
+  type: ExternalName
+  externalName: ui-bakery-datasource.ui-bakery.svc.cluster.local
+  ports:
+    - port: 6060
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: python-runtime
+spec:
+  type: ExternalName
+  externalName: ui-bakery-python-runtime.ui-bakery.svc.cluster.local
+  ports:
+    - port: 5050
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bakery-front
+spec:
+  type: ExternalName
+  externalName: ui-bakery-bakery-front.ui-bakery.svc.cluster.local
+  ports:
+    - port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: workbench-front
+spec:
+  type: ExternalName
+  externalName: ui-bakery-workbench-front.ui-bakery.svc.cluster.local
+  ports:
+    - port: 8080


### PR DESCRIPTION
…treams

The gateway container has service names hardcoded in its nginx config (bakery-back, automation, datasource, etc.). Add ExternalName services mapping those original names to app-template's prefixed service names (ui-bakery-backend, ui-bakery-automation, etc.). Also restore UI_BAKERY_INTERNAL_API_URL to http://bakery-back:8080 to match.

https://claude.ai/code/session_01Rzc4F5mm8Wa2N34zkm27Pr