### PR TITLE
fix(kubernetes): rename db CRs to force recreation with bakery user/db

### DIFF
--- a/kubernetes/apps/ui-bakery/ui-bakery/database/database.yaml
+++ b/kubernetes/apps/ui-bakery/ui-bakery/database/database.yaml
@@ -2,7 +2,7 @@
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
-  name: ui-bakery
+  name: ui-bakery-bakery
 spec:
   mariaDbRef:
     name: mariadb

--- a/kubernetes/apps/ui-bakery/ui-bakery/database/grant.yaml
+++ b/kubernetes/apps/ui-bakery/ui-bakery/database/grant.yaml
@@ -2,7 +2,7 @@
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
-  name: ui-bakery
+  name: ui-bakery-bakery
 spec:
   mariaDbRef:
     name: mariadb

--- a/kubernetes/apps/ui-bakery/ui-bakery/database/user.yaml
+++ b/kubernetes/apps/ui-bakery/ui-bakery/database/user.yaml
@@ -2,7 +2,7 @@
 apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
-  name: ui-bakery
+  name: ui-bakery-bakery
 spec:
   mariaDbRef:
     name: mariadb


### PR DESCRIPTION
MariaDB CR spec.name is immutable. Rename metadata.name on Database, User, and Grant CRs from 'ui-bakery' to 'ui-bakery-bakery' so Flux creates new resources rather than patching in-place. Old CRs are pruned (cleanupPolicy: Skip leaves the old ui_bakery MySQL objects unmanaged).

https://claude.ai/code/session_01Rzc4F5mm8Wa2N34zkm27Pr