### PR TITLE
feat(volsync-system): switch S3 consumers from garage to garage-ha (Phase 4)

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/bucket-init/bucket-init.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/bucket-init/bucket-init.yaml
@@ -29,10 +29,10 @@ spec:
             - /bin/sh
             - -c
             - |
-              aws --endpoint-url http://garage.volsync-system.svc.cluster.local:3900 \
+              aws --endpoint-url http://garage-ha-app.volsync-system.svc.cluster.local:3900 \
                 s3api head-bucket --bucket cnpg 2>/dev/null && \
                 echo "Bucket cnpg already exists" && exit 0
-              aws --endpoint-url http://garage.volsync-system.svc.cluster.local:3900 \
+              aws --endpoint-url http://garage-ha-app.volsync-system.svc.cluster.local:3900 \
                 s3 mb s3://cnpg && \
                 echo "Bucket cnpg created successfully"
           securityContext:

--- a/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   configuration:
     destinationPath: s3://cnpg/
-    endpointURL: http://garage.volsync-system.svc.cluster.local:3900
+    endpointURL: http://garage-ha-app.volsync-system.svc.cluster.local:3900
     s3Credentials:
       accessKeyId:
         name: cloudnative-pg-secret

--- a/kubernetes/apps/database/mariadb-operator/bucket-init/bucket-init.yaml
+++ b/kubernetes/apps/database/mariadb-operator/bucket-init/bucket-init.yaml
@@ -29,10 +29,10 @@ spec:
             - /bin/sh
             - -c
             - |
-              aws --endpoint-url http://garage.volsync-system.svc.cluster.local:3900 \
+              aws --endpoint-url http://garage-ha-app.volsync-system.svc.cluster.local:3900 \
                 s3api head-bucket --bucket mariadb-backups 2>/dev/null && \
                 echo "Bucket mariadb-backups already exists" && exit 0
-              aws --endpoint-url http://garage.volsync-system.svc.cluster.local:3900 \
+              aws --endpoint-url http://garage-ha-app.volsync-system.svc.cluster.local:3900 \
                 s3 mb s3://mariadb-backups && \
                 echo "Bucket mariadb-backups created successfully"
           securityContext:

--- a/kubernetes/apps/database/mariadb-operator/cluster/backup.yaml
+++ b/kubernetes/apps/database/mariadb-operator/cluster/backup.yaml
@@ -15,7 +15,7 @@ spec:
     s3:
       bucket: mariadb-backups
       prefix: galera
-      endpoint: garage.volsync-system.svc.cluster.local:3900
+      endpoint: garage-ha-app.volsync-system.svc.cluster.local:3900
       region: USTX01
       accessKeyIdSecretKeyRef:
         name: mariadb-secret

--- a/kubernetes/apps/identity/kanidm/instance/cronjob.yaml
+++ b/kubernetes/apps/identity/kanidm/instance/cronjob.yaml
@@ -41,7 +41,7 @@ spec:
                   fi
               env:
                 - name: S3_ENDPOINT
-                  value: http://garage.volsync-system.svc.cluster.local:3900
+                  value: http://garage-ha-app.volsync-system.svc.cluster.local:3900
                 - name: AWS_ACCESS_KEY_ID
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
## Summary
Cut over CNPG, MariaDB, and Kanidm backup endpoints from the old single-instance \`garage\` to the 3-zone \`garage-ha\` cluster.

Since the access keys (same IDs + secrets) were imported to garage-ha and bucket data was rclone-copied before this PR, only the service hostname changes:

> \`garage.volsync-system.svc.cluster.local:3900\` → \`garage-ha-app.volsync-system.svc.cluster.local:3900\`

## Changed
- \`kubernetes/apps/database/cloudnative-pg/cluster/objectstore.yaml\`
- \`kubernetes/apps/database/cloudnative-pg/bucket-init/bucket-init.yaml\` (2 sites)
- \`kubernetes/apps/database/mariadb-operator/cluster/backup.yaml\`
- \`kubernetes/apps/database/mariadb-operator/bucket-init/bucket-init.yaml\` (2 sites)
- \`kubernetes/apps/identity/kanidm/instance/cronjob.yaml\`

## Not touched
- \`kubernetes/apps/volsync-system/garage/webui/helmrelease.yaml\` — belongs to the old install, repointed/removed in Phase 5.

## Test plan
- [ ] CI / flux-local validates
- [ ] After merge: CNPG \`ObjectStore\` reconciles with new endpoint, a fresh WAL archive lands successfully
- [ ] MariaDB next scheduled backup writes to \`garage-ha-app\`
- [ ] Kanidm next \`backup-sync\` CronJob succeeds against new endpoint
- [ ] Old \`garage\` deployment remains running (Phase 5 decom is a separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)