### PR TITLE
fix(talos): disable EEE on igc NIC for singlenodemaster

### DIFF
--- a/talos/patches/singlenodemaster/machine-kernel.yaml
+++ b/talos/patches/singlenodemaster/machine-kernel.yaml
@@ -1,0 +1,6 @@
+machine:
+  kernel:
+    modules:
+      - name: igc
+        parameters:
+          - disable_eee=1

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -38,6 +38,8 @@ nodes:
             - siderolabs/nfsd
             - siderolabs/nfsrahead
     controlPlane: true
+    patches:
+      - "@./patches/singlenodemaster/machine-kernel.yaml"
 
     networkInterfaces:
       - interface: bond0


### PR DESCRIPTION
Adds options igc disable_eee=1 via kernel module parameter patch to fix network instability on the Intel I225/I226 NIC.

https://claude.ai/code/session_01DvQiQSAxo4JfnbaPLsZPBe