### PR TITLE
fix(kubernetes): strip /god-mode prefix before forwarding to plane-admin

### DIFF
--- a/kubernetes/apps/utils/plane/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/plane/app/helmrelease.yaml
@@ -415,6 +415,12 @@ spec:
               - path:
                   type: PathPrefix
                   value: /god-mode/
+            filters:
+              - type: URLRewrite
+                urlRewrite:
+                  path:
+                    type: ReplacePrefixMatch
+                    replacePrefixMatch: /
             backendRefs:
               - identifier: admin
                 port: 3000


### PR DESCRIPTION
The official Caddyfile strips the path prefix before proxying to admin:3000. The admin nginx container serves static files at / (root), not at /god-mode/. Without stripping, Envoy forwards /god-mode/foo to nginx which can't find the asset files, causing the god-mode setup loop.

Add URLRewrite filter on /god-mode/ route: ReplacePrefixMatch /god-mode/ → /

https://claude.ai/code/session_01RRcJH7eDcq6dkATuoG6xhv