### PR TITLE
fix(observability): pre-create cube/earthdistance extensions for TeslaMate

### DIFF
--- a/docs/infrastructure/databases.md
+++ b/docs/infrastructure/databases.md
@@ -52,6 +52,84 @@ postgres-rw.database.svc.cluster.local:5432
 
 A recovery cluster definition exists at `kubernetes/apps/database/cloudnative-pg/recovery/cluster.yaml` for disaster recovery scenarios.
 
+### Onboarding a new app
+
+The repository's standard pattern is **one shared cluster, per-app database + role**, provisioned by an `init-db` initContainer using `ghcr.io/home-operations/postgres-init`. The init container reads `INIT_POSTGRES_SUPER_PASS` (from the `cloudnative-pg` 1Password item) and creates the database and a non-superuser role for the app.
+
+```yaml
+initContainers:
+  init-db:
+    image:
+      repository: ghcr.io/home-operations/postgres-init
+      tag: 18@sha256:...
+    envFrom:
+      - secretRef:
+          name: <app>-secret
+```
+
+The matching `ExternalSecret` template:
+
+```yaml
+template:
+  data:
+    INIT_POSTGRES_DBNAME: "{{ .APP_POSTGRES_DB }}"
+    INIT_POSTGRES_HOST: postgres-rw.database.svc.cluster.local
+    INIT_POSTGRES_PORT: "5432"
+    INIT_POSTGRES_USER: "{{ .APP_POSTGRES_USER }}"
+    INIT_POSTGRES_PASS: "{{ .APP_POSTGRES_PASSWORD }}"
+    INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+```
+
+Apps then connect with their own role (`DATABASE_USER`/`DATABASE_PASS`).
+
+### Apps that need PostgreSQL extensions
+
+`CREATE EXTENSION` for "trusted" extensions like `pgcrypto` or `uuid-ossp` works as a regular role, but **`cube`, `earthdistance`, `postgis`, `pg_stat_statements`, etc. require superuser**. The per-app role created by `init-db` is intentionally **not** a superuser, so any migration that tries to install these extensions will fail with:
+
+```
+ERROR 42501 (insufficient_privilege) permission denied to create extension "earthdistance"
+hint: Must be superuser to create this extension.
+```
+
+Pre-create the extensions in a second initContainer that connects as the postgres superuser. Example from TeslaMate (`kubernetes/apps/observability/teslamate/app/helmrelease.yaml`):
+
+```yaml
+initContainers:
+  init-db:
+    image:
+      repository: ghcr.io/home-operations/postgres-init
+      tag: 18@sha256:...
+    envFrom:
+      - secretRef:
+          name: teslamate-secret
+  init-extensions:
+    image:
+      repository: ghcr.io/home-operations/postgres-init
+      tag: 18@sha256:...
+    command:
+      - /bin/sh
+      - -c
+      - |
+        PGPASSWORD="$INIT_POSTGRES_SUPER_PASS" psql \
+          -h "$INIT_POSTGRES_HOST" \
+          -p "$INIT_POSTGRES_PORT" \
+          -U postgres \
+          -d "$INIT_POSTGRES_DBNAME" \
+          -v ON_ERROR_STOP=1 \
+          -c "CREATE EXTENSION IF NOT EXISTS cube;" \
+          -c "CREATE EXTENSION IF NOT EXISTS earthdistance;"
+    envFrom:
+      - secretRef:
+          name: teslamate-secret
+```
+
+Notes:
+
+- Reuse the `postgres-init` image — it already ships `psql` and matches the existing pattern.
+- Connect as **`-U postgres`**, not as the app's role, so the `CREATE EXTENSION` succeeds.
+- Use `CREATE EXTENSION IF NOT EXISTS` so the container is idempotent (Flux will reschedule it on every pod restart).
+- Set `-v ON_ERROR_STOP=1` so a failed `CREATE EXTENSION` aborts the init and surfaces the error in pod events instead of silently letting the app start with a broken schema.
+
 ## MariaDB Operator (MariaDB Galera)
 
 [MariaDB Operator](https://github.com/mariadb-operator/mariadb-operator) runs a **MariaDB 11.7** high-availability Galera cluster with 3 instances.

--- a/kubernetes/apps/observability/teslamate/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/teslamate/app/helmrelease.yaml
@@ -22,6 +22,28 @@ spec:
             envFrom:
               - secretRef:
                   name: teslamate-secret
+          init-extensions:
+            # TeslaMate's CreateGeoExtensions migration runs CREATE EXTENSION
+            # cube/earthdistance, which requires superuser. Pre-create them as
+            # the postgres superuser so the migration is a no-op.
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18@sha256:6fa1f331cddd2eb0b6afa7b8d3685c864127a81ab01c3d9400bc3ff5263a51cf
+            command:
+              - /bin/sh
+              - -c
+              - |
+                PGPASSWORD="$INIT_POSTGRES_SUPER_PASS" psql \
+                  -h "$INIT_POSTGRES_HOST" \
+                  -p "$INIT_POSTGRES_PORT" \
+                  -U postgres \
+                  -d "$INIT_POSTGRES_DBNAME" \
+                  -v ON_ERROR_STOP=1 \
+                  -c "CREATE EXTENSION IF NOT EXISTS cube;" \
+                  -c "CREATE EXTENSION IF NOT EXISTS earthdistance;"
+            envFrom:
+              - secretRef:
+                  name: teslamate-secret
         containers:
           app:
             image:


### PR DESCRIPTION
## Summary
TeslaMate aborted on first migration with:

```
TeslaMate.Repo.Migrations.CreateGeoExtensions.change/0 forward
execute "CREATE EXTENSION IF NOT EXISTS earthdistance WITH SCHEMA public"
** (Postgrex.Error) ERROR 42501 (insufficient_privilege) permission denied
   to create extension "earthdistance"
   hint: Must be superuser to create this extension.
```

The per-app `teslamate` role created by `init-db` is intentionally not a Postgres superuser, but `cube` / `earthdistance` are not "trusted" extensions and require superuser to install.

Add a second initContainer `init-extensions` that connects as the `postgres` superuser (using `INIT_POSTGRES_SUPER_PASS` from `teslamate-secret`) and runs `CREATE EXTENSION IF NOT EXISTS cube; CREATE EXTENSION IF NOT EXISTS earthdistance;` on the teslamate database. The TeslaMate migration that follows then becomes a no-op.

Also documents the pattern in `docs/infrastructure/databases.md` so future apps that need superuser-only extensions (postgis, pg_stat_statements, etc.) have a worked example, plus a short "Onboarding a new app" section that captures the standard init-db / ExternalSecret pattern that was previously undocumented.

## Test plan
- [ ] `flux get hr -n observability teslamate` reports `Ready=True`
- [ ] `kubectl -n observability logs deploy/teslamate -c init-extensions` shows `CREATE EXTENSION` succeeded twice
- [ ] `kubectl exec -n database postgres-1 -- psql -U postgres -d teslamate -c '\dx'` lists `cube` and `earthdistance`
- [ ] `kubectl -n observability logs deploy/teslamate -c app` shows the geo migration completing instead of crashing
- [ ] TeslaMate UI reachable at `https://teslamate.00o.sh` and able to render dashboards backed by the geo data

https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW)_