### PR TITLE
fix(observability): TeslaMate 3.0.0 with fake-stamped superuser migrations (no SUPERUSER)

### DIFF
--- a/docs/infrastructure/databases.md
+++ b/docs/infrastructure/databases.md
@@ -117,10 +117,36 @@ initContainers:
           -d "$INIT_POSTGRES_DBNAME" \
           -v ON_ERROR_STOP=1 \
           -v app_user="$INIT_POSTGRES_USER" <<'SQL'
-        CREATE EXTENSION IF NOT EXISTS cube;
-        CREATE EXTENSION IF NOT EXISTS earthdistance;
+        -- 1. Install + upgrade the non-trusted geo extensions as superuser.
+        CREATE EXTENSION IF NOT EXISTS cube WITH SCHEMA public;
+        CREATE EXTENSION IF NOT EXISTS earthdistance WITH SCHEMA public;
+        ALTER EXTENSION earthdistance UPDATE;
 
-        GRANT postgres TO :"app_user";
+        -- 2. Transfer ownership of every cube/earthdistance member
+        --    function to the app role so the migration's ALTER FUNCTION
+        --    calls succeed when the app runs them as itself.
+        SELECT 'ALTER FUNCTION ' || objid::regprocedure::text
+               || ' OWNER TO ' || quote_ident(:'app_user') || ';'
+        FROM pg_depend
+        WHERE classid='pg_proc'::regclass AND deptype='e'
+          AND refclassid='pg_extension'::regclass
+          AND refobjid IN (SELECT oid FROM pg_extension
+                           WHERE extname IN ('cube','earthdistance'))
+        \gexec
+
+        -- 3. Pre-create Ecto's schema_migrations table and stamp the
+        --    superuser-only migrations as already applied so the app
+        --    skips them. The DDL they would run has been done above.
+        CREATE TABLE IF NOT EXISTS public.schema_migrations (
+          version     bigint       PRIMARY KEY,
+          inserted_at timestamp(0) WITHOUT TIME ZONE NOT NULL
+        );
+        ALTER TABLE public.schema_migrations OWNER TO :"app_user";
+
+        INSERT INTO public.schema_migrations (version, inserted_at) VALUES
+          (20240929084639, NOW()),  -- recreate_geo_extensions
+          (20250407155134, NOW())   -- upgrade_earthdistance
+        ON CONFLICT (version) DO NOTHING;
         SQL
     envFrom:
       - secretRef:
@@ -129,12 +155,17 @@ initContainers:
 
 Notes:
 
-- Reuse the `postgres-init` image — it already ships `psql` and matches the existing pattern.
+- Reuse the `postgres-init` image — it ships `psql` and matches the existing pattern.
 - Connect as **`-U postgres`**, not as the app's role, so the `CREATE EXTENSION` succeeds.
-- Use `CREATE EXTENSION IF NOT EXISTS` so the container is idempotent (Flux will reschedule it on every pod restart). `GRANT postgres TO ...` is also a no-op when the membership already exists, so the whole script is safe to re-run.
-- Set `-v ON_ERROR_STOP=1` so a failed `CREATE EXTENSION` aborts the init and surfaces the error in pod events instead of silently letting the app start with a broken schema.
-- **PostgreSQL has no `ALTER EXTENSION ... OWNER TO`.** Extensions inherit ownership from whichever role ran `CREATE EXTENSION` and there is no syntax to reassign it later. If the app's migrations need to `ALTER EXTENSION` (TeslaMate's `update_geo_extensions` runs `ALTER EXTENSION cube UPDATE`), grant the app role membership in `postgres` so it inherits postgres's ownership for permission checks. This effectively gives the app role superuser inside its own database — fine for single-tenant homelab apps; revisit if you ever multi-tenant a CNPG database.
-- Per-object `ALTER FUNCTION ... OWNER TO ...` transfers via `\gexec` were tried earlier; they cleared the function-level errors but couldn't help with `ALTER EXTENSION` itself, since extensions aren't in `pg_depend.refclassid='pg_extension'` as transferable members. `GRANT postgres TO ...` is the simpler and complete fix.
+- The whole script is **idempotent**: `CREATE EXTENSION IF NOT EXISTS`, `ALTER EXTENSION ... UPDATE` (no-op when current), `\gexec`-driven ownership transfer (no-op when the role already owns it), `CREATE TABLE IF NOT EXISTS`, and `INSERT ... ON CONFLICT DO NOTHING`. Safe to re-run on every pod restart.
+- Set `-v ON_ERROR_STOP=1` so a failed step aborts the init and surfaces the error in pod events instead of silently letting the app start with a broken schema.
+- **Don't promote the app role to SUPERUSER.** It looks tempting but PostgreSQL's SUPERUSER attribute is **cluster-wide**, not per-database — the app role would gain read/write access to every other CNPG-backed database in the same cluster (n8n, plane, penpot, …). In a shared-cluster setup that's an unacceptable blast radius.
+- **`GRANT postgres TO app` doesn't help** for `CREATE EXTENSION`. Role membership inherits *privileges* (table GRANTs, etc.) but **not role attributes** like `SUPERUSER`, and `CREATE EXTENSION` on non-trusted extensions checks the SUPERUSER attribute.
+- **Why the fake-stamp pattern works:** Ecto records applied migrations in `schema_migrations`. If a migration's version is already in that table when the migrator boots, Ecto skips it. Pre-create the table (matching the DDL Ecto would emit), do the superuser DDL yourself as postgres, and `INSERT` the version. The app then sees no work to do.
+- **What you must keep in sync** when the upstream app adds a new superuser-requiring migration: replicate its DDL in step 1/2 above, and add its version to the `INSERT` in step 3. The migration list as of TeslaMate 3.0.0:
+  - `20190925152807_create_geo_extensions` — *not* skipped; runs fine as the app role once function ownership is transferred (the inner `CREATE EXTENSION IF NOT EXISTS` short-circuits before its privilege check, the `ALTER FUNCTION` calls succeed because of the ownership transfer, and the `CREATE INDEX` runs as the table owner).
+  - `20240929084639_recreate_geo_extensions` — skipped; `DROP EXTENSION cube CASCADE` requires extension ownership which can't be granted.
+  - `20250407155134_upgrade_earthdistance` — skipped; we run the same `ALTER EXTENSION earthdistance UPDATE` as postgres in step 1.
 
 ## MariaDB Operator (MariaDB Galera)
 

--- a/kubernetes/apps/observability/teslamate/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/teslamate/app/helmrelease.yaml
@@ -23,20 +23,26 @@ spec:
               - secretRef:
                   name: teslamate-secret
           init-extensions:
-            # TeslaMate's geo migrations install cube/earthdistance
-            # (superuser-only) and then run ALTER EXTENSION / ALTER FUNCTION
-            # on them, which require the migration role to be the extension
-            # owner. PostgreSQL has no `ALTER EXTENSION ... OWNER TO`
-            # syntax - extensions inherit ownership from the role that ran
-            # CREATE EXTENSION (postgres, in our case) and there's no way
-            # to reassign it after the fact.
+            # TeslaMate has three migrations that need Postgres superuser
+            # privileges. We can't make the teslamate role superuser without
+            # giving it cluster-wide access to every other CNPG-backed app's
+            # database, and PostgreSQL has no syntax to reassign extension
+            # ownership. Workaround: do the superuser-only DDL here as the
+            # postgres superuser, then mark those migrations as already
+            # applied in Ecto's schema_migrations table so TeslaMate skips
+            # them when it boots.
             #
-            # The supported workaround is role membership: GRANT postgres
-            # TO teslamate makes the app role inherit postgres's ownership
-            # for permission checks, so the migration's ALTER EXTENSION /
-            # ALTER FUNCTION calls succeed without us needing to chase
-            # individual member objects (functions, types, operators, ...).
-            # Acceptable in this single-tenant homelab cluster.
+            # Migrations handled here (TeslaMate priv/repo/migrations):
+            #   20190925152807_create_geo_extensions     (NOT skipped - the
+            #     CREATE EXTENSION IF NOT EXISTS calls inside it short-circuit
+            #     before the superuser check, and once we transfer extension
+            #     function ownership the ALTER FUNCTION / CREATE INDEX run
+            #     fine as teslamate.)
+            #   20240929084639_recreate_geo_extensions   (SKIPPED - DROP
+            #     EXTENSION CASCADE needs ext owner, can't be granted)
+            #   20250407155134_upgrade_earthdistance     (SKIPPED - ALTER
+            #     EXTENSION ... UPDATE needs ext owner; we run the same
+            #     UPDATE as postgres below so the result is identical)
             image:
               repository: ghcr.io/home-operations/postgres-init
               tag: 18@sha256:6fa1f331cddd2eb0b6afa7b8d3685c864127a81ab01c3d9400bc3ff5263a51cf
@@ -51,10 +57,40 @@ spec:
                   -d "$INIT_POSTGRES_DBNAME" \
                   -v ON_ERROR_STOP=1 \
                   -v app_user="$INIT_POSTGRES_USER" <<'SQL'
-                CREATE EXTENSION IF NOT EXISTS cube;
-                CREATE EXTENSION IF NOT EXISTS earthdistance;
+                -- 1. Install + upgrade the non-trusted geo extensions.
+                CREATE EXTENSION IF NOT EXISTS cube WITH SCHEMA public;
+                CREATE EXTENSION IF NOT EXISTS earthdistance WITH SCHEMA public;
+                ALTER EXTENSION earthdistance UPDATE;
 
-                GRANT postgres TO :"app_user";
+                -- 2. Hand every cube/earthdistance member function to the
+                --    teslamate role so the ALTER FUNCTION calls in the
+                --    create_geo_extensions migration succeed when the app
+                --    runs them.
+                SELECT 'ALTER FUNCTION ' || objid::regprocedure::text
+                       || ' OWNER TO ' || quote_ident(:'app_user') || ';'
+                FROM pg_depend
+                WHERE classid    = 'pg_proc'::regclass
+                  AND deptype    = 'e'
+                  AND refclassid = 'pg_extension'::regclass
+                  AND refobjid IN (SELECT oid FROM pg_extension
+                                   WHERE extname IN ('cube','earthdistance'))
+                \gexec
+
+                -- 3. Pre-create Ecto's schema_migrations table (matches the
+                --    DDL Ecto emits on first run) and stamp the two
+                --    migrations we can't let teslamate run as already
+                --    applied. Idempotent on re-runs.
+                CREATE TABLE IF NOT EXISTS public.schema_migrations (
+                  version     bigint        PRIMARY KEY,
+                  inserted_at timestamp(0)  WITHOUT TIME ZONE NOT NULL
+                );
+                ALTER TABLE public.schema_migrations OWNER TO :"app_user";
+
+                INSERT INTO public.schema_migrations (version, inserted_at)
+                VALUES
+                  (20240929084639, NOW()),
+                  (20250407155134, NOW())
+                ON CONFLICT (version) DO NOTHING;
                 SQL
             envFrom:
               - secretRef:
@@ -63,7 +99,7 @@ spec:
           app:
             image:
               repository: docker.io/teslamate/teslamate
-              tag: 1.32.0@sha256:8c282ada5c72b7b0cbd316ec7bc010a9214d5943cf1e1b36ab9b7a98f45a5809
+              tag: 3.0.0@sha256:6569026b73bd657455bbec05965d07fa30b6d4d70eaab0bd5b343231c0429167
             env:
               TZ: America/New_York
               VIRTUAL_HOST: teslamate.00o.sh


### PR DESCRIPTION
## Summary
Replaces #919. SUPERUSER on the shared CNPG cluster is unacceptable (cluster-wide blast radius across every other CNPG-backed app), and dropping HA into a dedicated cluster just for TeslaMate is also unacceptable. This PR keeps the shared HA cluster *and* keeps the teslamate role unprivileged, by inspecting TeslaMate's actual migrations and using Ecto's own `schema_migrations` table to fake-stamp the few that need privileges we can't grant.

### What init-extensions now does (as postgres)
```sql
-- 1. The only superuser-required DDL TeslaMate 3.0.0 needs
CREATE EXTENSION IF NOT EXISTS cube WITH SCHEMA public;
CREATE EXTENSION IF NOT EXISTS earthdistance WITH SCHEMA public;
ALTER EXTENSION earthdistance UPDATE;

-- 2. Hand cube/earthdistance member functions to teslamate so its
--    ALTER FUNCTION ll_to_earth/earth_box calls succeed
SELECT 'ALTER FUNCTION ' || objid::regprocedure::text
       || ' OWNER TO ' || quote_ident(:'app_user') || ';'
FROM pg_depend WHERE classid='pg_proc'::regclass AND deptype='e'
  AND refclassid='pg_extension'::regclass
  AND refobjid IN (SELECT oid FROM pg_extension
                   WHERE extname IN ('cube','earthdistance'))
\gexec

-- 3. Pre-create Ecto's schema_migrations and stamp the migrations
--    whose superuser-only ops can't be granted away
CREATE TABLE IF NOT EXISTS public.schema_migrations (
  version bigint PRIMARY KEY, inserted_at timestamp(0) NOT NULL
);
ALTER TABLE public.schema_migrations OWNER TO :"app_user";
INSERT INTO public.schema_migrations (version, inserted_at) VALUES
  (20240929084639, NOW()),  -- recreate_geo_extensions (DROP EXT CASCADE)
  (20250407155134, NOW())   -- upgrade_earthdistance  (ALTER EXT UPDATE)
ON CONFLICT (version) DO NOTHING;
```

### What TeslaMate then does on boot
- `20190925152807_create_geo_extensions` — runs fine as teslamate. `CREATE EXTENSION IF NOT EXISTS` short-circuits before its priv check when the extension already exists; `ALTER FUNCTION ll_to_earth / earth_box` succeed because we transferred function ownership; `CREATE INDEX` on geofences runs as the table owner.
- `20240929084639_recreate_geo_extensions` — Ecto sees it in `schema_migrations`, skips it. The `DROP EXTENSION cube CASCADE; CREATE EXTENSION cube ...` it would have done is a no-op for fresh installs anyway.
- `20250407155134_upgrade_earthdistance` — Ecto skips it. Step 1 already ran the same `ALTER EXTENSION earthdistance UPDATE` as postgres.

### Other changes
- Bumps image to `teslamate/teslamate:3.0.0` (per @user — built-in Fleet API onboarding, free for personal use)
- Whole init-extensions script is idempotent: `IF NOT EXISTS`, `ON CONFLICT DO NOTHING`, `ALTER FUNCTION OWNER TO` is a no-op when already owned, `ALTER EXTENSION ... UPDATE` is a no-op when at the latest version
- Docs updated with the migration list and the rationale for fake-stamping (so the next person who needs to upgrade TeslaMate or add another superuser-extension app has the recipe)

### Maintenance footprint
When a future TeslaMate release adds a new superuser-requiring migration, copy its DDL into step 1/2 and add its version to the step 3 INSERT. The migration list is captured in the docs.

## Test plan
- [ ] `kubectl -n observability logs deploy/teslamate -c init-extensions` shows the three steps running and exit 0
- [ ] `kubectl exec -n database postgres-1 -- psql -U postgres -d teslamate -c "SELECT version FROM public.schema_migrations ORDER BY version"` includes both `20240929084639` and `20250407155134`
- [ ] `kubectl exec -n database postgres-1 -- psql -U postgres -d teslamate -c "\df+ ll_to_earth"` shows owner = teslamate
- [ ] `kubectl exec -n database postgres-1 -- psql -U postgres -d teslamate -c "\du teslamate"` does **not** show Superuser
- [ ] `kubectl -n observability logs deploy/teslamate -c app` shows the migrator running through to completion (skipping the two fake-stamped versions)
- [ ] `flux get hr -n observability teslamate` reports `Ready=True`
- [ ] `https://teslamate.00o.sh` loads, Fleet API onboarding flow appears (3.0.0)

https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW)_