### PR TITLE
Add RustDesk remote desktop server to utilities

### DIFF
--- a/kubernetes/apps/utils/kustomization.yaml
+++ b/kubernetes/apps/utils/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - ./n8n/ks.yaml
   - ./penpot/ks.yaml
   - ./plane/ks.yaml
+  - ./rustdesk/ks.yaml
   - ./smtp-relay/ks.yaml

--- a/kubernetes/apps/utils/rustdesk/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/rustdesk/app/helmrelease.yaml
@@ -1,0 +1,97 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app rustdesk
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: rustdesk
+  interval: 1h
+  values:
+    controllers:
+      rustdesk:
+        type: statefulset
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          hbbs:
+            image:
+              repository: rustdesk/rustdesk-server
+              tag: 1.1.10-3
+            command: ["hbbs"]
+            env:
+              RELAY: &relay rustdesk.00o.sh:21117
+              ENCRYPTED_ONLY: "1"
+              DB_URL: /data/db_v2.sqlite3
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+          hbbr:
+            image:
+              repository: rustdesk/rustdesk-server
+              tag: 1.1.10-3
+            command: ["hbbr"]
+            resources:
+              requests:
+                cpu: 10m
+              limits:
+                memory: 128Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+
+    service:
+      app:
+        controller: rustdesk
+        type: LoadBalancer
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: rustdesk.00o.sh
+          lbipam.cilium.io/ips: 10.0.6.21
+          gethomepage.dev/enabled: "true"
+          gethomepage.dev/group: Utilities
+          gethomepage.dev/name: RustDesk
+          gethomepage.dev/icon: rustdesk.png
+          gethomepage.dev/description: Remote Desktop
+        externalTrafficPolicy: Cluster
+        ports:
+          api:
+            port: 21114
+            protocol: TCP
+          hbbs-tcp:
+            port: 21115
+            protocol: TCP
+          hbbs-udp:
+            port: 21116
+            protocol: UDP
+          hbbr:
+            port: 21117
+            protocol: TCP
+          hbbs-web:
+            port: 21118
+            protocol: TCP
+          hbbr-web:
+            port: 21119
+            protocol: TCP
+
+    persistence:
+      data:
+        existingClaim: *app
+        advancedMounts:
+          rustdesk:
+            hbbs:
+              - path: /data
+            hbbr:
+              - path: /data

--- a/kubernetes/apps/utils/rustdesk/app/kustomization.yaml
+++ b/kubernetes/apps/utils/rustdesk/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/utils/rustdesk/app/ocirepository.yaml
+++ b/kubernetes/apps/utils/rustdesk/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: rustdesk
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/utils/rustdesk/ks.yaml
+++ b/kubernetes/apps/utils/rustdesk/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app rustdesk
+  namespace: flux-system
+spec:
+  targetNamespace: utils
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: volsync
+      namespace: volsync-system
+  interval: 1h
+  path: ./kubernetes/apps/utils/rustdesk/app
+  postBuild:
+    substitute:
+      APP: *app
+      VOLSYNC_CAPACITY: 1Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## Summary
This PR adds RustDesk, a remote desktop application, to the Kubernetes cluster as a new utility service. The deployment includes both the hbbs (ID/relay server) and hbbr (relay server) components configured as a StatefulSet with persistent storage.

## Key Changes
- **New HelmRelease**: Added `helmrelease.yaml` configuring RustDesk server deployment with:
  - StatefulSet controller with auto-reload annotations
  - Two containers: hbbs (ID server) and hbbr (relay server) from `rustdesk/rustdesk-server:1.1.10-3`
  - LoadBalancer service exposing 6 ports (API, hbbs TCP/UDP, hbbr, and web interfaces)
  - External DNS hostname: `rustdesk.00o.sh` with static IP `10.0.6.21`
  - Persistent volume mount at `/data` for database storage
  - Security context with non-root user (root) and dropped capabilities

- **OCIRepository**: Added `ocirepository.yaml` to pull the app-template Helm chart from `ghcr.io/bjw-s-labs/helm/app-template:4.6.2`

- **Kustomization**: Added `ks.yaml` to integrate RustDesk into the flux-system with:
  - VolSync component for backup/restore capabilities
  - 1Gi storage capacity allocation
  - Dependency on volsync-system

- **Integration**: Updated `kubernetes/apps/utils/kustomization.yaml` to include the new RustDesk Kustomization resource

## Notable Implementation Details
- Encrypted-only mode enabled (`ENCRYPTED_ONLY: "1"`)
- Database stored in SQLite at `/data/db_v2.sqlite3`
- Minimal resource requests (10m CPU) with 128Mi memory limits per container
- Homepage integration enabled with custom icon and description
- External traffic policy set to Cluster for LoadBalancer service

https://claude.ai/code/session_011RxRgQ8UUaEwR7wR3GB5aY