### PR TITLE
Add self-hosted Zitadel identity platform deployment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -757,6 +757,9 @@ talosctl logs --nodes <ip> --insecure
 **voip**: VoIP and telephony
 - freepbx-b1-k3s01 (containerized FreePBX telephony platform with MariaDB backend)
 
+**zitadel**: External identity provider (SaaS development)
+- zitadel (self-hosted Zitadel identity platform at login.00o.sh, network-isolated, PostgreSQL backend, external-only access)
+
 **volsync-system**: Backup and replication
 - garage (S3-compatible storage backend)
 - kopia (backup repository)
@@ -797,6 +800,7 @@ Check `.mise.toml` for exact versions of all tools.
 
 ## Recent Notable Changes
 
+- **2026-03-19**: Added self-hosted Zitadel identity platform at login.00o.sh for SaaS development (network-isolated, external-only access, PostgreSQL backend, NetworkPolicy restricting traffic to Postgres egress and Envoy ingress only)
 - **2026-03-07**: Added ambersecurityinc runner scale set to actions-runner-system (minRunners: 1, maxRunners: 3, 25Gi storage, 1Password integration)
 - **2026-03-07**: Added ARC Grafana monitoring dashboard for runner autoscaling metrics
 - **2026-03-07**: Added VolSync mass point-in-time restore script (`scripts/volsync-restore-all.sh`) for all 16 VolSync-backed apps

--- a/kubernetes/apps/zitadel/kustomization.yaml
+++ b/kubernetes/apps/zitadel/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: zitadel
+
+components:
+  - ../../components/alerts
+
+resources:
+  - ./namespace.yaml
+  - ./zitadel/ks.yaml

--- a/kubernetes/apps/zitadel/namespace.yaml
+++ b/kubernetes/apps/zitadel/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: zitadel
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/zitadel/zitadel/app/externalsecret.yaml
+++ b/kubernetes/apps/zitadel/zitadel/app/externalsecret.yaml
@@ -1,0 +1,43 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: zitadel
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: zitadel-secret
+    template:
+      engineVersion: v2
+      data:
+        INIT_POSTGRES_DBNAME: "{{ .ZITADEL_POSTGRES_DB }}"
+        INIT_POSTGRES_HOST: postgres-rw.database.svc.cluster.local
+        INIT_POSTGRES_PORT: "5432"
+        INIT_POSTGRES_USER: "{{ .ZITADEL_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .ZITADEL_POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        masterkey: "{{ .ZITADEL_MASTERKEY }}"
+        config-yaml: |
+          Database:
+            Postgres:
+              Host: postgres-rw.database.svc.cluster.local
+              Port: 5432
+              Database: {{ .ZITADEL_POSTGRES_DB }}
+              User:
+                Username: {{ .ZITADEL_POSTGRES_USER }}
+                Password: {{ .ZITADEL_POSTGRES_PASSWORD }}
+                SSL:
+                  Mode: disable
+              Admin:
+                Username: postgres
+                Password: {{ .POSTGRES_SUPER_PASS }}
+                SSL:
+                  Mode: disable
+  dataFrom:
+    - extract:
+        key: zitadel
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/zitadel/zitadel/app/helmrelease.yaml
+++ b/kubernetes/apps/zitadel/zitadel/app/helmrelease.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: zitadel
+spec:
+  chart:
+    spec:
+      chart: zitadel
+      version: 9.26.0
+      sourceRef:
+        kind: HelmRepository
+        name: zitadel
+  interval: 1h
+  values:
+    replicaCount: 1
+
+    postgresql:
+      enabled: false
+
+    zitadel:
+      masterkeySecretName: zitadel-secret
+      configSecretName: zitadel-secret
+      configSecretKey: config-yaml
+
+      configmapConfig:
+        ExternalDomain: login.00o.sh
+        ExternalSecure: true
+        ExternalPort: 443
+        TLS:
+          Enabled: false
+
+    initJob:
+      enabled: true
+
+    gateway:
+      httpRoute:
+        enabled: true
+        parentRefs:
+          - name: envoy-external
+            namespace: network
+            sectionName: https
+        hostnames:
+          - login.00o.sh
+
+    login:
+      enabled: true
+      replicaCount: 1
+      resources:
+        requests:
+          cpu: 10m
+          memory: 64Mi
+        limits:
+          memory: 256Mi
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 1Gi
+
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      fsGroup: 1000
+
+    securityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true

--- a/kubernetes/apps/zitadel/zitadel/app/helmrepository.yaml
+++ b/kubernetes/apps/zitadel/zitadel/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: zitadel
+spec:
+  interval: 1h
+  url: https://charts.zitadel.com

--- a/kubernetes/apps/zitadel/zitadel/app/kustomization.yaml
+++ b/kubernetes/apps/zitadel/zitadel/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./helmrepository.yaml
+  - ./networkpolicy.yaml

--- a/kubernetes/apps/zitadel/zitadel/app/networkpolicy.yaml
+++ b/kubernetes/apps/zitadel/zitadel/app/networkpolicy.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: zitadel-isolation
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow traffic from Envoy Gateway only
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: network
+          podSelector:
+            matchLabels:
+              gateway.envoyproxy.io/owning-gateway-name: envoy-external
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    # Allow DNS resolution
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Allow PostgreSQL access
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: database
+          podSelector:
+            matchLabels:
+              cnpg.io/cluster: postgres
+      ports:
+        - protocol: TCP
+          port: 5432
+    # Allow intra-namespace traffic (zitadel <-> login pods)
+    - to:
+        - podSelector: {}

--- a/kubernetes/apps/zitadel/zitadel/ks.yaml
+++ b/kubernetes/apps/zitadel/zitadel/ks.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app zitadel
+  namespace: flux-system
+spec:
+  targetNamespace: zitadel
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: postgres-cluster
+      namespace: database
+    - name: onepassword
+      namespace: external-secrets
+  interval: 1h
+  path: ./kubernetes/apps/zitadel/zitadel/app
+  postBuild:
+    substitute:
+      APP: *app
+    substituteFrom:
+      - name: cluster-secrets
+        kind: Secret
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## Summary
This PR adds a complete deployment configuration for self-hosted Zitadel, an open-source identity and access management platform, to serve as an external identity provider for SaaS development at `login.00o.sh`.

## Key Changes
- **HelmRelease Configuration** (`helmrelease.yaml`): Deploys Zitadel v9.26.0 with:
  - Single replica setup with resource limits (50m CPU, 256Mi-1Gi memory)
  - External domain configuration at `login.00o.sh` with HTTPS via Envoy Gateway
  - PostgreSQL backend integration (external database, not embedded)
  - Login UI component enabled with dedicated resources
  - Metrics collection via ServiceMonitor for Prometheus integration
  - Security context enforcing non-root user (1000), read-only filesystem, and dropped capabilities

- **Network Security** (`networkpolicy.yaml`): Implements strict network isolation:
  - Ingress restricted to Envoy Gateway traffic only on port 8080
  - Egress limited to DNS (kube-dns), PostgreSQL (database cluster), and intra-namespace communication
  - Namespace-based pod selection for external gateway access

- **Secrets Management** (`externalsecret.yaml`): Integrates with External Secrets Operator:
  - Pulls Zitadel credentials from 1Password via ClusterSecretStore
  - Dynamically generates PostgreSQL connection configuration
  - Manages masterkey and database initialization parameters

- **Flux Configuration**: 
  - Kustomization resources for namespace and application deployment
  - HelmRepository reference for Zitadel chart
  - Dependency ordering (PostgreSQL cluster and External Secrets must be ready first)

- **Documentation**: Updated CLAUDE.md with Zitadel deployment details

## Notable Implementation Details
- Uses external PostgreSQL database (`postgres-rw.database.svc.cluster.local`) rather than embedded database
- Configured for external-only access through Envoy Gateway with TLS termination at gateway level
- Network policies enforce zero-trust networking with explicit allow rules
- Secrets sourced from 1Password, supporting both Zitadel-specific and CloudNative-PG credentials
- Namespace marked with `prune: disabled` annotation to prevent accidental deletion

https://claude.ai/code/session_01Xi7ADeP55D4g8q8PLrGrXH