### PR TITLE
Add GitHub Actions runner for Amber Security Inc

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/ambersecurityinc/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/ambersecurityinc/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: ambersecurityinc-runner
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: ambersecurityinc-runner-secret
+    template:
+      data:
+        github_app_id: '{{ .ACTIONS_RUNNER_APP_ID }}'
+        github_app_installation_id: '{{ .ACTIONS_RUNNER_INSTALLATION_ID }}'
+        github_app_private_key: '{{ .ACTIONS_RUNNER_PRIVATE_KEY }}'
+  dataFrom:
+    - extract:
+        key: actions-runner-ambersecurityinc

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/ambersecurityinc/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/ambersecurityinc/externalsecret.yaml
@@ -17,4 +17,4 @@ spec:
         github_app_private_key: '{{ .ACTIONS_RUNNER_PRIVATE_KEY }}'
   dataFrom:
     - extract:
-        key: actions-runner-ambersecurityinc
+        key: actions-runner-amber

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/ambersecurityinc/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/ambersecurityinc/helmrelease.yaml
@@ -1,0 +1,51 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name ambersecurityinc-runner
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: gha-runner-scale-set
+  interval: 1h
+  values:
+    githubConfigUrl: https://github.com/ambersecurityinc
+    githubConfigSecret: ambersecurityinc-runner-secret
+    minRunners: 1
+    maxRunners: 3
+    containerMode:
+      type: kubernetes
+      kubernetesModeWorkVolumeClaim:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: openebs-hostpath
+        resources:
+          requests:
+            storage: 25Gi
+    controllerServiceAccount:
+      name: actions-runner-controller
+      namespace: actions-runner-system
+    template:
+      spec:
+        containers:
+          - name: runner
+            image: ghcr.io/home-operations/actions-runner:2.332.0@sha256:577ec3d514700203d07a8b14ac9238e2c8bf7565969f9d3bddf5dac1c60c43b7
+            command:
+              - /home/runner/run.sh
+            env:
+              - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+                value: "false"
+              - name: NODE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: status.hostIP
+            volumeMounts:
+              - mountPath: /var/run/secrets/talos.dev
+                name: talos
+                readOnly: true
+        serviceAccountName: *name
+        volumes:
+          - name: talos
+            secret:
+              secretName: *name

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/ambersecurityinc/kustomization.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/ambersecurityinc/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./ambersecurityinc
-  - ./special-winner
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/ambersecurityinc/rbac.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/ambersecurityinc/rbac.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ambersecurityinc-runner
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ambersecurityinc-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: ambersecurityinc-runner
+    namespace: actions-runner-system
+---
+apiVersion: talos.dev/v1alpha1
+kind: ServiceAccount
+metadata:
+  name: ambersecurityinc-runner
+spec:
+  roles:
+    - os:admin


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions runner configuration for Amber Security Inc organization, enabling self-hosted CI/CD capabilities within the Kubernetes cluster.

## Key Changes
- **HelmRelease**: Deployed `gha-runner-scale-set` chart with:
  - Auto-scaling configuration (1-3 runners)
  - Kubernetes container mode with 25Gi persistent storage
  - Custom runner image with Talos integration
  - Environment variables for job container requirements and node IP discovery

- **RBAC Configuration**: 
  - Created ServiceAccount for the runner
  - Granted cluster-admin ClusterRole permissions
  - Added Talos os:admin role for system-level access

- **External Secret**: 
  - Integrated with OnePassword secret store
  - Configured to fetch GitHub App credentials (ID, installation ID, and private key)
  - Maps secrets to the runner authentication configuration

- **Kustomization**: Updated parent kustomization to include the new ambersecurityinc runner resources

## Implementation Details
- Runner uses a pinned container image with SHA256 digest for reproducibility
- Mounts Talos secrets for privileged operations
- Configured with OpenEBS hostpath storage for persistent workspace
- Follows existing runner pattern established in the cluster

https://claude.ai/code/session_012T8bquPVitxzYCt2mnHjRL