### PR TITLE
Refine Renovate config and improve system upgrade health checks

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -79,7 +79,16 @@
       description: "Talos Group",
       groupName: "talos",
       matchDatasources: ["docker"],
-      matchPackageNames: ["/siderolabs/"],
+      matchPackageNames: ["/siderolabs/installer/", "/siderolabs/talosctl/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+    },
+    {
+      description: "Kubernetes Group",
+      groupName: "kubernetes",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/siderolabs/kubelet/"],
       group: {
         commitMessageTopic: "{{{groupName}}} group",
       },

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -16,5 +16,7 @@ spec:
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource
+      description: VolSync replication sources are not synchronizing
       expr: |-
         status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+      timeout: 10m

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -13,11 +13,13 @@ spec:
   healthChecks:
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource
+      description: VolSync replication sources are not synchronizing
       expr: |-
         status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
-  # Check all nodes are ready
+      timeout: 10m
     - apiVersion: v1
       kind: Node
+      description: All nodes are ready
       expr: |
         status.conditions.filter(c, c.type == "Ready").all(c, c.status == "True")
       timeout: 10m


### PR DESCRIPTION
## Summary
This PR makes two key improvements: refining the Renovate dependency update configuration to better organize Talos and Kubernetes package updates, and enhancing system upgrade health checks with clearer descriptions and timeout configurations.

## Key Changes

- **Renovate Configuration (.renovaterc.json5)**
  - Split the generic Talos group into two more specific groups:
    - Talos group: now matches only `/siderolabs/installer/` and `/siderolabs/talosctl/` packages
    - New Kubernetes group: matches `/siderolabs/kubelet/` packages
  - This provides better granularity for managing updates to different component types

- **System Upgrade Health Checks**
  - Added descriptive labels to health check conditions for improved clarity:
    - VolSync replication source check: "VolSync replication sources are not synchronizing"
    - Node readiness check: "All nodes are ready"
  - Added missing `timeout: 10m` configuration to VolSync health checks in both Talos and Kubernetes upgrade manifests
  - Improved formatting and consistency across health check definitions

## Implementation Details
The health check improvements ensure that upgrade operations have explicit timeout constraints and clearer documentation of what each check validates, making troubleshooting and monitoring more straightforward.

https://claude.ai/code/session_018f4AHK7HzXKhPsCjuBQKfb