### PR TITLE
fix(media): remove RECYCLARR_DATA_DIR to fix cross-device link migration error

### DIFF
--- a/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/recyclarr/app/helmrelease.yaml
@@ -25,8 +25,6 @@ spec:
             image:
               repository: ghcr.io/recyclarr/recyclarr
               tag: 8.3.2@sha256:55afe316d3e4e4e3b9120cef7c79436b1b5311f6a18d4ef4b7653e720499c90a
-            env:
-              RECYCLARR_DATA_DIR: /tmp
             envFrom:
               - secretRef:
                   name: "{{ .Release.Name }}-secret"


### PR DESCRIPTION
Recyclarr's internal migration from /config/cache to /config/state fails
with EXDEV (cross-device link) because RECYCLARR_DATA_DIR=/tmp points to
an emptyDir on a different filesystem than the /config PVC. Removing the
env var lets Recyclarr use the default /config directory for its data,
keeping all migration paths on the same filesystem.

https://claude.ai/code/session_01H4UmsMTAfCqQ8HzuSTeMfK