### PR TITLE
fix(observability): correct kguardian controller patch target and mer…

### DIFF
--- a/kubernetes/apps/kube-system/kguardian/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/kguardian/app/helmrelease.yaml
@@ -60,14 +60,21 @@ spec:
                       - secretRef:
                           name: kguardian-secret
           - target:
-              kind: Deployment
+              kind: DaemonSet
               name: kguardian-controller
             patch: |
-              - op: add
-                path: /spec/template/spec/containers/0/env/-
-                value:
-                  name: RUST_LOG
-                  value: "kguardian::pod_reconciler=debug,kguardian=info"
+              apiVersion: apps/v1
+              kind: DaemonSet
+              metadata:
+                name: kguardian-controller
+              spec:
+                template:
+                  spec:
+                    containers:
+                      - name: controller
+                        env:
+                          - name: RUST_LOG
+                            value: "kguardian::pod_reconciler=debug,kguardian=info"
           - target:
               kind: Deployment
               name: kguardian-database


### PR DESCRIPTION
…ge strategy

- Change target kind from Deployment to DaemonSet (kguardian-controller is a DaemonSet, not a Deployment)
- Switch from JSON patch (env/-) to strategic merge patch to safely add RUST_LOG without failing when no env array exists on the container

https://claude.ai/code/session_01DvQiQSAxo4JfnbaPLsZPBe