### PR TITLE
fix(kubernetes): use tcpSocket probe for plane-live (WebSocket server)

### DIFF
--- a/kubernetes/apps/utils/plane/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/plane/app/helmrelease.yaml
@@ -212,8 +212,7 @@ spec:
                 enabled: true
                 custom: true
                 spec:
-                  httpGet:
-                    path: /
+                  tcpSocket:
                     port: 3000
                   initialDelaySeconds: 15
                   periodSeconds: 10


### PR DESCRIPTION
The live service is a Hocuspocus WebSocket server - GET / returns 404 causing the httpGet liveness probe to repeatedly kill the pod. Switch to tcpSocket which just verifies the port is open.

https://claude.ai/code/session_01RRcJH7eDcq6dkATuoG6xhv