### PR TITLE
fix(volsync-system): garage-ha layout Job uses distinct label

### DIFF
--- a/kubernetes/apps/volsync-system/garage-ha/layout/job.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/layout/job.yaml
@@ -11,16 +11,18 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: garage-ha-layout-v1
+  # Job uses a distinct app.kubernetes.io/name so the StatefulSet's
+  # anti-affinity rule (which targets app.kubernetes.io/name=garage-ha)
+  # doesn't reject the Job pod from every node.
   labels:
-    app.kubernetes.io/name: garage-ha
+    app.kubernetes.io/name: garage-ha-layout
 spec:
   backoffLimit: 5
   ttlSecondsAfterFinished: 86400
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: garage-ha
-        app.kubernetes.io/component: layout
+        app.kubernetes.io/name: garage-ha-layout
     spec:
       restartPolicy: OnFailure
       securityContext:


### PR DESCRIPTION
## Problem
After #1025 landed, \`garage-ha-layout-v1\` Job pod sat \`Pending\` for over an hour with:

> 0/3 nodes are available: 3 node(s) didn't satisfy existing pods anti-affinity rules

Root cause: the Job pod inherited \`app.kubernetes.io/name: garage-ha\`, which is exactly the label the StatefulSet's \`podAntiAffinity\` rule targets. With all 3 Garage pods occupying all 3 nodes, every node "rejected" the Job pod.

## Fix
Relabel the Job (and its pod template) to \`app.kubernetes.io/name: garage-ha-layout\` so the anti-affinity rule doesn't match.

## Test plan
- [ ] After merge: Job pod schedules onto any node, runs, exits 0
- [ ] \`/garage status\` shows 3 nodes with zones z1/z2/z3 (no more \`NO ROLE ASSIGNED\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)