### PR TITLE
fix(kubernetes): set GUNICORN_WORKERS for Plane API container

### DIFF
--- a/kubernetes/apps/utils/plane/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/plane/app/helmrelease.yaml
@@ -32,6 +32,7 @@ spec:
               REDIS_URL: redis://plane-valkey:6379/0
               CELERY_BROKER_URL: amqp://plane:plane@plane-rabbitmq:5672/plane
               AWS_S3_ENDPOINT_URL: http://garage.volsync-system.svc.cluster.local:3900
+              AWS_S3_ADDRESSING_STYLE: path
               AWS_STORAGE_BUCKET_NAME: plane-uploads
               AWS_REGION: garage
             envFrom:
@@ -50,6 +51,7 @@ spec:
               REDIS_URL: redis://plane-valkey:6379/0
               CELERY_BROKER_URL: amqp://plane:plane@plane-rabbitmq:5672/plane
               AWS_S3_ENDPOINT_URL: http://garage.volsync-system.svc.cluster.local:3900
+              AWS_S3_ADDRESSING_STYLE: path
               AWS_STORAGE_BUCKET_NAME: plane-uploads
               AWS_REGION: garage
               FILE_SIZE_LIMIT: "5242880"
@@ -109,6 +111,7 @@ spec:
               REDIS_URL: redis://plane-valkey:6379/0
               CELERY_BROKER_URL: amqp://plane:plane@plane-rabbitmq:5672/plane
               AWS_S3_ENDPOINT_URL: http://garage.volsync-system.svc.cluster.local:3900
+              AWS_S3_ADDRESSING_STYLE: path
               AWS_STORAGE_BUCKET_NAME: plane-uploads
               AWS_REGION: garage
               DATABASE_URL:

--- a/kubernetes/apps/utils/plane/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/plane/app/helmrelease.yaml
@@ -54,6 +54,7 @@ spec:
               AWS_REGION: garage
               FILE_SIZE_LIMIT: "5242880"
               ENABLE_SIGNUP: "1"
+              GUNICORN_WORKERS: "2"
               DATABASE_URL:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
Plane's entrypoint script reads GUNICORN_WORKERS to pass to -w flag; leaving it unset causes gunicorn to fail with 'invalid int value: empty'.

https://claude.ai/code/session_01RRcJH7eDcq6dkATuoG6xhv