### PR TITLE
fix(observability): use \gexec for TeslaMate extension ownership transfer

### DIFF
--- a/docs/infrastructure/databases.md
+++ b/docs/infrastructure/databases.md
@@ -120,26 +120,16 @@ initContainers:
         CREATE EXTENSION IF NOT EXISTS cube;
         CREATE EXTENSION IF NOT EXISTS earthdistance;
 
-        DO $do$
-        DECLARE stmt text;
-        BEGIN
-          SELECT string_agg(
-                   format('ALTER FUNCTION %s OWNER TO %I',
-                          p.oid::regprocedure::text, :'app_user'),
-                   E';\n') || ';'
-            INTO stmt
-          FROM pg_proc p
-          JOIN pg_depend d
-            ON d.classid = 'pg_proc'::regclass
-           AND d.objid   = p.oid
-           AND d.deptype = 'e'
-          JOIN pg_extension e ON e.oid = d.refobjid
-          WHERE e.extname IN ('cube', 'earthdistance');
-
-          IF stmt IS NOT NULL THEN
-            EXECUTE stmt;
-          END IF;
-        END $do$;
+        SELECT format('ALTER FUNCTION %s OWNER TO %I;',
+                      p.oid::regprocedure::text, :'app_user')
+        FROM pg_proc p
+        JOIN pg_depend d
+          ON d.classid = 'pg_proc'::regclass
+         AND d.objid   = p.oid
+         AND d.deptype = 'e'
+        JOIN pg_extension e ON e.oid = d.refobjid
+        WHERE e.extname IN ('cube', 'earthdistance')
+        \gexec
         SQL
     envFrom:
       - secretRef:
@@ -152,7 +142,8 @@ Notes:
 - Connect as **`-U postgres`**, not as the app's role, so the `CREATE EXTENSION` succeeds.
 - Use `CREATE EXTENSION IF NOT EXISTS` so the container is idempotent (Flux will reschedule it on every pod restart).
 - Set `-v ON_ERROR_STOP=1` so a failed `CREATE EXTENSION` aborts the init and surfaces the error in pod events instead of silently letting the app start with a broken schema.
-- **If the app's migrations also `ALTER FUNCTION` on extension members** (TeslaMate's `CreateGeoExtensions` does this for the `earthdistance` helpers), the postgres role that ran `CREATE EXTENSION` owns those functions — not the app role — so subsequent `ALTER FUNCTION` calls fail with `must be owner of function …`. Transfer ownership of every function attached to the extension to the app role, like the `DO` block above. Walking `pg_depend` rather than hard-coding function names keeps it forward-compatible with future extension upgrades.
+- **If the app's migrations also `ALTER FUNCTION` on extension members** (TeslaMate's `CreateGeoExtensions` does this for the `earthdistance` helpers), the postgres role that ran `CREATE EXTENSION` owns those functions — not the app role — so subsequent `ALTER FUNCTION` calls fail with `must be owner of function …`. Transfer ownership of every function attached to the extension to the app role using `\gexec` to expand the result rows into executable statements. Walking `pg_depend` rather than hard-coding function names keeps it forward-compatible with future extension upgrades.
+- **Don't wrap the ownership transfer in a `DO $$ … $$` block.** psql's `:'var'` interpolation doesn't run inside dollar-quoted strings, so `:'app_user'` ends up on the server verbatim and the function fails to parse. `\gexec` runs each generated row as a top-level statement where psql interpolation does work.
 
 ## MariaDB Operator (MariaDB Galera)
 

--- a/kubernetes/apps/observability/teslamate/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/teslamate/app/helmrelease.yaml
@@ -46,30 +46,18 @@ spec:
                 CREATE EXTENSION IF NOT EXISTS cube;
                 CREATE EXTENSION IF NOT EXISTS earthdistance;
 
-                DO $do$
-                DECLARE
-                  stmt text;
-                BEGIN
-                  SELECT string_agg(
-                           format('ALTER FUNCTION %s OWNER TO %I',
-                                  p.oid::regprocedure::text,
-                                  :'app_user'),
-                           E';\n'
-                         ) || ';'
-                    INTO stmt
-                  FROM pg_proc p
-                  JOIN pg_depend d
-                    ON d.classid = 'pg_proc'::regclass
-                   AND d.objid   = p.oid
-                   AND d.deptype = 'e'
-                  JOIN pg_extension e
-                    ON e.oid = d.refobjid
-                  WHERE e.extname IN ('cube', 'earthdistance');
-
-                  IF stmt IS NOT NULL THEN
-                    EXECUTE stmt;
-                  END IF;
-                END $do$;
+                SELECT format('ALTER FUNCTION %s OWNER TO %I;',
+                              p.oid::regprocedure::text,
+                              :'app_user')
+                FROM pg_proc p
+                JOIN pg_depend d
+                  ON d.classid = 'pg_proc'::regclass
+                 AND d.objid   = p.oid
+                 AND d.deptype = 'e'
+                JOIN pg_extension e
+                  ON e.oid = d.refobjid
+                WHERE e.extname IN ('cube', 'earthdistance')
+                \gexec
                 SQL
             envFrom:
               - secretRef:


### PR DESCRIPTION
## Summary
The TeslaMate init-extensions container is in CrashLoopBackOff. PR #915 wrapped the ownership transfer in a `DO $do$ ... $do$` block, but psql's `:'app_user'` interpolation **does not run inside dollar-quoted strings** — so the server received literal `:'app_user'` and aborted with a syntax error on every restart.

Replace the `DO` block with a top-level `SELECT ... \gexec`:

```sql
CREATE EXTENSION IF NOT EXISTS cube;
CREATE EXTENSION IF NOT EXISTS earthdistance;

SELECT format('ALTER FUNCTION %s OWNER TO %I;',
              p.oid::regprocedure::text, :'app_user')
FROM pg_proc p
JOIN pg_depend d
  ON d.classid = 'pg_proc'::regclass
 AND d.objid   = p.oid
 AND d.deptype = 'e'
JOIN pg_extension e ON e.oid = d.refobjid
WHERE e.extname IN ('cube', 'earthdistance')
\gexec
```

`\gexec` runs each result row as a top-level SQL statement, and the `SELECT` is regular psql input where `:'app_user'` interpolates correctly. No PL/pgSQL, no dollar-quoting, no shell escaping.

Docs in `docs/infrastructure/databases.md` are updated with the new snippet plus a note explaining why the `DO` form was wrong.

## Test plan
- [ ] `kubectl -n observability logs deploy/teslamate -c init-extensions` shows the generated `ALTER FUNCTION` lines and exits 0
- [ ] Re-running the init container is idempotent (`CREATE EXTENSION IF NOT EXISTS` and ownership-already-correct paths both succeed)
- [ ] `kubectl exec -n database postgres-1 -- psql -U postgres -d teslamate -c "\df+ ll_to_earth"` reports owner = teslamate
- [ ] `kubectl -n observability logs deploy/teslamate -c app` shows the `CreateGeoExtensions` migration succeeding
- [ ] `flux get hr -n observability teslamate` reports `Ready=True`

https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW)_