### PR TITLE
fix(observability): drop embedded mosquitto sidecar from TeslaMate

### DIFF
--- a/kubernetes/apps/observability/teslamate/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/teslamate/app/helmrelease.yaml
@@ -32,9 +32,7 @@ spec:
               VIRTUAL_HOST: teslamate.00o.sh
               CHECK_ORIGIN: "true"
               PORT: &port 4000
-              DISABLE_MQTT: "false"
-              MQTT_HOST: localhost
-              MQTT_PORT: "1883"
+              DISABLE_MQTT: "true"
               DATABASE_HOST: postgres-rw.database.svc.cluster.local
               DATABASE_PORT: "5432"
               DATABASE_NAME:
@@ -80,20 +78,6 @@ spec:
                 memory: 256Mi
               limits:
                 memory: 1Gi
-          mosquitto:
-            image:
-              repository: docker.io/library/eclipse-mosquitto
-              tag: 2.0.21@sha256:94f5a3d7deafa59fa3440d227ddad558f59d293c612138de841eec61bfa4d353
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
-            resources:
-              requests:
-                cpu: 10m
-                memory: 32Mi
-              limits:
-                memory: 128Mi
 
     defaultPodOptions:
       securityContext:
@@ -131,38 +115,7 @@ spec:
               - identifier: app
                 port: *port
 
-    configMaps:
-      mosquitto:
-        data:
-          mosquitto.conf: |
-            listener 1883
-            allow_anonymous true
-            persistence true
-            persistence_location /mosquitto/data/
-            log_dest stdout
-
     persistence:
-      mosquitto-config:
-        type: configMap
-        name: teslamate-mosquitto
-        advancedMounts:
-          teslamate:
-            mosquitto:
-              - path: /mosquitto/config/mosquitto.conf
-                subPath: mosquitto.conf
-                readOnly: true
-      mosquitto-data:
-        type: emptyDir
-        advancedMounts:
-          teslamate:
-            mosquitto:
-              - path: /mosquitto/data
-      mosquitto-log:
-        type: emptyDir
-        advancedMounts:
-          teslamate:
-            mosquitto:
-              - path: /mosquitto/log
       tmp:
         type: emptyDir
         advancedMounts:


### PR DESCRIPTION
## Summary
TeslaMate wasn't deploying because the embedded mosquitto sidecar pointed at a ConfigMap that didn't exist. Two bugs in one:

1. **Wrong ConfigMap name** — `persistence.mosquitto-config.name: teslamate-mosquitto`, but bjw-s `app-template` named the rendered ConfigMap `teslamate` (release name only, since there's a single key under `configMaps:`). The volume mount could never resolve.
2. **No MQTT broker on the cluster** — even if the sidecar mounted, there's no consumer for the topics it publishes.

MQTT is optional for TeslaMate — Postgres data, the web UI, and Grafana dashboards all work without it. The lighter fix is to drop the sidecar entirely:

- `DISABLE_MQTT: "true"`
- Remove the `mosquitto` container
- Remove the `configMaps.mosquitto` entry
- Remove the three `mosquitto-*` `persistence` volumes
- Remove `MQTT_HOST` / `MQTT_PORT` env vars

If a real MQTT broker shows up in the cluster later, point TeslaMate at it via env vars and re-enable.

## Test plan
- [ ] `flux get hr -n observability teslamate` reports `Ready=True` after reconcile
- [ ] `kubectl -n observability get pod -l app.kubernetes.io/name=teslamate` shows a single running container (`app`), no `mosquitto`
- [ ] TeslaMate web UI loads at `https://teslamate.00o.sh`
- [ ] Grafana TeslaMate dashboards still render (Postgres-backed, MQTT not required)

https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW)_