### PR TITLE
fix(volsync-system): garage-ha automount SA token for kubernetes_discovery

### DIFF
--- a/kubernetes/apps/volsync-system/garage-ha/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/helmrelease.yaml
@@ -72,6 +72,11 @@ spec:
               limits:
                 memory: 512Mi
     defaultPodOptions:
+      # app-template v5 doesn't auto-mount SA tokens by default. Garage's
+      # kubernetes_discovery feature talks to the K8s API to publish/discover
+      # its GarageNode CRD entries; without the token, peers never see each
+      # other.
+      automountServiceAccountToken: true
       securityContext:
         runAsNonRoot: true
         runAsUser: 10000


### PR DESCRIPTION
## Problem
After #1023 landed and the chown init unblocked startup, the 3 garage-ha pods are Running but logs show:

> Failed to create kubernetes custom resource: ... failed to read the default namespace: No such file or directory
> Could not retrieve node list from Kubernetes: ...

`/garage status` confirms only one node visible per pod — \`kubernetes_discovery\` can't reach the API because the ServiceAccount token isn't mounted.

## Root cause
app-template v5 defaults to \`automountServiceAccountToken: false\`. Other workloads in the repo that need API access (homepage, gatus, kubevirt-manager) explicitly re-enable it; garage-ha needs the same.

## Fix
Set \`defaultPodOptions.automountServiceAccountToken: true\` on the garage-ha HelmRelease.

## Test plan
- [ ] After merge + reconcile: \`/garage status\` from any pod shows **3 healthy nodes**
- [ ] No more "failed to read the default namespace" errors in pod logs
- [ ] \`kubectl get garagenodes\` (the CRD Garage auto-creates) returns 3 entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)