### PR TITLE
fix(observability): set fsGroupChangePolicy=OnRootMismatch on victoria-logs

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -12,6 +12,13 @@ spec:
   values:
     fullnameOverride: victoria-logs
     server:
+      podSecurityContext:
+        # Skip the recursive volume chown on every pod start - kubelet
+        # only walks the volume when the root dir's owner doesn't match.
+        # Without this, a chart upgrade that nudges fsGroup re-chowns
+        # every file on the 20Gi NFS PVC and the pod sits in
+        # "fixing permissions" for hours.
+        fsGroupChangePolicy: OnRootMismatch
       persistentVolume:
         enabled: true
         storageClassName: nfs-fast


### PR DESCRIPTION
## Summary
The chart bump `0.12.0 → 0.12.4` (#993e19a) tweaked the pod's `fsGroup`, so on the next pod start the kubelet decided to recursively `chown` every file on the 20Gi `nfs-fast` PVC to match. With many small log files over NFS that's been stuck in "fixing permissions" for **hours**.

Default `fsGroupChangePolicy` is `Always` — kubelet walks the entire volume on every pod start. Setting it to `OnRootMismatch` means kubelet only inspects the volume root and skips the recursive walk when ownership already matches. Recommended for any non-trivial PVC, basically required on NFS.

```yaml
server:
  podSecurityContext:
    fsGroupChangePolicy: OnRootMismatch
```

## Caveat
This **does not fix the currently in-progress chown** — that pod will keep working through the volume until either:
- it finishes naturally (could be more hours yet on NFS), or
- you `kubectl delete pod` it after manually `chown -R <uid>:<gid>` the export from the NFS server side.

What this PR does is ensure the *next* chart bump (or any future restart) doesn't re-trip the same trap.

## Test plan
- [ ] `flux get hr -n observability victoria-logs` reports `Ready=True` after reconcile
- [ ] `kubectl -n observability get sts victoria-logs-server -o yaml | yq '.spec.template.spec.securityContext.fsGroupChangePolicy'` returns `OnRootMismatch`
- [ ] On next pod restart (or chart bump), the pod transitions Pending → Running without sitting in "fixing permissions" for more than a few seconds

https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEBkgwj4bwGgfxZKw8cWyW)_