### PR TITLE
feat(volsync-system): enable authenticated kopia server (prep for 0.23)

### DIFF
--- a/kubernetes/apps/utils/homepage/app/externalsecret.yaml
+++ b/kubernetes/apps/utils/homepage/app/externalsecret.yaml
@@ -21,8 +21,10 @@ spec:
         HOMEPAGE_VAR_PLEX_TOKEN: "{{ .PLEX_TOKEN }}"
         HOMEPAGE_VAR_AUTOBRR_API_KEY: "{{ .AUTOBRR_API_KEY }}"
         HOMEPAGE_VAR_BAZARR_API_KEY: "{{ .BAZARR_API_KEY }}"
-        HOMEPAGE_VAR_KOPIA_USERNAME: "{{ .KOPIA_USERNAME }}"
-        HOMEPAGE_VAR_KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+        # Server-access creds for the Kopia web UI widget (not the
+        # repository encryption password .KOPIA_PASSWORD).
+        HOMEPAGE_VAR_KOPIA_USERNAME: "{{ .KOPIA_SERVER_USERNAME }}"
+        HOMEPAGE_VAR_KOPIA_PASSWORD: "{{ .KOPIA_SERVER_PASSWORD }}"
   dataFrom:
     - extract:
         key: radarr

--- a/kubernetes/apps/volsync-system/kopia/app/externalsecret.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/externalsecret.yaml
@@ -13,6 +13,8 @@ spec:
     template:
       data:
         KOPIA_PASSWORD: "{{ .KOPIA_PASSWORD }}"
+        KOPIA_SERVER_USERNAME: "{{ .KOPIA_SERVER_USERNAME }}"
+        KOPIA_SERVER_PASSWORD: "{{ .KOPIA_SERVER_PASSWORD }}"
   dataFrom:
     - extract:
         key: volsync-template

--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -28,8 +28,13 @@ spec:
             envFrom:
               - secretRef:
                   name: kopia-secret
+            # Kopia 0.23 forces --without-password to bind loopback-only,
+            # so we run an authenticated server instead. --insecure lets
+            # the server speak HTTP (Envoy Gateway terminates TLS).
             args:
-              - --without-password
+              - --insecure
+              - --server-username=$(KOPIA_SERVER_USERNAME)
+              - --server-password=$(KOPIA_SERVER_PASSWORD)
               - --disable-csrf-token-checks
             probes:
               # Kopia's HTTP server briefly goes unresponsive during snapshot
@@ -76,6 +81,8 @@ spec:
         annotations:
           gatus.home-operations.com/endpoint: |-
             group: storage
+            conditions:
+              - "[STATUS] == 401"
           gethomepage.dev/enabled: "true"
           gethomepage.dev/group: Storage
           gethomepage.dev/name: Kopia


### PR DESCRIPTION
## Summary

Kopia 0.23 introduces a breaking change: servers started with `--without-password` are now restricted to loopback binds. Our server is reachable via cluster Service and via Envoy at https://kopia.00o.sh, so 0.23 would break both. This PR switches to an authenticated server so we can land the 0.23 bump cleanly.

## Changes

- **kopia HR** — drop \`--without-password\`, add \`--insecure\` (Envoy terminates TLS, server speaks HTTP behind it), pass \`--server-username\` / \`--server-password\` from the secret. Gatus endpoint condition flipped to expect HTTP 401 (i.e. \"auth-required server is responding\") so the probe stays green without leaking creds into the annotation.
- **kopia ExternalSecret** — extract two new fields from the existing \`volsync-template\` 1Password item: \`KOPIA_SERVER_USERNAME\` and \`KOPIA_SERVER_PASSWORD\`.
- **homepage ExternalSecret** — point the Kopia widget at the new server creds. (Previously \`HOMEPAGE_VAR_KOPIA_*\` were sourced from \`KOPIA_USERNAME\` / \`KOPIA_PASSWORD\` — but \`KOPIA_PASSWORD\` is the repository encryption password, not the web-UI access password, so the widget was effectively unauthenticated against the \`--without-password\` server.)

## One-time prerequisite — do this before merging

Add two new fields to the \`volsync-template\` item in 1Password:
- \`KOPIA_SERVER_USERNAME\` — e.g. \`admin\`
- \`KOPIA_SERVER_PASSWORD\` — generate a strong random string (1Password has a generator)

Once merged, the kopia pod will roll with auth on. The same creds work in the browser at https://kopia.00o.sh and in the Homepage widget.

## Not affected

- VolSync ReplicationSource backups (all 14 apps) — each mover writes to the repository on NFS directly, doesn't touch the kopia HTTP server.
- \`kopia-maint-daily\` CronJob — same pattern (direct repo access via \`volsync-maintenance-secret\`).
- \`scripts/volsync-restore-all.sh\` — uses ReplicationDestinations, not the kopia server.

## Test plan

- [x] 1Password fields added (\`KOPIA_SERVER_USERNAME\`, \`KOPIA_SERVER_PASSWORD\`)
- [ ] kopia pod rolls and stays Ready (loosened probes already handle restart spikes)
- [ ] \`curl -I https://kopia.00o.sh\` returns 401 (auth required)
- [ ] Browser at https://kopia.00o.sh prompts for creds; new creds work
- [ ] Homepage Kopia widget shows snapshot count / repository size
- [ ] Gatus \`storage / kopia\` endpoint goes green
- [ ] Pick one VolSync app, watch the next 02:00 backup cycle succeed

Once those clear, PR #966 (kopia 0.23.0) can be merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)