### PR TITLE
Add local-hostpath directory creation to machine configuration

### DIFF
--- a/talos/patches/global/machine-files.yaml
+++ b/talos/patches/global/machine-files.yaml
@@ -8,3 +8,6 @@ machine:
         [plugins."io.containerd.cri.v1.runtime"]
           cdi_spec_dirs = ["/var/cdi/static", "/var/cdi/dynamic"]
           device_ownership_from_security_context = true
+    - op: create
+      path: /var/mnt/local-hostpath/.keep
+      content: ""


### PR DESCRIPTION
## Summary
This change adds a new file creation operation to the Talos machine configuration to ensure the `/var/mnt/local-hostpath/` directory exists on the system.

## Key Changes
- Added a new `create` operation in the machine files patch that creates an empty `.keep` file at `/var/mnt/local-hostpath/.keep`
- This ensures the parent directory `/var/mnt/local-hostpath/` is created during machine initialization

## Implementation Details
The change uses Talos's machine configuration patching mechanism to create a placeholder file (`.keep`) in the local-hostpath directory. This is a common pattern to ensure a directory structure exists, as git and many version control systems don't track empty directories. The empty content string ensures only the directory structure is created without any actual file data.

https://claude.ai/code/session_014jcdEQKcLby8iZwcqVARUH