### PR TITLE
fix(observability): match Grafana datasource placeholders to secret keys

### DIFF
--- a/kubernetes/apps/observability/teslamate/app/grafanadashboard.yaml
+++ b/kubernetes/apps/observability/teslamate/app/grafanadashboard.yaml
@@ -31,10 +31,10 @@ spec:
     type: grafana-postgresql-datasource
     access: proxy
     url: postgres-rw.database.svc.cluster.local:5432
-    user: $${user}
-    database: $${database}
+    user: $${INIT_POSTGRES_USER}
+    database: $${INIT_POSTGRES_DBNAME}
     secureJsonData:
-      password: $${password}
+      password: $${INIT_POSTGRES_PASS}
     jsonData:
       sslmode: disable
       postgresVersion: 1700


### PR DESCRIPTION
## Summary
TeslaMate Grafana dashboards were failing with:
```
db query error: pq: password authentication failed for user "${user}"
```
The literal `${user}` reaching Postgres means grafana-operator never substituted the placeholder.

`grafana-operator`'s `valuesFrom` does **string replacement of `${KEY_NAME}`** placeholders where `KEY_NAME` must match the secret key. The datasource was using `${user}` / `${database}` / `${password}`, but the secret keys are `INIT_POSTGRES_USER` / `INIT_POSTGRES_DBNAME` / `INIT_POSTGRES_PASS` — so nothing matched and the placeholders passed through verbatim (after Flux postBuild expanded `$${...}` to `${...}`).

Switch the placeholders to `$${INIT_POSTGRES_USER}` / `$${INIT_POSTGRES_DBNAME}` / `$${INIT_POSTGRES_PASS}` so the operator's substitution actually fires.

## Test plan
- [ ] After reconcile, `kubectl -n observability get grafanadatasource teslamate -o yaml` shows the substituted values in `.status` (or no `${...}` strings)
- [ ] In Grafana, the TeslaMate datasource → Save & test → succeeds
- [ ] TeslaMate dashboards (e.g. `Drives`, `Charges`) render rows instead of the `pq: password authentication failed` error

https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW)_