### PR TITLE
Add documentation site, utility scripts, and infrastructure updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ This document provides comprehensive guidance for AI assistants working with thi
 
 - **OS**: Talos Linux 1.12.4 (immutable Kubernetes OS)
 - **Orchestration**: Kubernetes 1.34.0
-- **GitOps**: Flux CD 2.7.5 (declarative continuous delivery)
+- **GitOps**: Flux CD 2.8.1 (declarative continuous delivery)
 - **CNI**: Cilium 1.19.0 (eBPF-based networking)
 - **Ingress**: Envoy Gateway v1.6.3 (HTTP routing)
 - **Secrets**: SOPS 3.12.1 + Age 1.3.1 encryption
@@ -89,13 +89,26 @@ special-winner/
 │   └── scripts/                   # Custom Jinja2 filters
 │       └── plugin.py              # Custom functions
 │
+├── docs/                            # MkDocs documentation site
+│   ├── index.md                    # Home page
+│   ├── architecture.md             # Architecture overview
+│   ├── getting-started/            # Setup guides
+│   ├── infrastructure/             # Infrastructure docs
+│   ├── applications/               # Application docs
+│   ├── operations/                 # Operations & troubleshooting
+│   ├── development/                # Development guides
+│   └── research/                   # Research notes
+│
 ├── scripts/                         # Utility scripts
 │   ├── bootstrap-apps.sh           # Main bootstrap script
+│   ├── generate-labels.sh          # Auto-generate GitHub labels from directory structure
+│   ├── volsync-restore-all.sh      # Mass VolSync point-in-time restore for all apps
 │   └── lib/common.sh               # Shared utilities
 │
 ├── .mise.toml                       # Development tools config
 ├── .sops.yaml                      # SOPS encryption config
 ├── makejinja.toml                 # Template rendering config
+├── mkdocs.yml                     # Documentation site config
 ├── Taskfile.yaml                  # Root task definitions
 └── README.md                        # User documentation
 ```
@@ -495,6 +508,9 @@ When adding a new Kubernetes application:
 | Tidy templates | `task template:tidy` |
 | VM console | `task vm:console VM=<name>` |
 | VM start/stop | `task vm:start VM=<name>` / `task vm:stop VM=<name>` |
+| Mass VolSync restore | `./scripts/volsync-restore-all.sh` |
+| Generate GitHub labels | `./scripts/generate-labels.sh` |
+| Build docs locally | `mkdocs build` or `mkdocs serve` |
 
 ## Renovate Automation
 
@@ -639,7 +655,7 @@ talosctl logs --nodes <ip> --insecure
 ### Current Namespaces and Applications
 
 **actions-runner-system**: GitHub Actions Infrastructure
-- actions-runner-controller (self-hosted runner controller)
+- actions-runner-controller (self-hosted runner controller with scale sets for special-winner and ambersecurityinc orgs)
 
 **cert-manager**: Certificate management
 - cert-manager
@@ -748,7 +764,7 @@ talosctl logs --nodes <ip> --insecure
 
 ## Additional Resources
 
-- **Official Docs**: See README.md for detailed user documentation
+- **Official Docs**: See [docs.00o.sh](https://docs.00o.sh) for detailed documentation (built from `docs/` directory)
 - **Community**: GitHub Discussions and Discord (Home Operations)
 - **Related Tools**:
   - [Talos Linux](https://www.talos.dev/)
@@ -766,7 +782,7 @@ talosctl logs --nodes <ip> --insecure
 This documentation applies to:
 - Talos Linux: 1.12.4
 - Kubernetes: 1.34.0
-- Flux CD: 2.7.5
+- Flux CD: 2.8.1
 - Cilium: 1.19.0
 - Helm: 4.1.1
 - Python: 3.14.3
@@ -781,6 +797,14 @@ Check `.mise.toml` for exact versions of all tools.
 
 ## Recent Notable Changes
 
+- **2026-03-07**: Added ambersecurityinc runner scale set to actions-runner-system (minRunners: 1, maxRunners: 3, 25Gi storage, 1Password integration)
+- **2026-03-07**: Added ARC Grafana monitoring dashboard for runner autoscaling metrics
+- **2026-03-07**: Added VolSync mass point-in-time restore script (`scripts/volsync-restore-all.sh`) for all 16 VolSync-backed apps
+- **2026-03-07**: Added label generation script (`scripts/generate-labels.sh`) for auto-generating GitHub label config from directory structure
+- **2026-03-07**: Added comprehensive MkDocs Material documentation site at docs.00o.sh (35 pages covering architecture, infrastructure, applications, operations, development)
+- **2026-03-07**: Flux CD updated from 2.7.5 to 2.8.1
+- **2026-03-07**: Tool updates: 1password-cli 2.30.0 → 2.32.1, helmfile 1.3.2 → 1.4.1, cue 0.15.4 → 0.16.0
+- **2026-03-07**: kube-prometheus-stack updated to 82.10.1, Kromgo to v0.8.0, n8n to 2.11.1, Recyclarr to 8.4.0
 - **2026-03-01**: Restored 1Password Connect Server for reads, added 1Password SDK ClusterSecretStore (`onepassword-sdk`) for write access via PushSecret
 - **2026-03-01**: Migrated External Secrets from 1Password Connect Server to 1Password SDK (removed connect-api/connect-sync deployment, uses service account token directly)
 - **2026-02-25**: Added UI Bakery low-code internal tool builder to ui-bakery namespace (7 microservices, MariaDB backend, ExternalSecrets, Envoy Gateway ingress at uibakery.00o.sh)
@@ -905,12 +929,17 @@ Located in `kubernetes/apps/actions-runner-system/`, this system provides self-h
 - **actions-runner-controller**: Manages GitHub Actions Runner Scale Sets
 - **runners**: Ephemeral runner pods that execute GitHub Actions workflows
 
+**Runner Scale Sets**:
+- **special-winner**: Runners for this repository's workflows
+- **ambersecurityinc**: Runners for the ambersecurityinc GitHub organization (minRunners: 1, maxRunners: 3, 25Gi storage)
+
 **How it works**:
 - Uses GitHub's official Actions Runner Controller (ARC) architecture
 - Creates on-demand runner pods for workflow jobs
 - Scales based on GitHub webhook events
 - Provides isolated execution environment with cluster access
 - Used by workflows like `image-pull.yaml` and `schemas.yaml` that need cluster access
+- Grafana dashboard for ARC monitoring (autoscaling runner set metrics)
 
 **Benefits**:
 - Access to internal cluster resources (Talosctl for image pulling)
@@ -1139,7 +1168,45 @@ Located in `kubernetes/apps/utils/homepage/`, Homepage provides a unified dashbo
 
 **Purpose**: Central entry point for accessing all deployed services with status monitoring.
 
+### VolSync Mass Restore
+
+The `scripts/volsync-restore-all.sh` script provides automated point-in-time restore for all 16 VolSync-backed applications.
+
+**Supported Apps**:
+- **Media (12)**: autobrr, bazarr, plex, prowlarr, qbittorrent, radarr, recyclarr, seerr, sonarr, tautulli, thelounge, qui
+- **Network (1)**: unifi-toolkit
+- **Observability (1)**: gatus
+- **Utils (2)**: forgejo, penpot
+
+**Workflow**:
+1. Suspends Flux Kustomizations
+2. Scales down app workloads (handles both Deployments and StatefulSets)
+3. Patches ReplicationDestinations with `restoreAsOf` timestamp and manual trigger
+4. Waits for restores to complete (20-minute timeout per app)
+5. Resumes Kustomizations on success
+
+**Usage**: Edit the `RESTORE_TIME` variable in the script (default: `2026-03-01T23:59:59Z`) and run:
+```bash
+./scripts/volsync-restore-all.sh
+```
+
+### Documentation Site
+
+The repository includes a comprehensive MkDocs Material documentation site published at [docs.00o.sh](https://docs.00o.sh).
+
+**Structure** (35 pages):
+- **Getting Started**: Prerequisites, configuration, bootstrap, post-install
+- **Infrastructure**: Talos, Flux, Cilium, Envoy, storage, databases, certs/DNS, secrets, identity/SSO
+- **Applications**: Media stack, FreePBX, virtualization, observability, utilities
+- **Operations**: Day-2 ops, backup/recovery, VM management, troubleshooting
+- **Development**: Templates, CI/CD pipelines, contributing
+- **Research**: SSO providers
+
+**Configuration**: `mkdocs.yml` at repository root
+**Build**: `mkdocs build` or pushed automatically via `docs.yaml` workflow
+**Deploy**: Cloudflare Pages (`special-winner-docs` project)
+
 ---
 
-**Last Updated**: 2026-02-25
+**Last Updated**: 2026-03-07
 **Template Source**: [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 **Operating System & Orchestration:**
 - [Talos Linux](https://github.com/siderolabs/talos) 1.12.4 - Immutable Kubernetes OS
 - [Kubernetes](https://kubernetes.io/) 1.34.0 - Container orchestration
-- [Flux CD](https://github.com/fluxcd/flux2) 2.7.5 - GitOps continuous delivery
+- [Flux CD](https://github.com/fluxcd/flux2) 2.8.1 - GitOps continuous delivery
 
 **Networking:**
 - [Cilium](https://github.com/cilium/cilium) 1.19.0 - eBPF-based CNI
@@ -55,6 +55,7 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 
 **Database:**
 - [CloudNative-PG](https://cloudnative-pg.io/) - PostgreSQL 17.7 HA cluster (3 instances)
+- [MariaDB Operator](https://github.com/mariadb-operator/mariadb-operator) - MariaDB 11.7 Galera cluster (3 instances)
 - [Dragonfly](https://www.dragonflydb.io/) - Redis-compatible in-memory datastore
 - [DBGate](https://dbgate.org/) - Database management web UI
 
@@ -97,8 +98,14 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 - [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) - Cloudflare bypass proxy
 - [TheLounge](https://thelounge.chat/) - Self-hosted IRC client
 
+**VoIP & Telephony:**
+- [FreePBX](https://www.freepbx.org/) - Containerized telephony platform (MariaDB backend)
+
+**Low-Code Platform:**
+- [UI Bakery](https://uibakery.io/) - Internal tool builder (7 microservices, MariaDB backend)
+
 **Infrastructure & Utilities:**
-- [GitHub Actions Runner Controller](https://github.com/actions/actions-runner-controller) - Self-hosted GitHub Actions runners
+- [GitHub Actions Runner Controller](https://github.com/actions/actions-runner-controller) - Self-hosted GitHub Actions runners (special-winner + ambersecurityinc scale sets)
 - [Forgejo](https://forgejo.org/) - Self-hosted Git repository service with CI/CD runners
 - [SMTP Relay](https://github.com/foxcpp/maddy) - Outbound email relay using Maddy
 - [n8n](https://n8n.io/) - Workflow automation platform
@@ -577,7 +584,7 @@ Community member [@whazor](https://github.com/whazor) created [Kubesearch](https
 - [ ] Vaultwarden (Bitwarden/1Password supplementary instance)
 - [ ] rclone CronJobs for automated cloud sync
 - [ ] Linkding (bookmark backup)
-- [ ] Migrate External Secrets from 1Password Connect to 1Password SDK (enables PushSecret for cross-namespace secret sync)
+- [x] Migrate External Secrets from 1Password Connect to 1Password SDK (enables PushSecret for cross-namespace secret sync)
 
 ### Phase 2: Test Multi-Node Features
 
@@ -665,11 +672,11 @@ If this repo is too hot to handle or too cold to hold check out these following 
 
 | Metric | Value |
 |--------|-------|
-| **Deployed Components** | 65+ applications across 17 namespaces |
+| **Deployed Components** | 70+ applications across 18 namespaces |
 | **Template Source** | [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template) |
 | **Infrastructure** | GitOps with Flux CD + Talos Linux |
 | **Documentation** | [docs.00o.sh](https://docs.00o.sh) |
-| **Last Updated** | 2026-02-22 |
+| **Last Updated** | 2026-03-07 |
 
 ---
 

--- a/docs/applications/index.md
+++ b/docs/applications/index.md
@@ -65,11 +65,17 @@ All applications are deployed via Flux CD from manifests in `kubernetes/apps/`.
 | [Fluent Bit](https://fluentbit.io/) | Log forwarding | observability |
 | [KEDA](https://keda.sh/) | Event-driven autoscaling | observability |
 
+### Low-Code Platform
+
+| App | Description | Namespace |
+|-----|-------------|-----------|
+| [UI Bakery](https://uibakery.io/) | Internal tool builder | ui-bakery |
+
 ### CI/CD
 
 | App | Description | Namespace |
 |-----|-------------|-----------|
-| Actions Runner Controller | GitHub Actions runners | actions-runner-system |
+| Actions Runner Controller | GitHub Actions runners (special-winner + ambersecurityinc scale sets) | actions-runner-system |
 | Forgejo Runner | Forgejo CI/CD runners | forgejo-runner-system |
 
 See the detailed pages for more on each category:

--- a/docs/development/ci-cd.md
+++ b/docs/development/ci-cd.md
@@ -85,12 +85,23 @@ Repository release management.
 
 ## Self-Hosted Runners
 
-Some workflows run on `special-winner-runner` (self-hosted) with cluster access:
+Some workflows run on self-hosted runners with cluster access, managed by Actions Runner Controller (ARC) in the `actions-runner-system` namespace.
+
+### Runner Scale Sets
+
+| Scale Set | Organization | Min Runners | Max Runners | Storage |
+|-----------|-------------|-------------|-------------|---------|
+| `special-winner` | 00o-sh | - | - | - |
+| `ambersecurityinc` | ambersecurityinc | 1 | 3 | 25Gi |
+
+### Workflows Using Self-Hosted Runners
 
 - `image-pull.yaml` -- Needs Talosctl for image pulling
 - `schemas.yaml` -- Needs kubectl for CRD extraction
 
-Runners are managed by Actions Runner Controller in the `actions-runner-system` namespace.
+### Monitoring
+
+An ARC Grafana dashboard is available for monitoring runner autoscaling metrics (counters, gauges, histograms) at the cluster's Grafana instance.
 
 ## Troubleshooting CI/CD
 

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -2,6 +2,25 @@
 
 Guides for developing and contributing to the cluster repository.
 
+## Utility Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/bootstrap-apps.sh` | Main cluster bootstrap |
+| `scripts/volsync-restore-all.sh` | Mass VolSync point-in-time restore for all 16 backed-up apps |
+| `scripts/generate-labels.sh` | Auto-generate `.github/labels.yaml` and `.github/labeler.yaml` from directory structure |
+
+## Documentation Site
+
+The docs site at [docs.00o.sh](https://docs.00o.sh) is built with MkDocs Material from the `docs/` directory. To preview locally:
+
+```sh
+pip install mkdocs-material
+mkdocs serve
+```
+
+Changes to `docs/` or `mkdocs.yml` on main are automatically published via the `docs.yaml` workflow.
+
 ## Pages
 
 - [Template System](templates.md) -- Jinja2 configuration templating

--- a/docs/operations/backup-recovery.md
+++ b/docs/operations/backup-recovery.md
@@ -105,6 +105,42 @@ kubectl -n <namespace> describe replicationsource <app-name>
     kubectl -n <namespace> get pods
     ```
 
+### Mass Point-in-Time Restore
+
+For disaster recovery scenarios where all VolSync-backed applications need to be restored simultaneously, use the automated mass restore script:
+
+```sh
+./scripts/volsync-restore-all.sh
+```
+
+!!! warning
+    This script restores **all 16 VolSync-backed applications** at once. Ensure you understand the implications before running it.
+
+**Supported applications (16 total):**
+
+| Namespace | Applications |
+|-----------|-------------|
+| media | autobrr, bazarr, plex, prowlarr, qbittorrent, radarr, recyclarr, seerr, sonarr, tautulli, thelounge, qui |
+| network | unifi-toolkit |
+| observability | gatus |
+| utils | forgejo, penpot |
+
+**How it works:**
+
+1. Suspends all Flux Kustomizations for the target apps
+2. Scales down workloads (handles both Deployments and StatefulSets)
+3. Patches each `ReplicationDestination` with a `restoreAsOf` timestamp and manual trigger
+4. Waits for all restores to complete (20-minute timeout per app)
+5. Resumes Flux Kustomizations on success
+
+**Configuration:** Edit the `RESTORE_TIME` variable at the top of the script to set the desired point-in-time (RFC3339 format, e.g., `2026-03-01T23:59:59Z`).
+
+**Notes:**
+
+- Handles multi-controller apps (e.g., penpot with separate frontend/backend deployments)
+- Prevents `kubectl` hangs when pods are already absent
+- Reports failures at the end with a summary of which apps failed
+
 ## PostgreSQL Backups
 
 CloudNative-PG handles PostgreSQL backups independently via the barman-cloud plugin:

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -16,6 +16,8 @@ Guides for managing the cluster day-to-day.
 | Validate K8s manifests | `task template:validate-kubernetes-config` |
 | VM console | `task vm:console VM=<name>` |
 | VM start/stop | `task vm:start VM=<name>` / `task vm:stop VM=<name>` |
+| Mass VolSync restore | `./scripts/volsync-restore-all.sh` |
+| Generate GitHub labels | `./scripts/generate-labels.sh` |
 
 ## Pages
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation infrastructure, new utility scripts for operational tasks, and updates to support additional applications and runner scale sets.

## Key Changes

### Documentation Site
- Added MkDocs Material documentation site published at `docs.00o.sh`
- Created `docs/` directory with 35 pages covering:
  - Getting Started (prerequisites, configuration, bootstrap)
  - Infrastructure (Talos, Flux, Cilium, storage, databases, secrets, identity)
  - Applications (media stack, FreePBX, virtualization, observability, utilities)
  - Operations (day-2 ops, backup/recovery, VM management, troubleshooting)
  - Development (templates, CI/CD pipelines, contributing)
  - Research (SSO providers)
- Added `mkdocs.yml` configuration at repository root
- Documentation automatically published via `docs.yaml` workflow to Cloudflare Pages

### Utility Scripts
- **`scripts/volsync-restore-all.sh`**: Automated mass point-in-time restore for all 16 VolSync-backed applications
  - Suspends Flux Kustomizations, scales down workloads, patches ReplicationDestinations with restore timestamps
  - Supports media (12 apps), network (1), observability (1), and utils (2) namespaces
  - Includes 20-minute timeout per app and failure reporting
- **`scripts/generate-labels.sh`**: Auto-generates GitHub label configuration from directory structure
  - Creates `.github/labels.yaml` and `.github/labeler.yaml`

### Infrastructure Updates
- **Actions Runner Controller**: Added `ambersecurityinc` runner scale set (minRunners: 1, maxRunners: 3, 25Gi storage, 1Password integration)
- **ARC Grafana Dashboard**: Added monitoring dashboard for runner autoscaling metrics
- **Flux CD**: Updated from 2.7.5 to 2.8.1
- **Tool Updates**: 1password-cli 2.30.0 → 2.32.1, helmfile 1.3.2 → 1.4.1, cue 0.15.4 → 0.16.0
- **Application Updates**: kube-prometheus-stack to 82.10.1, Kromgo to v0.8.0, n8n to 2.11.1, Recyclarr to 8.4.0

### New Applications
- **FreePBX**: Containerized telephony platform with MariaDB backend
- **UI Bakery**: Low-code internal tool builder (7 microservices, MariaDB backend)
- **MariaDB Operator**: MariaDB 11.7 Galera cluster (3 instances) for database workloads

### Documentation Updates
- Updated CLAUDE.md with new directory structure, task commands, and recent changes
- Updated README.md with new applications and updated component versions
- Added operational guides for mass restore and documentation site usage
- Updated CI/CD documentation with runner scale set details and ARC monitoring

## Notable Implementation Details

- Mass restore script handles both Deployments and StatefulSets, preventing kubectl hangs when pods are absent
- Documentation site uses MkDocs Material theme with automatic deployment on main branch changes
- Runner scale sets configured with organization-specific settings and storage allocations
- All 16 VolSync-backed applications catalogued with namespace organization for disaster recovery scenarios

https://claude.ai/code/session_01Prnav98bozk3URGHpGDw4Q