### PR TITLE
docs: refresh version pins and deployed-app listings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,19 +10,19 @@ This document provides comprehensive guidance for AI assistants working with thi
 
 ### Core Components
 
-- **OS**: Talos Linux 1.12.4 (immutable Kubernetes OS)
-- **Orchestration**: Kubernetes 1.34.0
-- **GitOps**: Flux CD 2.8.1 (declarative continuous delivery)
-- **CNI**: Cilium 1.19.0 (eBPF-based networking)
-- **Ingress**: Envoy Gateway v1.6.3 (HTTP routing)
-- **Secrets**: SOPS 3.12.1 + Age 1.3.1 encryption
+- **OS**: Talos Linux 1.13.0 (immutable Kubernetes OS)
+- **Orchestration**: Kubernetes 1.35.4
+- **GitOps**: Flux CD 2.8.6 (declarative continuous delivery)
+- **CNI**: Cilium 1.19.3 (eBPF-based networking)
+- **Ingress**: Envoy Gateway v1.7.2 (HTTP routing)
+- **Secrets**: SOPS 3.13.0 + Age 1.3.1 encryption
 - **Identity**: Kanidm (SSO/OAuth2 identity provider)
 - **DNS**: k8s_gateway + CoreDNS + External-DNS
-- **Certificates**: cert-manager with Cloudflare integration
-- **Package Management**: Helm 4.1.1 (Helm v4 for chart management)
+- **Certificates**: cert-manager v1.20.2 with Cloudflare integration
+- **Package Management**: Helm 4.1.4 (Helm v4 for chart management)
 - **Database**: CloudNative-PG (PostgreSQL 17.7) + Dragonfly (Redis-compatible) + MariaDB Operator (MariaDB 11.7 Galera)
 - **Virtualization**: KubeVirt 1.7.0 (virtual machine management)
-- **External Secrets**: External Secrets Operator 2.0.0 + 1Password Connect (reads) + 1Password SDK (writes)
+- **External Secrets**: External Secrets Operator 2.4.1 + 1Password Connect (reads) + 1Password SDK (writes)
 
 ## Directory Structure
 
@@ -670,6 +670,8 @@ talosctl logs --nodes <ip> --insecure
 - echo (test application)
 - librespeed (multi-path speed test with per-route Envoy tuning)
 
+> **Note:** The `voip` namespace exists but the FreePBX HelmReleases are currently disabled (commented out in `kubernetes/apps/voip/kustomization.yaml`). The `kubernetes/apps/kubevirt/virtualmachines/` directory likewise no longer ships the FreePBX VM manifests; only the Debian, Ubuntu and Windows VMs remain active.
+
 **external-secrets**: Secret management
 - discord-webhook (Discord integration)
 - external-secrets (operator)
@@ -699,7 +701,7 @@ talosctl logs --nodes <ip> --insecure
 - cdi (Containerized Data Importer for VM disk management)
 - kubevirt (KubeVirt operator)
 - kubevirt-manager (web UI for VM management)
-- virtualmachines (VM instances: debian-desktop, debian-server, ubuntu-server, windows-server, freepbx-b1-k3s01, freepbx-b2-k3s01, freepbx-b3-k3s01)
+- virtualmachines (VM instances: debian-desktop, debian-server, ubuntu-server, windows-server)
 
 **media**: Media applications
 - autobrr (automation for torrent trackers)
@@ -710,11 +712,11 @@ talosctl logs --nodes <ip> --insecure
 - qbittorrent (torrent client)
 - qui (qBittorrent web UI)
 - radarr (movie collection manager)
-- recyclarr (quality profile management for *arr apps)
 - seerr (media request and discovery)
 - sonarr (TV series collection manager)
 - tautulli (Plex monitoring and statistics)
 - thelounge (IRC client)
+- recyclarr (currently disabled — manifests retained, kustomization entry commented out)
 
 **network**: Network infrastructure
 - cloudflare-dns
@@ -736,6 +738,7 @@ talosctl logs --nodes <ip> --insecure
 - kube-prometheus-stack (Prometheus, AlertManager, Grafana)
 - opencost (Kubernetes cost monitoring and analysis)
 - silence-operator (alert silencing)
+- teslamate (Tesla data logger with Grafana dashboards, PostgreSQL backend)
 - victoria-logs (log aggregation)
 
 **openebs-system**: Storage
@@ -744,21 +747,14 @@ talosctl logs --nodes <ip> --insecure
 **system-upgrade**: System management
 - tuppr (automated upgrades)
 
-**ui-bakery**: Low-code platform
-- ui-bakery (low-code internal tool builder with MariaDB backend, ExternalSecrets, Envoy Gateway ingress)
-
 **utils**: Utility services
 - forgejo (self-hosted Git repository service)
 - homepage (cluster dashboard)
-- n8n (workflow automation platform)
-- penpot (open-source design and prototyping platform)
+- plane (open-source project management platform with PostgreSQL backend)
 - smtp-relay (SMTP relay for outbound email using Maddy)
+- n8n, penpot, rustdesk (manifests retained but currently disabled in `kustomization.yaml`)
 
-**voip**: VoIP and telephony
-- freepbx-b1-k3s01 (containerized FreePBX telephony platform with MariaDB backend)
-
-**zitadel**: External identity provider (SaaS development)
-- zitadel (self-hosted Zitadel identity platform at login.00o.sh, network-isolated, PostgreSQL backend, external-only access)
+**voip**: VoIP and telephony (currently inactive — namespace exists but all HelmReleases commented out)
 
 **volsync-system**: Backup and replication
 - garage (S3-compatible storage backend)
@@ -783,14 +779,16 @@ talosctl logs --nodes <ip> --insecure
 ## Version Information
 
 This documentation applies to:
-- Talos Linux: 1.12.4
-- Kubernetes: 1.34.0
-- Flux CD: 2.8.1
-- Cilium: 1.19.0
-- Helm: 4.1.1
-- Python: 3.14.3
-- Envoy Gateway: v1.6.3
-- External Secrets: 2.0.0
+- Talos Linux: 1.13.0
+- Kubernetes: 1.35.4
+- Flux CD: 2.8.6
+- Cilium: 1.19.3
+- Helm: 4.1.4
+- Python: 3.14.5
+- Envoy Gateway: v1.7.2
+- External Secrets: 2.4.1
+- cert-manager: v1.20.2
+- SOPS: 3.13.0
 - CloudNative-PG: PostgreSQL 17.7
 - KubeVirt: 1.7.0
 - kGuardian: 1.7.0
@@ -800,7 +798,13 @@ Check `.mise.toml` for exact versions of all tools.
 
 ## Recent Notable Changes
 
-- **2026-03-19**: Added self-hosted Zitadel identity platform at login.00o.sh for SaaS development (network-isolated, external-only access, PostgreSQL backend, NetworkPolicy restricting traffic to Postgres egress and Envoy ingress only)
+- **2026-05-14**: Documentation refresh — version bumps across README/docs/CLAUDE.md (Talos 1.13.0, Kubernetes 1.35.4, Flux 2.8.6, Cilium 1.19.3, Helm 4.1.4, SOPS 3.13.0, Python 3.14.5, Envoy Gateway v1.7.2) and updated deployed-applications listings
+- **2026-05-14**: Removed `ui-bakery` and `zitadel` namespaces from the cluster
+- **2026-05-14**: Disabled FreePBX HelmReleases in the `voip` namespace and removed the FreePBX KubeVirt VM manifests; `voip` namespace remains
+- **2026-05-14**: Disabled `recyclarr` (media), `n8n`, `penpot`, and `rustdesk` (utils) in their respective kustomizations
+- **2026-04**: Added `plane` (open-source project management platform) to the `utils` namespace with PostgreSQL backend
+- **2026-04**: Added `teslamate` (Tesla data logger) to the `observability` namespace
+- **2026-03-19**: Added self-hosted Zitadel identity platform at login.00o.sh for SaaS development (network-isolated, external-only access, PostgreSQL backend, NetworkPolicy restricting traffic to Postgres egress and Envoy ingress only) — _later removed (see 2026-05-14)_
 - **2026-03-07**: Added ambersecurityinc runner scale set to actions-runner-system (minRunners: 1, maxRunners: 3, 25Gi storage, 1Password integration)
 - **2026-03-07**: Added ARC Grafana monitoring dashboard for runner autoscaling metrics
 - **2026-03-07**: Added VolSync mass point-in-time restore script (`scripts/volsync-restore-all.sh`) for all 16 VolSync-backed apps
@@ -877,9 +881,8 @@ Located in `kubernetes/apps/kubevirt/`, this namespace provides virtual machine 
 - **debian-server**: Debian 13 headless server (1 CPU, 1G RAM, 50Gi NFS storage)
 - **ubuntu-server**: Ubuntu server instance
 - **windows-server**: Windows Server 2022 with virtio drivers (2 CPU, 2G RAM, 60Gi NFS storage)
-- **freepbx-b1-k3s01**: FreePBX telephony/PBX system (with secrets)
-- **freepbx-b2-k3s01**: FreePBX telephony/PBX system (with secrets)
-- **freepbx-b3-k3s01**: FreePBX telephony/PBX system (with secrets)
+
+> The FreePBX VMs (`freepbx-b{1,2,3}-k3s01`) have been removed from the `virtualmachines/` directory; the matching `voip` HelmReleases are also disabled.
 
 **Storage**:
 - Uses NFS (nfs-fast storageClass) for VM disks with ReadWriteMany access
@@ -1212,5 +1215,5 @@ The repository includes a comprehensive MkDocs Material documentation site publi
 
 ---
 
-**Last Updated**: 2026-03-07
+**Last Updated**: 2026-05-14
 **Template Source**: [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template)

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 ### Core Infrastructure
 
 **Operating System & Orchestration:**
-- [Talos Linux](https://github.com/siderolabs/talos) 1.12.4 - Immutable Kubernetes OS
-- [Kubernetes](https://kubernetes.io/) 1.34.0 - Container orchestration
-- [Flux CD](https://github.com/fluxcd/flux2) 2.8.1 - GitOps continuous delivery
+- [Talos Linux](https://github.com/siderolabs/talos) 1.13.0 - Immutable Kubernetes OS
+- [Kubernetes](https://kubernetes.io/) 1.35.4 - Container orchestration
+- [Flux CD](https://github.com/fluxcd/flux2) 2.8.6 - GitOps continuous delivery
 
 **Networking:**
-- [Cilium](https://github.com/cilium/cilium) 1.19.0 - eBPF-based CNI
+- [Cilium](https://github.com/cilium/cilium) 1.19.3 - eBPF-based CNI
 - [CoreDNS](https://coredns.io/) - Cluster DNS
 - [Envoy Gateway](https://github.com/envoyproxy/gateway) - HTTP routing and ingress
 - [Error Pages](https://github.com/tarampampam/error-pages) - Custom error pages for Envoy Gateway
@@ -43,7 +43,7 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 - [cert-manager](https://github.com/cert-manager/cert-manager) - TLS certificate automation
 - [External Secrets Operator](https://external-secrets.io/) - External secret management
 - [1Password](https://1password.com/) - Secret storage backend
-- [SOPS](https://github.com/getsops/sops) 3.12.1 - Encrypted secrets in Git
+- [SOPS](https://github.com/getsops/sops) 3.13.0 - Encrypted secrets in Git
 
 **Storage:**
 - [OpenEBS](https://github.com/openebs/openebs) - Cloud-native storage
@@ -70,6 +70,7 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 - [Kromgo](https://github.com/kashalls/kromgo) - Custom metrics publishing
 - [Silence Operator](https://github.com/kbudde/silence-operator) - Alert silencing automation
 - [OpenCost](https://www.opencost.io/) - Kubernetes cost monitoring and analysis
+- [TeslaMate](https://github.com/teslamate-org/teslamate) - Self-hosted Tesla data logger with Grafana dashboards
 
 **Virtualization:**
 - [KubeVirt](https://kubevirt.io/) - Virtual machine management on Kubernetes
@@ -98,18 +99,13 @@ A Kubernetes cluster deployed with [Talos Linux](https://github.com/siderolabs/t
 - [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) - Cloudflare bypass proxy
 - [TheLounge](https://thelounge.chat/) - Self-hosted IRC client
 
-**VoIP & Telephony:**
-- [FreePBX](https://www.freepbx.org/) - Containerized telephony platform (MariaDB backend)
-
-**Low-Code Platform:**
-- [UI Bakery](https://uibakery.io/) - Internal tool builder (7 microservices, MariaDB backend)
+**Project Management:**
+- [Plane](https://plane.so/) - Open-source project management platform (PostgreSQL backend)
 
 **Infrastructure & Utilities:**
 - [GitHub Actions Runner Controller](https://github.com/actions/actions-runner-controller) - Self-hosted GitHub Actions runners (special-winner + ambersecurityinc scale sets)
 - [Forgejo](https://forgejo.org/) - Self-hosted Git repository service with CI/CD runners
 - [SMTP Relay](https://github.com/foxcpp/maddy) - Outbound email relay using Maddy
-- [n8n](https://n8n.io/) - Workflow automation platform
-- [Penpot](https://penpot.app/) - Open-source design and prototyping platform
 - [Homepage](https://gethomepage.dev/) - Cluster dashboard for all services
 
 **Additional DNS:**
@@ -561,7 +557,7 @@ Community member [@whazor](https://github.com/whazor) created [Kubesearch](https
 - [x] Test Debian Server VM
 - [x] Test Debian Desktop VM (Debian 13 w/ XFCE4)
 - [ ] Test Kali Linux VM
-- [x] Deploy FreePBX telephony VMs (3 instances: b1, b2, b3)
+- [ ] Deploy FreePBX telephony VMs (3 instances: b1, b2, b3) - manifests staged, currently disabled
 
 **Security & Observability**
 - [ ] Kyverno or OPA Gatekeeper for policy enforcement
@@ -672,11 +668,11 @@ If this repo is too hot to handle or too cold to hold check out these following 
 
 | Metric | Value |
 |--------|-------|
-| **Deployed Components** | 70+ applications across 18 namespaces |
+| **Deployed Components** | 60+ applications across 17 namespaces |
 | **Template Source** | [onedr0p/cluster-template](https://github.com/onedr0p/cluster-template) |
 | **Infrastructure** | GitOps with Flux CD + Talos Linux |
 | **Documentation** | [docs.00o.sh](https://docs.00o.sh) |
-| **Last Updated** | 2026-03-07 |
+| **Last Updated** | 2026-05-14 |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,31 +8,30 @@ Built on the [onedr0p/cluster-template](https://github.com/onedr0p/cluster-templ
 
 | Component | Technology | Version |
 |-----------|-----------|---------|
-| OS | Talos Linux | 1.12.4 |
-| Orchestration | Kubernetes | 1.34.0 |
-| GitOps | Flux CD | 2.7.5 |
-| CNI | Cilium | 1.19.0 |
-| Ingress | Envoy Gateway | v1.6.3 |
-| Secrets | SOPS + Age | 3.12.1 / 1.3.1 |
+| OS | Talos Linux | 1.13.0 |
+| Orchestration | Kubernetes | 1.35.4 |
+| GitOps | Flux CD | 2.8.6 |
+| CNI | Cilium | 1.19.3 |
+| Ingress | Envoy Gateway | v1.7.2 |
+| Secrets | SOPS + Age | 3.13.0 / 1.3.1 |
 | Identity | Kanidm | SSO/OAuth2 |
-| Packages | Helm | 4.1.1 (v4) |
+| Packages | Helm | 4.1.4 (v4) |
 | Database | CloudNative-PG | PostgreSQL 17.7 |
 | Virtualization | KubeVirt | 1.7.0 |
 
 ## What's Deployed
 
-**65+ applications** across **17 namespaces** covering:
+**60+ applications** across **17 namespaces** covering:
 
 - **Media** -- Plex, Radarr, Sonarr, Prowlarr, Bazarr, qBittorrent, and more
-- **Virtualization** -- KubeVirt with Debian, Ubuntu, Windows, and FreePBX VMs
+- **Virtualization** -- KubeVirt with Debian, Ubuntu, and Windows VMs
 - **Identity** -- Kanidm SSO with OAuth2 integrations
-- **Observability** -- Prometheus, Grafana, Victoria Logs, Gatus, OpenCost
-- **Databases** -- PostgreSQL 17.7 HA cluster (3 instances) + Dragonfly
-- **Networking** -- Cilium, Envoy Gateway, Cloudflare Tunnel, Multus
+- **Observability** -- Prometheus, Grafana, Victoria Logs, Gatus, OpenCost, TeslaMate
+- **Databases** -- PostgreSQL 17.7 HA cluster (3 instances) + MariaDB 11.7 Galera + Dragonfly
+- **Networking** -- Cilium, Envoy Gateway, Cloudflare Tunnel, Multus, Macvtap
 - **Storage** -- OpenEBS, VolSync, Garage S3, NFS
 - **CI/CD** -- GitHub Actions runners, Forgejo with CI runners
-- **Networking** -- LibreSpeed multi-path speed test
-- **Utilities** -- Penpot, Homepage, SMTP relay, and more
+- **Utilities** -- Plane, Homepage, Forgejo, SMTP relay, and more
 
 ## Quick Links
 


### PR DESCRIPTION
## Summary

Refresh `README.md`, `docs/index.md`, and `CLAUDE.md` so they match the current cluster state.

**Version bumps** (from `.mise.toml` / `talos/talenv.yaml` / `bootstrap/helmfile.d/01-apps.yaml`):

- Talos Linux: 1.12.4 → **1.13.0**
- Kubernetes: 1.34.0 → **1.35.4**
- Flux CD: 2.8.1 → **2.8.6**
- Cilium: 1.19.0 → **1.19.3**
- Helm: 4.1.1 → **4.1.4**
- SOPS: 3.12.1 → **3.13.0**
- Python: 3.14.3 → **3.14.5**
- Envoy Gateway: v1.6.3 → **v1.7.2**
- External Secrets: 2.0.0 → **2.4.1**
- cert-manager: pinned at **v1.20.2**

**Deployed-applications changes**:

- Removed `ui-bakery` and `zitadel` namespaces (both deleted from the cluster).
- Marked `voip` (FreePBX HelmReleases) and the FreePBX KubeVirt VMs as disabled/removed.
- Marked `recyclarr` (media) and `n8n` / `penpot` / `rustdesk` (utils) as currently disabled in their kustomizations.
- Added `plane` (project management, PostgreSQL backend) to `utils`.
- Added `teslamate` (Tesla data logger) to `observability`.
- Bumped repository-stats line to **60+ applications across 17 namespaces** and last-updated date to 2026-05-14.

## Test plan

- [ ] `mkdocs build` renders the updated index without warnings
- [ ] README versions match `.mise.toml` and `talos/talenv.yaml`
- [ ] CLAUDE.md namespace listings match `kubernetes/apps/*/kustomization.yaml`


---
_Generated by [Claude Code](https://claude.ai/code/session_01LrcvsaAc3kSNouJST2cdm9)_