### PR TITLE
fix(kubernetes): use hardcoded db name/user 'bakery' for UI Bakery

### DIFF
--- a/kubernetes/apps/ui-bakery/ui-bakery/database/database.yaml
+++ b/kubernetes/apps/ui-bakery/ui-bakery/database/database.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   mariaDbRef:
     name: mariadb
-  name: ui_bakery
+  name: bakery
   characterSet: utf8mb4
   collate: utf8mb4_unicode_ci
   cleanupPolicy: Skip

--- a/kubernetes/apps/ui-bakery/ui-bakery/database/grant.yaml
+++ b/kubernetes/apps/ui-bakery/ui-bakery/database/grant.yaml
@@ -8,9 +8,9 @@ spec:
     name: mariadb
   privileges:
     - "ALL PRIVILEGES"
-  database: ui_bakery
+  database: bakery
   table: "*"
-  username: ui_bakery
+  username: bakery
   host: "%"
   grantOption: false
   cleanupPolicy: Skip

--- a/kubernetes/apps/ui-bakery/ui-bakery/database/user.yaml
+++ b/kubernetes/apps/ui-bakery/ui-bakery/database/user.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   mariaDbRef:
     name: mariadb
-  name: ui_bakery
+  name: bakery
   passwordSecretKeyRef:
     name: ui-bakery-db-secret
     key: password


### PR DESCRIPTION
UI Bakery backend hardcodes the MySQL database name and username as 'bakery' — not configurable via env vars. Change MariaDB Database, User, and Grant CRs to provision the 'bakery' db and user.

https://claude.ai/code/session_01Rzc4F5mm8Wa2N34zkm27Pr