### PR TITLE
fix(kubernetes): remove cluster-secrets dependency from zitadel kusto…

### DIFF
--- a/kubernetes/apps/zitadel/zitadel/ks.yaml
+++ b/kubernetes/apps/zitadel/zitadel/ks.yaml
@@ -20,9 +20,6 @@ spec:
   postBuild:
     substitute:
       APP: *app
-    substituteFrom:
-      - name: cluster-secrets
-        kind: Secret
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
…mization

The postBuild substituteFrom referenced cluster-secrets which doesn't exist in the zitadel namespace, causing ExternalSecret build failures.

https://claude.ai/code/session_01Xi7ADeP55D4g8q8PLrGrXH