### PR TITLE
feat(github): add Renovate PR grouping for Talos and MariaDB

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -76,6 +76,23 @@
       },
     },
     {
+      description: "Talos Group",
+      groupName: "talos",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/siderolabs/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+    },
+    {
+      description: "MariaDB Group",
+      groupName: "mariadb",
+      matchPackageNames: ["/mariadb/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+    },
+    {
       description: "Group ghcr.io pin dependencies",
       matchUpdateTypes: ["pin"],
       matchDatasources: ["docker"],


### PR DESCRIPTION
Group all siderolabs/* container images into a single "talos" PR and
all mariadb/* packages (operator, CRDs, container image) into a single
"mariadb" PR to reduce PR noise.

https://claude.ai/code/session_01GEKTaqpAKzKSsjLtXDnTNy