### PR TITLE
fix(observability): promote teslamate role to SUPERUSER

### DIFF
--- a/docs/infrastructure/databases.md
+++ b/docs/infrastructure/databases.md
@@ -117,10 +117,7 @@ initContainers:
           -d "$INIT_POSTGRES_DBNAME" \
           -v ON_ERROR_STOP=1 \
           -v app_user="$INIT_POSTGRES_USER" <<'SQL'
-        CREATE EXTENSION IF NOT EXISTS cube;
-        CREATE EXTENSION IF NOT EXISTS earthdistance;
-
-        GRANT postgres TO :"app_user";
+        ALTER ROLE :"app_user" WITH SUPERUSER;
         SQL
     envFrom:
       - secretRef:
@@ -130,11 +127,11 @@ initContainers:
 Notes:
 
 - Reuse the `postgres-init` image — it already ships `psql` and matches the existing pattern.
-- Connect as **`-U postgres`**, not as the app's role, so the `CREATE EXTENSION` succeeds.
-- Use `CREATE EXTENSION IF NOT EXISTS` so the container is idempotent (Flux will reschedule it on every pod restart). `GRANT postgres TO ...` is also a no-op when the membership already exists, so the whole script is safe to re-run.
-- Set `-v ON_ERROR_STOP=1` so a failed `CREATE EXTENSION` aborts the init and surfaces the error in pod events instead of silently letting the app start with a broken schema.
-- **PostgreSQL has no `ALTER EXTENSION ... OWNER TO`.** Extensions inherit ownership from whichever role ran `CREATE EXTENSION` and there is no syntax to reassign it later. If the app's migrations need to `ALTER EXTENSION` (TeslaMate's `update_geo_extensions` runs `ALTER EXTENSION cube UPDATE`), grant the app role membership in `postgres` so it inherits postgres's ownership for permission checks. This effectively gives the app role superuser inside its own database — fine for single-tenant homelab apps; revisit if you ever multi-tenant a CNPG database.
-- Per-object `ALTER FUNCTION ... OWNER TO ...` transfers via `\gexec` were tried earlier; they cleared the function-level errors but couldn't help with `ALTER EXTENSION` itself, since extensions aren't in `pg_depend.refclassid='pg_extension'` as transferable members. `GRANT postgres TO ...` is the simpler and complete fix.
+- Connect as **`-U postgres`** (the cluster superuser); only a superuser can grant the SUPERUSER attribute to another role.
+- `ALTER ROLE ... WITH SUPERUSER` is idempotent — re-running it on a role that already has SUPERUSER is a no-op, so the init container is safe on every pod restart.
+- Set `-v ON_ERROR_STOP=1` so any failure aborts the init and surfaces the error in pod events instead of silently letting the app start with a broken setup.
+- **Why we promote the app role to SUPERUSER instead of pre-creating extensions:** PostgreSQL has no `ALTER EXTENSION ... OWNER TO` syntax. Extensions inherit ownership from whichever role ran `CREATE EXTENSION` and there is no way to reassign it later. If the app's migrations need to `CREATE EXTENSION` (cube/earthdistance for TeslaMate), `ALTER EXTENSION cube UPDATE`, `ALTER FUNCTION` on extension members, or any other superuser operation, the migration role itself must hold SUPERUSER. Role membership (`GRANT postgres TO ...`) inherits *privileges* but **not** role attributes like SUPERUSER, so it doesn't help here. Pre-installing every extension the app might want is whack-a-mole as upstream evolves. Promoting the app role is the simplest durable fix.
+- **Trade-off:** the app role becomes a database-wide superuser. Acceptable in a single-tenant homelab; revisit if a CNPG database is ever shared across apps.
 
 ## MariaDB Operator (MariaDB Galera)
 

--- a/kubernetes/apps/observability/teslamate/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/teslamate/app/helmrelease.yaml
@@ -23,20 +23,18 @@ spec:
               - secretRef:
                   name: teslamate-secret
           init-extensions:
-            # TeslaMate's geo migrations install cube/earthdistance
-            # (superuser-only) and then run ALTER EXTENSION / ALTER FUNCTION
-            # on them, which require the migration role to be the extension
-            # owner. PostgreSQL has no `ALTER EXTENSION ... OWNER TO`
-            # syntax - extensions inherit ownership from the role that ran
-            # CREATE EXTENSION (postgres, in our case) and there's no way
-            # to reassign it after the fact.
+            # TeslaMate's migrations need to CREATE / ALTER non-trusted
+            # extensions (cube, earthdistance, plus whatever the next
+            # migration adds) and ALTER EXTENSION on them. Both operations
+            # require the SUPERUSER role attribute, which is NOT inherited
+            # via GRANT role-membership - only privileges (GRANTed perms)
+            # are. Pre-installing the known extensions here is a moving
+            # target as TeslaMate adds more.
             #
-            # The supported workaround is role membership: GRANT postgres
-            # TO teslamate makes the app role inherit postgres's ownership
-            # for permission checks, so the migration's ALTER EXTENSION /
-            # ALTER FUNCTION calls succeed without us needing to chase
-            # individual member objects (functions, types, operators, ...).
-            # Acceptable in this single-tenant homelab cluster.
+            # Make the teslamate role itself a SUPERUSER so the app's
+            # migrations can do whatever they need. Acceptable in this
+            # single-tenant homelab cluster; revisit if multi-tenancy
+            # ever lands on this CNPG cluster.
             image:
               repository: ghcr.io/home-operations/postgres-init
               tag: 18@sha256:6fa1f331cddd2eb0b6afa7b8d3685c864127a81ab01c3d9400bc3ff5263a51cf
@@ -51,10 +49,7 @@ spec:
                   -d "$INIT_POSTGRES_DBNAME" \
                   -v ON_ERROR_STOP=1 \
                   -v app_user="$INIT_POSTGRES_USER" <<'SQL'
-                CREATE EXTENSION IF NOT EXISTS cube;
-                CREATE EXTENSION IF NOT EXISTS earthdistance;
-
-                GRANT postgres TO :"app_user";
+                ALTER ROLE :"app_user" WITH SUPERUSER;
                 SQL
             envFrom:
               - secretRef:


### PR DESCRIPTION
Superseded by #920 (closes here without merging) — the SUPERUSER approach gives the teslamate role cluster-wide access to every other CNPG database in the shared cluster, which is unacceptable. The new PR keeps teslamate unprivileged by pre-running the superuser DDL as postgres and stamping the can't-grant migrations into Ecto's `schema_migrations` table so they're skipped.