### PR TITLE
chore(kubernetes): add Renovate grouping for Plane packages

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -94,6 +94,15 @@
       },
     },
     {
+      description: "Plane Group",
+      groupName: "plane",
+      matchDatasources: ["docker"],
+      matchPackageNames: ["/makeplane/"],
+      group: {
+        commitMessageTopic: "{{{groupName}}} group",
+      },
+    },
+    {
       description: "MariaDB Operator Group",
       groupName: "mariadb-operator",
       matchDatasources: ["helm"],


### PR DESCRIPTION
Groups all makeplane/* container images (plane-backend, plane-frontend,
plane-admin, plane-space, plane-live) into a single Renovate PR.

https://claude.ai/code/session_01UwYiwa9pdTcc9K8g6JG35r