### PR TITLE
Add RUST_LOG environment variable to kguardian controller

### DIFF
--- a/kubernetes/apps/kube-system/kguardian/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/kguardian/app/helmrelease.yaml
@@ -61,6 +61,15 @@ spec:
                           name: kguardian-secret
           - target:
               kind: Deployment
+              name: kguardian-controller
+            patch: |
+              - op: add
+                path: /spec/template/spec/containers/0/env/-
+                value:
+                  name: RUST_LOG
+                  value: "kguardian::pod_reconciler=debug,kguardian=info"
+          - target:
+              kind: Deployment
               name: kguardian-database
             patch: |
               - op: replace


### PR DESCRIPTION
## Summary
Added debug logging configuration to the kguardian controller deployment via a Kustomize patch in the Helm release manifest.

## Key Changes
- Added a new Kustomize patch targeting the `kguardian-controller` Deployment
- Configured `RUST_LOG` environment variable with debug-level logging for the pod reconciler module while keeping general kguardian logging at info level
- This enables more detailed logging for troubleshooting pod reconciliation issues while maintaining reasonable log verbosity for other components

## Implementation Details
- The patch uses JSON Patch (RFC 6902) to append the environment variable to the container's env list
- Log level configuration: `kguardian::pod_reconciler=debug,kguardian=info`
- This follows the existing pattern of environment variable injection used for the kguardian-secret in the same manifest

https://claude.ai/code/session_01DvQiQSAxo4JfnbaPLsZPBe