### PR TITLE
fix(utils): fix rustdesk server configuration

### DIFF
--- a/kubernetes/apps/utils/rustdesk/app/dnsendpoint.yaml
+++ b/kubernetes/apps/utils/rustdesk/app/dnsendpoint.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: rustdesk
+  annotations:
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+spec:
+  endpoints:
+    - dnsName: rustdesk.00o.sh
+      recordTTL: 300
+      recordType: A
+      targets:
+        - 10.0.6.21

--- a/kubernetes/apps/utils/rustdesk/app/helmrelease.yaml
+++ b/kubernetes/apps/utils/rustdesk/app/helmrelease.yaml
@@ -19,33 +19,25 @@ spec:
           hbbs:
             image:
               repository: rustdesk/rustdesk-server
-              tag: 1.1.10-3
+              tag: latest
             command: ["hbbs"]
             env:
-              RELAY: &relay rustdesk.00o.sh:21117
               ENCRYPTED_ONLY: "1"
-              DB_URL: /data/db_v2.sqlite3
             resources:
               requests:
                 cpu: 10m
               limits:
                 memory: 128Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities: {drop: ["ALL"]}
           hbbr:
             image:
               repository: rustdesk/rustdesk-server
-              tag: 1.1.10-3
+              tag: latest
             command: ["hbbr"]
             resources:
               requests:
                 cpu: 10m
               limits:
                 memory: 128Mi
-            securityContext:
-              allowPrivilegeEscalation: false
-              capabilities: {drop: ["ALL"]}
 
     defaultPodOptions:
       securityContext:
@@ -67,11 +59,11 @@ spec:
           gethomepage.dev/description: Remote Desktop
         externalTrafficPolicy: Cluster
         ports:
-          api:
-            port: 21114
+          hbbs-nat:
+            port: 21115
             protocol: TCP
           hbbs-tcp:
-            port: 21115
+            port: 21116
             protocol: TCP
           hbbs-udp:
             port: 21116
@@ -79,10 +71,10 @@ spec:
           hbbr:
             port: 21117
             protocol: TCP
-          hbbs-web:
+          hbbs-ws:
             port: 21118
             protocol: TCP
-          hbbr-web:
+          hbbr-ws:
             port: 21119
             protocol: TCP
 
@@ -92,6 +84,6 @@ spec:
         advancedMounts:
           rustdesk:
             hbbs:
-              - path: /data
+              - path: /root
             hbbr:
-              - path: /data
+              - path: /root

--- a/kubernetes/apps/utils/rustdesk/app/kustomization.yaml
+++ b/kubernetes/apps/utils/rustdesk/app/kustomization.yaml
@@ -3,5 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./dnsendpoint.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml


### PR DESCRIPTION
- Mount volume to /root (not /data) per official docs
- Add TCP entry for port 21116 (needs both TCP and UDP)
- Remove incorrect RELAY env var and capabilities drop
- Switch to latest image tag
- Add DNSEndpoint CRD for cloudflare-dns (non-proxied A record) since cloudflare-dns only watches crd/gateway-httproute sources

https://claude.ai/code/session_011RxRgQ8UUaEwR7wR3GB5aY