### PR TITLE
chore(voip): comment out FreePBX HelmReleases to stop reconciling

### DIFF
--- a/kubernetes/apps/voip/kustomization.yaml
+++ b/kubernetes/apps/voip/kustomization.yaml
@@ -9,6 +9,6 @@ components:
 
 resources:
   - ./namespace.yaml
-  - ./freepbx-b1-k3s01/ks.yaml
-  - ./freepbx-b2-k3s01/ks.yaml
-  - ./freepbx-b3-k3s01/ks.yaml
+  # - ./freepbx-b1-k3s01/ks.yaml
+  # - ./freepbx-b2-k3s01/ks.yaml
+  # - ./freepbx-b3-k3s01/ks.yaml


### PR DESCRIPTION
## Summary
Stops the three FreePBX VoIP HelmReleases (`freepbx-b1-k3s01`, `freepbx-b2-k3s01`, `freepbx-b3-k3s01`) from reconciling by commenting them out in `kubernetes/apps/voip/kustomization.yaml`. The app directories are intentionally left on disk so the instances can be brought back by uncommenting these three lines.

## Test plan
- [ ] After merge: `flux get ks -n flux-system | grep freepbx` shows the three Kustomizations being pruned
- [ ] `kubectl -n voip get hr` no longer lists the three FreePBX HelmReleases
- [ ] `kubernetes/apps/voip/freepbx-b{1,2,3}-k3s01/` directories still present in the repo

https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW)_