### PR TITLE
fix(kubernetes): target real API server endpoints in zitadel NetworkP…

### DIFF
--- a/kubernetes/apps/zitadel/zitadel/app/networkpolicy.yaml
+++ b/kubernetes/apps/zitadel/zitadel/app/networkpolicy.yaml
@@ -48,10 +48,14 @@ spec:
     # Allow Kubernetes API access (init containers, service account)
     - to:
         - ipBlock:
-            cidr: 172.31.0.1/32
+            cidr: 10.0.6.211/32
+        - ipBlock:
+            cidr: 10.0.6.212/32
+        - ipBlock:
+            cidr: 10.0.6.213/32
       ports:
         - protocol: TCP
-          port: 443
+          port: 6443
     # Allow intra-namespace traffic (zitadel <-> login pods)
     - to:
         - podSelector: {}


### PR DESCRIPTION
…olicy

Cilium with kube-proxy replacement doesn't match ipBlock rules against ClusterIPs. Use the actual API server node IPs (10.0.6.211-213:6443) instead of the Kubernetes service ClusterIP (172.31.0.1:443).

https://claude.ai/code/session_01Xi7ADeP55D4g8q8PLrGrXH