### PR TITLE
fix(observability): escape postBuild substitution in TeslaMate datasource

### DIFF
--- a/kubernetes/apps/observability/teslamate/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/teslamate/app/grafanadashboard.yaml
@@ -31,10 +31,10 @@ spec:
     type: grafana-postgresql-datasource
     access: proxy
     url: postgres-rw.database.svc.cluster.local:5432
-    user: ${user}
-    database: ${database}
+    user: $${user}
+    database: $${database}
     secureJsonData:
-      password: ${password}
+      password: $${password}
     jsonData:
       sslmode: disable
       postgresVersion: 1700


### PR DESCRIPTION
## Summary
Fixes the post-merge `kustomize-controller` failure on `kustomization/teslamate.observability`:

```
GrafanaDatasource.grafana.integreatly.org "teslamate" is invalid:
spec.datasource.database: Invalid value: "null"
spec.datasource.user: Invalid value: "null"
```

The `cluster-apps` parent Flux Kustomization runs `postBuild.substitute` over every child manifest. Envsubst saw my `${user}` / `${database}` / `${password}` placeholders, treated them as undefined variables, and replaced them with empty strings. YAML then parsed the empty scalars as `null`, which the `GrafanaDatasource` CRD rightly rejects.

Escape them with `$${...}` so Flux leaves them verbatim. The grafana-operator's own `valuesFrom` block then substitutes them at reconcile time using `INIT_POSTGRES_USER` / `INIT_POSTGRES_DBNAME` / `INIT_POSTGRES_PASS` from `teslamate-secret`.

## Test plan
- [ ] `flux get hr -n observability teslamate` reports `Ready=True` once this is reconciled
- [ ] `kubectl -n observability get grafanadatasource teslamate -o jsonpath='{.status.conditions}'` reports a successful reconcile
- [ ] In Grafana, the `TeslaMate` datasource shows `Save & test` succeeds against `postgres-rw.database.svc.cluster.local:5432`
- [ ] Any TeslaMate dashboard renders rows (proves the credentials substituted correctly)

https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW)_