### PR TITLE
feat(volsync-system): garage 3-zone HA cluster (Phase 2)

### DIFF
--- a/kubernetes/apps/volsync-system/garage-ha/app/externalsecret.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: garage-ha
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: garage-ha-secret
+    template:
+      data:
+        GARAGE_ADMIN_TOKEN: "{{ .GARAGE_ADMIN_TOKEN }}"
+        GARAGE_METRICS_TOKEN: "{{ .GARAGE_METRICS_TOKEN }}"
+        GARAGE_RPC_SECRET: "{{ .GARAGE_RPC_SECRET }}"
+  dataFrom:
+    - extract:
+        key: garage-ha

--- a/kubernetes/apps/volsync-system/garage-ha/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/helmrelease.yaml
@@ -1,0 +1,168 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app garage-ha
+spec:
+  interval: 2h
+  chartRef:
+    kind: OCIRepository
+    name: garage-ha-app
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      garage:
+        type: statefulset
+        replicas: 3
+        annotations:
+          reloader.stakater.com/auto: "true"
+        statefulset:
+          podManagementPolicy: Parallel
+          volumeClaimTemplates:
+            - name: data
+              accessMode: ReadWriteOnce
+              size: 100Gi
+              storageClass: garage-local
+              globalMounts:
+                - path: /data
+        containers:
+          app:
+            image:
+              repository: dxflrs/garage
+              tag: v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+            envFrom:
+              - secretRef:
+                  name: garage-ha-secret
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 100m
+                memory: 256Mi
+              limits:
+                memory: 512Mi
+    defaultPodOptions:
+      serviceAccount:
+        name: garage-ha
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        fsGroup: 10000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      # One pod per node — Garage's 3-zone topology depends on each replica
+      # being on a distinct node so a node loss takes out exactly one zone.
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: *app
+              topologyKey: kubernetes.io/hostname
+    serviceAccount:
+      garage-ha:
+        # ServiceAccount itself is created by rbac.yaml (with the matching
+        # ClusterRole/Binding for the GarageNode CRD); referenced above
+        # via defaultPodOptions.serviceAccount.name. This block exists only
+        # so app-template doesn't auto-create a competing SA.
+        identifier: garage-ha
+        enabled: false
+    service:
+      # Headless service used by kubernetes_discovery to enumerate peers.
+      headless:
+        controller: garage
+        clusterIP: None
+        ports:
+          rpc:
+            port: 3901
+      # Client-facing ClusterIP service (S3, admin, web). Other apps
+      # (CNPG, MariaDB, Kanidm) will point here after Phase 4 cutover.
+      app:
+        controller: garage
+        ports:
+          api:
+            port: &port 3903
+          web:
+            port: &webPort 3902
+          s3:
+            port: &s3Port 3900
+    route:
+      api:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            name: Garage S3 API (HA)
+            group: storage
+            interval: 1m
+            urlPath: /health
+            conditions:
+              - "[STATUS] >= 200 && [STATUS] < 405"
+        hostnames:
+          - garage-ha-api.00o.sh
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *port
+      s3:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            name: Garage S3 (HA)
+            group: storage
+            interval: 1m
+            urlPath: /health
+            conditions:
+              - "[STATUS] >= 200 && [STATUS] < 405"
+        hostnames:
+          - garage-ha-s3.00o.sh
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *s3Port
+      web:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            name: Garage Bucket Web Access (HA)
+            group: storage
+            interval: 1m
+            urlPath: /
+            conditions:
+              - "[STATUS] >= 200 && [STATUS] < 405"
+        hostnames:
+          - garage-ha-web.00o.sh
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: *app
+                port: *webPort
+    persistence:
+      config:
+        enabled: true
+        type: configMap
+        name: garage-ha
+        globalMounts:
+          - path: /etc/garage.toml
+            subPath: configuration.toml

--- a/kubernetes/apps/volsync-system/garage-ha/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/helmrelease.yaml
@@ -54,8 +54,6 @@ spec:
               limits:
                 memory: 512Mi
     defaultPodOptions:
-      serviceAccount:
-        name: garage-ha
       securityContext:
         runAsNonRoot: true
         runAsUser: 10000
@@ -73,14 +71,10 @@ spec:
                 matchLabels:
                   app.kubernetes.io/name: *app
               topologyKey: kubernetes.io/hostname
+    # Chart creates the ServiceAccount; the matching ClusterRole/Binding
+    # for the GarageNode CRD lives in rbac.yaml.
     serviceAccount:
-      garage-ha:
-        # ServiceAccount itself is created by rbac.yaml (with the matching
-        # ClusterRole/Binding for the GarageNode CRD); referenced above
-        # via defaultPodOptions.serviceAccount.name. This block exists only
-        # so app-template doesn't auto-create a competing SA.
-        identifier: garage-ha
-        enabled: false
+      garage-ha: {}
     service:
       # Headless service used by kubernetes_discovery to enumerate peers.
       headless:

--- a/kubernetes/apps/volsync-system/garage-ha/app/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/kustomization.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./persistentvolumes.yaml
+  - ./rbac.yaml
+  - ./storageclass.yaml
+configMapGenerator:
+  - name: garage-ha
+    files:
+      - ./resources/configuration.toml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/volsync-system/garage-ha/app/ocirepository.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: garage-ha-app
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/volsync-system/garage-ha/app/persistentvolumes.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/persistentvolumes.yaml
@@ -4,11 +4,11 @@
 # Garage pods schedule via anti-affinity (one-per-node), and each pod's
 # PVC binds to the PV whose nodeAffinity matches the scheduled node.
 #
-# PVE node paths (/var/mnt/garage-data) are dedicated mounts of sdb, set
-# up by Talos UserVolumeConfig in talos/patches/node-0{1,2}-pve/.
-# singlenodemaster reuses its existing /var/mnt/nvme-data mount; the
-# garage-data/ subdirectory there is created by an init Job before this
-# manifest is applied (see PR description).
+# Volumes are `hostPath` with `type: DirectoryOrCreate` so kubelet creates
+# the path on first mount — no manual mkdir needed on any node.
+# - PVE nodes: path is on the sdb mount set up by Talos UserVolumeConfig.
+# - singlenodemaster: path is a subdirectory of the existing /var/mnt/nvme-data
+#   mount; kubelet creates the subdirectory the first time.
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -23,8 +23,9 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: garage-local
   volumeMode: Filesystem
-  local:
+  hostPath:
     path: /var/mnt/nvme-data/garage-data
+    type: DirectoryOrCreate
   nodeAffinity:
     required:
       nodeSelectorTerms:
@@ -48,8 +49,9 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: garage-local
   volumeMode: Filesystem
-  local:
+  hostPath:
     path: /var/mnt/garage-data
+    type: DirectoryOrCreate
   nodeAffinity:
     required:
       nodeSelectorTerms:
@@ -73,8 +75,9 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: garage-local
   volumeMode: Filesystem
-  local:
+  hostPath:
     path: /var/mnt/garage-data
+    type: DirectoryOrCreate
   nodeAffinity:
     required:
       nodeSelectorTerms:

--- a/kubernetes/apps/volsync-system/garage-ha/app/persistentvolumes.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/persistentvolumes.yaml
@@ -1,0 +1,85 @@
+---
+# Three pre-created PVs, one per node, for the Garage HA StatefulSet's
+# volumeClaimTemplate. Each PV pins to a specific node via nodeAffinity;
+# Garage pods schedule via anti-affinity (one-per-node), and each pod's
+# PVC binds to the PV whose nodeAffinity matches the scheduled node.
+#
+# PVE node paths (/var/mnt/garage-data) are dedicated mounts of sdb, set
+# up by Talos UserVolumeConfig in talos/patches/node-0{1,2}-pve/.
+# singlenodemaster reuses its existing /var/mnt/nvme-data mount; the
+# garage-data/ subdirectory there is created by an init Job before this
+# manifest is applied (see PR description).
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: garage-ha-data-singlenodemaster
+  labels:
+    app.kubernetes.io/name: garage-ha
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: garage-local
+  volumeMode: Filesystem
+  local:
+    path: /var/mnt/nvme-data/garage-data
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - singlenodemaster
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: garage-ha-data-node-01-pve
+  labels:
+    app.kubernetes.io/name: garage-ha
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: garage-local
+  volumeMode: Filesystem
+  local:
+    path: /var/mnt/garage-data
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - node-01-pve
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: garage-ha-data-node-02-pve
+  labels:
+    app.kubernetes.io/name: garage-ha
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: garage-local
+  volumeMode: Filesystem
+  local:
+    path: /var/mnt/garage-data
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - node-02-pve

--- a/kubernetes/apps/volsync-system/garage-ha/app/rbac.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/rbac.yaml
@@ -1,0 +1,47 @@
+---
+# ServiceAccount + RBAC for Garage's kubernetes-discovery feature. Garage
+# uses a `GarageNode` CRD entry per peer to advertise itself and discover
+# others, so each instance needs to read/write that CRD across the cluster.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: garage-ha
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: garage-ha
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - create
+      - patch
+  - apiGroups:
+      - deuxfleurs.fr
+    resources:
+      - garagenodes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: garage-ha
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: garage-ha
+subjects:
+  - kind: ServiceAccount
+    name: garage-ha
+    namespace: volsync-system

--- a/kubernetes/apps/volsync-system/garage-ha/app/rbac.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/rbac.yaml
@@ -1,12 +1,9 @@
 ---
-# ServiceAccount + RBAC for Garage's kubernetes-discovery feature. Garage
-# uses a `GarageNode` CRD entry per peer to advertise itself and discover
-# others, so each instance needs to read/write that CRD across the cluster.
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: garage-ha
----
+# RBAC for Garage's kubernetes-discovery feature. Garage uses a `GarageNode`
+# CRD entry per peer to advertise itself and discover others, so each
+# instance needs to read/write that CRD across the cluster.
+# The ServiceAccount itself is created by the app-template chart via
+# `serviceAccount.garage-ha: {}` in helmrelease.yaml.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/kubernetes/apps/volsync-system/garage-ha/app/resources/configuration.toml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/resources/configuration.toml
@@ -1,0 +1,32 @@
+metadata_dir = "/data/meta"
+data_dir = "/data/data"
+db_engine = "lmdb"
+metadata_auto_snapshot_interval = "6h"
+
+replication_factor = 3
+compression_level = 2
+
+rpc_bind_addr = "[::]:3901"
+# Auto-pick the pod IP from the cluster pod CIDR for inter-instance RPC.
+# Pod CIDR is defined in cluster.yaml (172.30.0.0/16, see CLAUDE.md).
+rpc_public_addr_subnet = "172.30.0.0/16"
+
+[s3_api]
+s3_region = "USTX01"
+api_bind_addr = "[::]:3900"
+root_domain = ".garage-s3.00o.sh"
+
+[s3_web]
+bind_addr = "[::]:3902"
+root_domain = ".garage-web.00o.sh"
+
+[admin]
+api_bind_addr = "[::]:3903"
+
+# Peer discovery: each pod registers itself in a `GarageNode` CRD entry
+# in this namespace; peers find each other by listing the CRD. RBAC for
+# the CRD is granted via rbac.yaml.
+[kubernetes_discovery]
+namespace = "volsync-system"
+service_name = "garage-ha-headless"
+skip_crd = false

--- a/kubernetes/apps/volsync-system/garage-ha/app/storageclass.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/storageclass.yaml
@@ -1,0 +1,12 @@
+---
+# Dedicated StorageClass for Garage HA replicas. No dynamic provisioning —
+# each PV is hand-crafted with a per-node path and node affinity (see
+# persistentvolumes.yaml). WaitForFirstConsumer ensures a PVC binds only
+# after its pod is scheduled, picking the PV whose node matches.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: garage-local
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: Retain

--- a/kubernetes/apps/volsync-system/garage-ha/ks.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/ks.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-ha
+  namespace: &namespace volsync-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: volsync
+  interval: 1h
+  path: ./kubernetes/apps/volsync-system/garage-ha/app
+  postBuild:
+    substitute:
+      APP: *app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 10m
+  wait: false

--- a/kubernetes/apps/volsync-system/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/kustomization.yaml
@@ -79,3 +79,4 @@ resources:
   - ./kopia/ks.yaml
   - ./volsync/ks.yaml
   - ./garage/ks.yaml
+  - ./garage-ha/ks.yaml


### PR DESCRIPTION
## Summary
Side-by-side install of a 3-replica HA Garage cluster alongside the existing single-instance `garage` deployment. The old install keeps serving backups; this one comes up empty, ready for Phase 3 to populate it via rclone copy.

Follows #1020 (Phase 1: PVE disk mounts).

## Architecture
- **StatefulSet** `garage-ha`, 3 replicas, pod anti-affinity (one per node)
- **replication_factor=3**, `kubernetes_discovery` for peer enumeration (peer list = `GarageNode` CRD entries)
- **Pre-created PVs** (100 GiB each, `hostPath` + `DirectoryOrCreate` so kubelet auto-creates the path on first mount):
  - singlenodemaster → `/var/mnt/nvme-data/garage-data` (subdir of existing NVMe)
  - node-01-pve → `/var/mnt/garage-data` (sdb mount from Phase 1)
  - node-02-pve → `/var/mnt/garage-data` (sdb mount from Phase 1)
- **StorageClass** `garage-local` (no-provisioner, WaitForFirstConsumer)
- **RBAC** granting Garage write access to the `GarageNode` CRD it self-manages
- **Services**: `garage-ha-headless` (clusterIP=None, peer RPC) and `garage-ha` (ClusterIP, S3/admin/web for clients)
- **HTTPRoutes**: `garage-ha-{api,s3,web}.00o.sh` — parallel to existing `garage-{api,s3,web}` hostnames

## Secrets
A new 1Password item `garage-ha` was created in vault `Kubernetes` with freshly-generated `GARAGE_ADMIN_TOKEN`, `GARAGE_METRICS_TOKEN`, `GARAGE_RPC_SECRET` (32-byte hex each, independent of the existing `garage` item).

## Test plan
- [ ] CI / flux-local validates
- [ ] After merge + reconcile: 3 `garage-ha-N` pods Running, one per node
- [ ] `kubectl -n volsync-system exec garage-ha-0 -- /garage status` shows 3 healthy nodes, 3 zones
- [ ] `kubectl get pv | grep garage-ha` shows all 3 PVs `Bound`
- [ ] Existing single-instance `garage` deployment unchanged and still serving (this PR doesn't touch it)

## Next steps after merge
- **Phase 3** PR: one-shot Job to `garage layout assign` zones for each new node, `garage layout apply`, then rclone-copy buckets from `garage` → `garage-ha`
- **Phase 4** PR: switch CNPG `objectstore.yaml`, MariaDB `backup.yaml`, Kanidm cronjob to `garage-ha.volsync-system.svc...`
- **Phase 5** PR: decommission old `garage`, rename `garage-ha` → `garage` if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)