### PR TITLE
fix(talos): disable forwardKubeDNSToHost in hostDNS feature

### DIFF
--- a/talos/patches/global/machine-kubelet.yaml
+++ b/talos/patches/global/machine-kubelet.yaml
@@ -1,5 +1,7 @@
 machine:
   features:
+    hostDNS:
+      forwardKubeDNSToHost: false
     kubernetesTalosAPIAccess:
       allowedKubernetesNamespaces:
         - system-upgrade


### PR DESCRIPTION
Prevents Talos from forwarding kube-dns queries to the host resolver, allowing Cilium and cluster DNS to handle resolution independently.

https://claude.ai/code/session_01DvQiQSAxo4JfnbaPLsZPBe