### PR TITLE
fix(observability): transfer cube/earthdistance function ownership to teslamate role

### DIFF
--- a/docs/infrastructure/databases.md
+++ b/docs/infrastructure/databases.md
@@ -116,8 +116,31 @@ initContainers:
           -U postgres \
           -d "$INIT_POSTGRES_DBNAME" \
           -v ON_ERROR_STOP=1 \
-          -c "CREATE EXTENSION IF NOT EXISTS cube;" \
-          -c "CREATE EXTENSION IF NOT EXISTS earthdistance;"
+          -v app_user="$INIT_POSTGRES_USER" <<'SQL'
+        CREATE EXTENSION IF NOT EXISTS cube;
+        CREATE EXTENSION IF NOT EXISTS earthdistance;
+
+        DO $do$
+        DECLARE stmt text;
+        BEGIN
+          SELECT string_agg(
+                   format('ALTER FUNCTION %s OWNER TO %I',
+                          p.oid::regprocedure::text, :'app_user'),
+                   E';\n') || ';'
+            INTO stmt
+          FROM pg_proc p
+          JOIN pg_depend d
+            ON d.classid = 'pg_proc'::regclass
+           AND d.objid   = p.oid
+           AND d.deptype = 'e'
+          JOIN pg_extension e ON e.oid = d.refobjid
+          WHERE e.extname IN ('cube', 'earthdistance');
+
+          IF stmt IS NOT NULL THEN
+            EXECUTE stmt;
+          END IF;
+        END $do$;
+        SQL
     envFrom:
       - secretRef:
           name: teslamate-secret
@@ -129,6 +152,7 @@ Notes:
 - Connect as **`-U postgres`**, not as the app's role, so the `CREATE EXTENSION` succeeds.
 - Use `CREATE EXTENSION IF NOT EXISTS` so the container is idempotent (Flux will reschedule it on every pod restart).
 - Set `-v ON_ERROR_STOP=1` so a failed `CREATE EXTENSION` aborts the init and surfaces the error in pod events instead of silently letting the app start with a broken schema.
+- **If the app's migrations also `ALTER FUNCTION` on extension members** (TeslaMate's `CreateGeoExtensions` does this for the `earthdistance` helpers), the postgres role that ran `CREATE EXTENSION` owns those functions — not the app role — so subsequent `ALTER FUNCTION` calls fail with `must be owner of function …`. Transfer ownership of every function attached to the extension to the app role, like the `DO` block above. Walking `pg_depend` rather than hard-coding function names keeps it forward-compatible with future extension upgrades.
 
 ## MariaDB Operator (MariaDB Galera)
 

--- a/kubernetes/apps/observability/teslamate/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/teslamate/app/helmrelease.yaml
@@ -23,9 +23,12 @@ spec:
               - secretRef:
                   name: teslamate-secret
           init-extensions:
-            # TeslaMate's CreateGeoExtensions migration runs CREATE EXTENSION
-            # cube/earthdistance, which requires superuser. Pre-create them as
-            # the postgres superuser so the migration is a no-op.
+            # TeslaMate's CreateGeoExtensions migration installs cube /
+            # earthdistance (superuser-only) and then runs ALTER FUNCTION on
+            # the geo helpers (owner-only). Install the extensions as the
+            # postgres superuser, then transfer ownership of every function
+            # belonging to those two extensions to the teslamate role so the
+            # subsequent ALTER FUNCTION calls in the app's migration succeed.
             image:
               repository: ghcr.io/home-operations/postgres-init
               tag: 18@sha256:6fa1f331cddd2eb0b6afa7b8d3685c864127a81ab01c3d9400bc3ff5263a51cf
@@ -39,8 +42,35 @@ spec:
                   -U postgres \
                   -d "$INIT_POSTGRES_DBNAME" \
                   -v ON_ERROR_STOP=1 \
-                  -c "CREATE EXTENSION IF NOT EXISTS cube;" \
-                  -c "CREATE EXTENSION IF NOT EXISTS earthdistance;"
+                  -v app_user="$INIT_POSTGRES_USER" <<'SQL'
+                CREATE EXTENSION IF NOT EXISTS cube;
+                CREATE EXTENSION IF NOT EXISTS earthdistance;
+
+                DO $do$
+                DECLARE
+                  stmt text;
+                BEGIN
+                  SELECT string_agg(
+                           format('ALTER FUNCTION %s OWNER TO %I',
+                                  p.oid::regprocedure::text,
+                                  :'app_user'),
+                           E';\n'
+                         ) || ';'
+                    INTO stmt
+                  FROM pg_proc p
+                  JOIN pg_depend d
+                    ON d.classid = 'pg_proc'::regclass
+                   AND d.objid   = p.oid
+                   AND d.deptype = 'e'
+                  JOIN pg_extension e
+                    ON e.oid = d.refobjid
+                  WHERE e.extname IN ('cube', 'earthdistance');
+
+                  IF stmt IS NOT NULL THEN
+                    EXECUTE stmt;
+                  END IF;
+                END $do$;
+                SQL
             envFrom:
               - secretRef:
                   name: teslamate-secret


### PR DESCRIPTION
## Summary
TeslaMate's `CreateGeoExtensions` migration cleared the first hurdle (`CREATE EXTENSION cube/earthdistance` now succeed because of #914's `init-extensions` container) but immediately hit a second one:

```
execute "ALTER FUNCTION ll_to_earth SET search_path = public"
** (Postgrex.Error) ERROR 42501 (insufficient_privilege)
   must be owner of function ll_to_earth
```

`ALTER FUNCTION` requires **ownership**, not just privileges. Because `init-extensions` runs `CREATE EXTENSION` as the `postgres` superuser, every function inside `cube` and `earthdistance` (`ll_to_earth`, `latitude`, `earth_distance`, all the `cube_*` helpers) is owned by `postgres` — not by the `teslamate` role that the migration runs as.

After `CREATE EXTENSION`, walk `pg_depend` for every `pg_proc` row attached to `cube` or `earthdistance` and reassign ownership to `$INIT_POSTGRES_USER`:

```sql
DO $do$
DECLARE stmt text;
BEGIN
  SELECT string_agg(
           format('ALTER FUNCTION %s OWNER TO %I',
                  p.oid::regprocedure::text, :'app_user'),
           E';\n') || ';'
    INTO stmt
  FROM pg_proc p
  JOIN pg_depend d
    ON d.classid = 'pg_proc'::regclass
   AND d.objid   = p.oid
   AND d.deptype = 'e'
  JOIN pg_extension e ON e.oid = d.refobjid
  WHERE e.extname IN ('cube', 'earthdistance');

  IF stmt IS NOT NULL THEN EXECUTE stmt; END IF;
END $do$;
```

Walking `pg_depend` (instead of hard-coding the function list) keeps this forward-compatible with future cube/earthdistance upgrades.

Also extends `docs/infrastructure/databases.md` so the next app that runs `ALTER FUNCTION` on extension members has the worked example.

## Test plan
- [ ] `kubectl -n observability logs deploy/teslamate -c init-extensions` shows the `DO` block ran without error
- [ ] `kubectl exec -n database postgres-1 -- psql -U postgres -d teslamate -c "\df+ ll_to_earth"` shows owner = `teslamate`
- [ ] `kubectl -n observability logs deploy/teslamate -c app` shows the `CreateGeoExtensions` migration completing
- [ ] `flux get hr -n observability teslamate` reports `Ready=True`
- [ ] TeslaMate UI loads at `https://teslamate.00o.sh` and trip data eventually populates the location-based dashboards

https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW)_