### PR TITLE
fix(ci): make dry-run validate against full CRD set

### DIFF
--- a/.github/dry-run/extract-crds.sh
+++ b/.github/dry-run/extract-crds.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Extracts CRDs from every chart referenced by kubernetes/apps/ so the
+# dry-run workflow can validate manifests against a complete schema set
+# without maintaining a duplicate chart list. Discovers:
+#   - OCIRepository (Flux v2 OCI source)
+#   - HelmRelease + HelmRepository (Flux v2 HTTP/HTTPS chart source)
+# For each unique chart it runs `helm template --include-crds` and emits
+# only resources of kind CustomResourceDefinition on stdout.
+
+set -Eeuo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+APPS_DIR="${REPO_ROOT}/kubernetes/apps"
+
+OCI_LIST="$(mktemp)"
+HELM_REPOS="$(mktemp)"
+HELM_RELEASES="$(mktemp)"
+trap 'rm -f "$OCI_LIST" "$HELM_REPOS" "$HELM_RELEASES"' EXIT
+
+log() { printf '%s\n' "$*" >&2; }
+
+# OCIRepository: url<TAB>tag (deduped, names irrelevant for CRD extraction)
+find "$APPS_DIR" -name "*.yaml" -type f -print0 \
+  | xargs -0 -I{} yq eval-all '
+      select(.kind == "OCIRepository")
+      | [.spec.url, .spec.ref.tag] | @tsv
+    ' {} 2>/dev/null \
+  | awk -F'\t' 'NF == 2 && $1 != "" && $2 != ""' \
+  | sort -u > "$OCI_LIST"
+
+# HelmRepository: namespace<TAB>name<TAB>url
+find "$APPS_DIR" -name "*.yaml" -type f -print0 \
+  | xargs -0 -I{} yq eval-all '
+      select(.kind == "HelmRepository")
+      | [.metadata.namespace // "flux-system", .metadata.name, .spec.url] | @tsv
+    ' {} 2>/dev/null \
+  | awk -F'\t' 'NF == 3 && $2 != "" && $3 != ""' \
+  | sort -u > "$HELM_REPOS"
+
+# HelmRelease (HelmRepository source): chart<TAB>version<TAB>repo-ns<TAB>repo-name (deduped)
+find "$APPS_DIR" -name "*.yaml" -type f -print0 \
+  | xargs -0 -I{} yq eval-all '
+      select(.kind == "HelmRelease" and .spec.chart.spec.sourceRef.kind == "HelmRepository")
+      | [
+          .spec.chart.spec.chart,
+          .spec.chart.spec.version,
+          .spec.chart.spec.sourceRef.namespace // .metadata.namespace // "flux-system",
+          .spec.chart.spec.sourceRef.name
+        ] | @tsv
+    ' {} 2>/dev/null \
+  | awk -F'\t' 'NF == 4 && $1 != "" && $2 != ""' \
+  | sort -u > "$HELM_RELEASES"
+
+log "Discovered $(wc -l < "$OCI_LIST") OCI charts, $(wc -l < "$HELM_REPOS") helm repos, $(wc -l < "$HELM_RELEASES") helm releases"
+
+render() {
+  local label="$1"; shift
+  local rendered err
+  err=$(mktemp)
+  if rendered=$(helm template "$@" --include-crds --no-hooks 2>"$err"); then
+    printf '%s\n' "$rendered" \
+      | yq eval-all 'select(.kind == "CustomResourceDefinition")' -
+  else
+    log "[warn] $label failed: $(head -1 "$err")"
+  fi
+  rm -f "$err"
+}
+
+# OCI charts
+while IFS=$'\t' read -r url tag; do
+  log "[oci] $url $tag"
+  render "oci/$url@$tag" crds "$url" --version "$tag"
+done < "$OCI_LIST"
+
+# HelmRepository-backed charts
+while IFS=$'\t' read -r chart version repo_ns repo_name; do
+  url=$(awk -F'\t' -v ns="$repo_ns" -v n="$repo_name" '$1 == ns && $2 == n { print $3; exit }' "$HELM_REPOS")
+  if [[ -z "$url" ]]; then
+    log "[skip] $chart: HelmRepository $repo_ns/$repo_name not found"
+    continue
+  fi
+  log "[hr]  $chart $version $url"
+  render "hr/$chart@$version" crds "$chart" --repo "$url" --version "$version"
+done < "$HELM_RELEASES"

--- a/.github/workflows/dry-run.yaml
+++ b/.github/workflows/dry-run.yaml
@@ -88,7 +88,7 @@ jobs:
           cache: false
 
       - name: Create k3d cluster
-        uses: nolar/setup-k3d-k3s@v1
+        uses: nolar/setup-k3d-k3s@62c9d1bd2bc843275c85d2e7dcd696edc1160eee # v1.1.0
         with:
           version: v1.31
           k3d-args: --no-lb --no-rollback --timeout 120s
@@ -103,12 +103,28 @@ jobs:
             kubectl create namespace "$ns" --dry-run=client -o yaml | kubectl apply -f -
           done
 
-      - name: Install CRDs from helmfile
+      - name: Install CRDs from bootstrap helmfile
         run: |
           # Extract only CRDs from helmfile output (skip instances like Alertmanager, PrometheusRule, etc.)
           helmfile --file bootstrap/helmfile.d/00-crds.yaml template --quiet \
             | yq eval-all 'select(.kind == "CustomResourceDefinition")' - \
             | kubectl apply --server-side --force-conflicts -f -
+
+      - name: Install CRDs from kubernetes/apps charts
+        env:
+          # renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api
+          GATEWAY_API_VERSION: v1.2.1
+        run: |
+          # Auto-discover every OCIRepository / HelmRepository-backed chart
+          # used in kubernetes/apps/, render --include-crds, and apply only
+          # the CustomResourceDefinitions. Avoids maintaining a separate
+          # chart list in CI - the manifests already are the source of truth.
+          ./.github/dry-run/extract-crds.sh \
+            | kubectl apply --server-side --force-conflicts -f -
+
+          # Gateway API CRDs (HTTPRoute, Gateway) - upstream YAML, no chart
+          kubectl apply --server-side --force-conflicts \
+            -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
 
       - name: Determine kustomizations to test
         id: targets
@@ -157,20 +173,18 @@ jobs:
               continue
             fi
 
-            # Server-side dry-run
-            if echo "$output" | kubectl apply --server-side --dry-run=server -f - > /dev/null 2>&1; then
+            # Server-side dry-run; capture output once so we can classify the result
+            if err=$(echo "$output" | kubectl apply --server-side --dry-run=server -f - 2>&1); then
               echo "PASS ${app}"
               PASSED=$((PASSED + 1))
+            elif echo "$err" | grep -qE 'no matches for kind|unable to recognize|ensure CRDs are installed'; then
+              # Resource type not registered in the cluster — can't validate, but not a real failure
+              echo "::warning::SKIP ${app} - missing CRDs"
+              SKIPPED=$((SKIPPED + 1))
             else
-              # Retry with client dry-run to distinguish CRD-missing from real errors
-              if echo "$output" | kubectl apply --dry-run=client -f - > /dev/null 2>&1; then
-                echo "::warning::SKIP ${app} - missing CRDs"
-                SKIPPED=$((SKIPPED + 1))
-              else
-                echo "::error::FAIL ${app}"
-                echo "$output" | kubectl apply --server-side --dry-run=server -f - 2>&1 || true
-                FAILED=$((FAILED + 1))
-              fi
+              echo "::error::FAIL ${app}"
+              echo "$err"
+              FAILED=$((FAILED + 1))
             fi
           done < /tmp/targets.txt
 


### PR DESCRIPTION
## Summary
- The `Server-Side Dry Run` workflow only installed CRDs from `bootstrap/helmfile.d/00-crds.yaml` (envoy-gateway, kube-prometheus-stack, external-dns), so any kustomization that referenced Flux, ESO, cert-manager, Grafana, CNPG, KEDA, Volsync, Dragonfly, MariaDB, Cilium, or snapshot-controller resources hit `no matches for kind` and was misclassified as a real failure (e.g. `media/thelounge/app`, `utils/teslamate/app`).
- Adds `.github/dry-run/extract-crds.sh`, which walks `kubernetes/apps/`, dedupes every `OCIRepository` and `HelmRepository`-backed `HelmRelease`, and runs `helm template --include-crds` against each chart+version pair. The repo manifests stay the single source of truth — adding a new operator chart no longer requires touching CI, and the bootstrap helmfile is unchanged.
- Workflow consumes the script output, layers Gateway API CRDs from the upstream standard-install bundle (version pinned via `# renovate: datasource=github-releases depName=kubernetes-sigs/gateway-api`), and pins `nolar/setup-k3d-k3s` to a commit SHA + version comment so Renovate tracks it the same way as `actions/checkout` and `jdx/mise-action`.
- Failure detection now treats `no matches for kind` / `unable to recognize` / `ensure CRDs are installed first` as `SKIP`, replacing the old client-dry-run fallback that also failed for unknown kinds and was always reporting `FAIL`.

## Test plan
- [ ] `Server-Side Dry Run` passes on this PR (only the workflow itself changed, so it should run in `changed` mode against the workflow file paths via `workflow_dispatch` if needed)
- [ ] After merge: re-run the dry-run on a recent failing PR (e.g. `media/thelounge` Renovate PR) and confirm it now reports `PASS` or `SKIP - missing CRDs` rather than `FAIL`
- [ ] `task bootstrap:apps` is unchanged (no edits to `bootstrap/helmfile.d/`)

https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW)_