### PR TITLE
feat(talos): mount sdb on PVE nodes for Garage 3-zone (Phase 1)

### DIFF
--- a/talos/patches/node-01-pve/user-volume-garage.yaml
+++ b/talos/patches/node-01-pve/user-volume-garage.yaml
@@ -1,0 +1,19 @@
+---
+# Mount the second virtio disk (sdb, ~137 GB) at /var/mnt/garage-data so it
+# can host the Garage 3-zone replica running on this node. The PVE nodes'
+# system disk (sda) stays in place for everything else — this disk is
+# dedicated to Garage data only.
+#
+# Selector picks the smaller of the two virtio disks: sda is the rotational
+# system disk (~275 GB), sdb is the dedicated non-rotational data disk
+# (~137 GB). disk.rotational == false matches sdb only.
+apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: garage-data
+provisioning:
+  diskSelector:
+    match: disk.transport == "virtio" && !disk.rotational
+  minSize: 100GB
+  maxSize: 150GB
+filesystem:
+  type: xfs

--- a/talos/patches/node-02-pve/user-volume-garage.yaml
+++ b/talos/patches/node-02-pve/user-volume-garage.yaml
@@ -1,0 +1,19 @@
+---
+# Mount the second virtio disk (sdb, ~137 GB) at /var/mnt/garage-data so it
+# can host the Garage 3-zone replica running on this node. The PVE nodes'
+# system disk (sda) stays in place for everything else — this disk is
+# dedicated to Garage data only.
+#
+# Selector picks the smaller of the two virtio disks: sda is the rotational
+# system disk (~275 GB), sdb is the dedicated non-rotational data disk
+# (~137 GB). disk.rotational == false matches sdb only.
+apiVersion: v1alpha1
+kind: UserVolumeConfig
+name: garage-data
+provisioning:
+  diskSelector:
+    match: disk.transport == "virtio" && !disk.rotational
+  minSize: 100GB
+  maxSize: 150GB
+filesystem:
+  type: xfs

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -99,6 +99,7 @@ nodes:
           ip: 10.0.6.10
     patches:
       - "@./patches/vm-node/machine-kubelet.yaml"
+      - "@./patches/node-01-pve/user-volume-garage.yaml"
 
   - hostname: "node-02-pve"
     ipAddress: "10.0.6.213"
@@ -138,6 +139,7 @@ nodes:
           ip: 10.0.6.10
     patches:
       - "@./patches/vm-node/machine-kubelet.yaml"
+      - "@./patches/node-02-pve/user-volume-garage.yaml"
 
 
 # Global patches


### PR DESCRIPTION
## Summary
Add Talos `UserVolumeConfig` patches that mount each PVE node's second virtio disk (sdb, ~137 GB, non-rotational) at `/var/mnt/garage-data`. Dedicated to the upcoming Garage 3-zone HA cluster.

Phase 1 of the Garage 3-zone migration. Subsequent phases (in separate PRs):
- Phase 2: `garage-ha` HelmRelease (StatefulSet, 3 replicas, anti-affinity, replication_factor=3) + pre-created PVs + storage class
- Phase 3: One-shot Job to form layout (`garage layout assign`/`apply`) and rclone-copy buckets from existing single-instance Garage
- Phase 4: Cut over CNPG / MariaDB / Kanidm consumer endpoints
- Phase 5: Decommission old single-instance Garage, drop NFS data dir + backup-sync sidecar + Phase 6 of `volsync-restore-all.sh`

## What changes
- `talos/patches/node-01-pve/user-volume-garage.yaml` — new
- `talos/patches/node-02-pve/user-volume-garage.yaml` — new
- `talos/talconfig.yaml` — reference the new patches under each PVE node's `patches:` list

Disk selector picks the non-rotational virtio disk only (sda is rotational, sdb is not), so sda stays untouched.

singlenodemaster is **not** touched — its NVMe layout stays as-is; Garage's SNM replica will use a subdir of `/var/mnt/nvme-data` when Phase 2 lands.

## Test plan
- [ ] CI / talhelper validation
- [ ] After merge, run `task talos:generate-config` then `task talos:apply-node IP=10.0.6.212 MODE=auto` and the same for 10.0.6.213. Mode `auto` reboots only if required for the UserVolume to mount.
- [ ] Confirm `talosctl -n 10.0.6.212 get mountstatuses | grep garage-data` shows the mount
- [ ] Confirm `talosctl -n 10.0.6.213 get mountstatuses | grep garage-data` shows the mount
- [ ] Confirm existing PVCs on each PVE node (8 of them at `/var/mnt/nvme-data/...` on sda) are unaffected — pods still running, data accessible

## Rollback
Revert this commit. UserVolumeConfig removal would not destroy the disk's content but the mount would go away on next config apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)