### PR TITLE
fix(volsync-system): garage-ha initContainer chowns /data

### DIFF
--- a/kubernetes/apps/volsync-system/garage-ha/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/helmrelease.yaml
@@ -33,6 +33,24 @@ spec:
               storageClass: garage-local
               globalMounts:
                 - path: /data
+        initContainers:
+          # hostPath / local PVs don't honor fsGroup, so the directory
+          # kubelet creates is root:root mode 0755 and the non-root Garage
+          # process can't write. Chown to the pod's UID/GID once per start.
+          chown-data:
+            image:
+              repository: ghcr.io/home-operations/busybox
+              tag: 1.37.0@sha256:026ed7273270ec08f6902b4ae8334c23b473e5394bec3bbbdbfe580c710d50bc
+            command: ["sh", "-c", "chown -R 10000:10000 /data"]
+            securityContext:
+              runAsUser: 0
+              runAsGroup: 0
+              runAsNonRoot: false
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: [ALL]
+                add: [CHOWN]
         containers:
           app:
             image:


### PR DESCRIPTION
## Summary
After #1021 merged, the 3 \`garage-ha-N\` pods cycle in \`Error\` state with \`Unable to create Garage metadata directory: Permission denied\`. Root cause: \`hostPath\` (and in-tree \`local\`) PVs do not honor \`fsGroup\`, so the directory kubelet creates via \`DirectoryOrCreate\` lands as \`root:root 0755\` and the non-root Garage process (UID 10000) can't write.

Adds an Alpine initContainer that runs as root once per pod start, chowns \`/data\` to \`10000:10000\`, then exits. Only the \`CHOWN\` capability is added; everything else stays dropped. Idempotent across restarts.

## Test plan
- [ ] After merge + reconcile: all 3 garage-ha pods Running 1/1
- [ ] \`kubectl -n volsync-system exec garage-ha-0 -c app -- /garage status\` lists 3 healthy nodes
- [ ] Pods' \`/data\` owned by 10000:10000

🤖 Generated with [Claude Code](https://claude.com/claude-code)