### PR TITLE
feat(volsync-system): garage-ha 3-zone layout bootstrap Job (Phase 3)

### DIFF
--- a/kubernetes/apps/volsync-system/garage-ha/ks.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/ks.yaml
@@ -25,3 +25,29 @@ spec:
   targetNamespace: *namespace
   timeout: 10m
   wait: false
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app garage-ha-layout
+  namespace: &namespace volsync-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  # Layout Job needs the StatefulSet and its Service running before it can
+  # connect via RPC; wait for the parent Kustomization to be Ready first.
+  dependsOn:
+    - name: garage-ha
+  interval: 1h
+  path: ./kubernetes/apps/volsync-system/garage-ha/layout
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: *namespace
+  timeout: 10m
+  wait: false

--- a/kubernetes/apps/volsync-system/garage-ha/layout/job.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/layout/job.yaml
@@ -1,0 +1,106 @@
+---
+# One-shot layout bootstrap for the Garage 3-zone cluster. Idempotent: if
+# all 3 nodes already have a non-`NO ROLE` zone assignment, the script
+# exits 0 without doing anything. Otherwise it waits for 3 healthy peers,
+# assigns distinct zones (z1/z2/z3) with 100 GiB capacity each, and applies
+# layout version 1.
+#
+# Connects to the cluster via the headless service to one of the garage-ha
+# pods using GARAGE_RPC_HOST + GARAGE_RPC_SECRET.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: garage-ha-layout-v1
+  labels:
+    app.kubernetes.io/name: garage-ha
+spec:
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: garage-ha
+        app.kubernetes.io/component: layout
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: layout
+          image: dxflrs/garage:v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          env:
+            - name: GARAGE_RPC_HOST
+              value: garage-ha-0.garage-ha-headless.volsync-system.svc.cluster.local:3901
+            - name: GARAGE_RPC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: garage-ha-secret
+                  key: GARAGE_RPC_SECRET
+          command: [/bin/sh, -c]
+          args:
+            - |
+              set -eu
+
+              echo "[$(date -Iseconds)] waiting for 3 healthy nodes…"
+              status=""
+              for i in $(seq 1 120); do
+                status=$(/garage status 2>/dev/null || true)
+                # The garage status table starts after the HEALTHY NODES header.
+                # Count node-id lines (first column is 16 hex chars).
+                count=$(printf '%s\n' "$status" | awk '
+                  /HEALTHY NODES/ { in_block=1; next }
+                  /^==/           { in_block=0 }
+                  in_block && /^[0-9a-f]{16}/ { c++ }
+                  END { print c+0 }
+                ')
+                if [ "$count" -ge 3 ]; then
+                  echo "[$(date -Iseconds)] 3 healthy nodes visible"
+                  break
+                fi
+                echo "[$(date -Iseconds)] $count/3 healthy, retrying…"
+                sleep 5
+              done
+              if [ "$count" -lt 3 ]; then
+                echo "ERROR: timed out waiting for 3 healthy nodes" >&2
+                /garage status >&2 || true
+                exit 1
+              fi
+
+              # Idempotency: if all 3 nodes already have a zone, we're done.
+              no_role=$(printf '%s\n' "$status" | awk '/HEALTHY NODES/,/^==[^=]/' | grep -c 'NO ROLE' || true)
+              if [ "$no_role" -eq 0 ]; then
+                echo "[$(date -Iseconds)] layout already applied; nothing to do"
+                exit 0
+              fi
+              echo "[$(date -Iseconds)] $no_role node(s) without role; assigning zones…"
+
+              # Extract node IDs by hostname (StatefulSet gives stable hostnames).
+              ID0=$(printf '%s\n' "$status" | awk '/garage-ha-0/{print $1; exit}')
+              ID1=$(printf '%s\n' "$status" | awk '/garage-ha-1/{print $1; exit}')
+              ID2=$(printf '%s\n' "$status" | awk '/garage-ha-2/{print $1; exit}')
+              if [ -z "${ID0:-}" ] || [ -z "${ID1:-}" ] || [ -z "${ID2:-}" ]; then
+                echo "ERROR: could not find all 3 garage-ha-N node IDs in status:" >&2
+                printf '%s\n' "$status" >&2
+                exit 1
+              fi
+              echo "[$(date -Iseconds)] node IDs: 0=$ID0 1=$ID1 2=$ID2"
+
+              # Three distinct zones (z1/z2/z3) so the 3-way replication has
+              # one copy per failure domain. Capacity 100 GiB per node matches
+              # the PV size in persistentvolumes.yaml.
+              /garage layout assign --zone z1 --capacity 100000000000 "$ID0"
+              /garage layout assign --zone z2 --capacity 100000000000 "$ID1"
+              /garage layout assign --zone z3 --capacity 100000000000 "$ID2"
+              /garage layout apply --version 1
+
+              echo "[$(date -Iseconds)] layout v1 applied"
+              /garage status

--- a/kubernetes/apps/volsync-system/garage-ha/layout/kustomization.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/layout/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./job.yaml


### PR DESCRIPTION
## Summary
Idempotent Job that bootstraps the 3-zone Garage layout once the StatefulSet is up. Follows #1020 (Phase 1), #1021 (Phase 2), #1023 (chown init fix), #1024 (SA token mount fix).

## What it does
1. Connects to \`garage-ha-0\` via RPC using \`GARAGE_RPC_HOST\` + \`GARAGE_RPC_SECRET\` (from the existing \`garage-ha-secret\` ExternalSecret).
2. Polls \`/garage status\` up to ~10 minutes waiting for 3 healthy nodes.
3. If all 3 already have a zone assigned: exits 0 (idempotent).
4. Otherwise: extracts node IDs by hostname (\`garage-ha-0/1/2\`), runs \`garage layout assign --zone z{1,2,3} --capacity 100GB\` for each, then \`garage layout apply --version 1\`.

## Structure
- New manifest: \`kubernetes/apps/volsync-system/garage-ha/layout/job.yaml\` (+ \`kustomization.yaml\`)
- New Flux \`Kustomization\` (\`garage-ha-layout\`) added to the existing \`garage-ha/ks.yaml\`, with \`dependsOn: garage-ha\` so it waits for the StatefulSet's KS to be Ready before running.

## What this PR does NOT do
- Bucket copy. That's one-off and stays as a scratch \`kubectl run rclone\` command at migration time, not in the repo.
- Endpoint cutover (CNPG / MariaDB / Kanidm) — that's Phase 4, separate PR.
- Decommission old garage — Phase 5.
- Domain swap (drop \`-ha-\` from hostnames) — Phase 6.

## Test plan
- [ ] CI / flux-local validates
- [ ] After merge + reconcile, \`kubectl -n volsync-system get jobs\` shows \`garage-ha-layout-v1\` Complete
- [ ] \`kubectl -n volsync-system exec garage-ha-0 -c app -- /garage status\` shows 3 nodes with zones z1/z2/z3 and Capacity \`93 GiB\` (or similar)
- [ ] \`kubectl -n volsync-system logs job/garage-ha-layout-v1\` shows "layout v1 applied"

## Rollback
The Job is idempotent and the layout, once applied, is part of cluster metadata — reverting this PR doesn't unwind the layout. To undo: \`garage layout revert\` or remove zone assignments manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)