### PR TITLE
fix(kubernetes): allow zitadel egress to kubernetes API server

### DIFF
--- a/kubernetes/apps/zitadel/zitadel/app/networkpolicy.yaml
+++ b/kubernetes/apps/zitadel/zitadel/app/networkpolicy.yaml
@@ -45,6 +45,13 @@ spec:
       ports:
         - protocol: TCP
           port: 5432
+    # Allow Kubernetes API access (init containers, service account)
+    - to:
+        - ipBlock:
+            cidr: 172.31.0.1/32
+      ports:
+        - protocol: TCP
+          port: 443
     # Allow intra-namespace traffic (zitadel <-> login pods)
     - to:
         - podSelector: {}


### PR DESCRIPTION
The NetworkPolicy was blocking egress to the K8s API (172.31.0.1:443), causing init container timeouts. Add ipBlock rule for API server access.

https://claude.ai/code/session_01Xi7ADeP55D4g8q8PLrGrXH