### PR TITLE
revert(kubernetes): remove URLRewrite on /god-mode/ route

### DIFF
--- a/kubernetes/apps/utils/plane/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/plane/app/helmrelease.yaml
@@ -415,12 +415,6 @@ spec:
               - path:
                   type: PathPrefix
                   value: /god-mode/
-            filters:
-              - type: URLRewrite
-                urlRewrite:
-                  path:
-                    type: ReplacePrefixMatch
-                    replacePrefixMatch: /
             backendRefs:
               - identifier: admin
                 port: 3000


### PR DESCRIPTION
Plane admin files are served at /god-mode/ in nginx docroot — stripping the prefix causes nginx to serve its default welcome page instead. Forwarding the full path is correct.

https://claude.ai/code/session_01RRcJH7eDcq6dkATuoG6xhv