### PR TITLE
fix(kubernetes): add cache to 1Password SDK ClusterSecretStore

### DIFF
--- a/kubernetes/apps/external-secrets/onepassword/app/clustersecretstore.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/app/clustersecretstore.yaml
@@ -13,3 +13,6 @@ spec:
           name: onepassword-secret
           namespace: external-secrets
           key: token
+      cache:
+        ttl: 5m
+        maxSize: 100


### PR DESCRIPTION
The onepasswordSDK provider was hitting 1Password API rate limits during
store validation (list vaults), creating a self-reinforcing failure loop
where all 87+ ExternalSecrets remained in SecretSyncedError. Adding
client-side caching (5m TTL, 100 entries) reduces API calls by caching
vault lookups and secret reads.

https://claude.ai/code/session_01HKNJLDU7f81xkCGJ8eS31e