### PR TITLE
fix(utils): add SMTP email config to plane-api for god-mode setup

### DIFF
--- a/kubernetes/apps/utils/plane/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/plane/app/helmrelease.yaml
@@ -68,6 +68,12 @@ spec:
               FILE_SIZE_LIMIT: "5242880"
               ENABLE_SIGNUP: "1"
               GUNICORN_WORKERS: "2"
+              EMAIL_HOST: smtp-relay.utils.svc.cluster.local
+              EMAIL_PORT: "25"
+              EMAIL_FROM: plane@00o.sh
+              DEFAULT_FROM_EMAIL: plane@00o.sh
+              EMAIL_USE_TLS: "0"
+              EMAIL_USE_SSL: "0"
               DATABASE_URL:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
Route outbound email through the cluster smtp-relay so the god-mode initial setup magic link can be delivered.

https://claude.ai/code/session_01RRcJH7eDcq6dkATuoG6xhv