### PR TITLE
feat(volsync-system): drop garage-ha- hostname prefix (Phase 6)

### DIFF
--- a/kubernetes/apps/volsync-system/garage-ha/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/app/helmrelease.yaml
@@ -121,14 +121,14 @@ spec:
       api:
         annotations:
           gatus.home-operations.com/endpoint: |-
-            name: Garage S3 API (HA)
+            name: Garage S3 API
             group: storage
             interval: 1m
             urlPath: /health
             conditions:
               - "[STATUS] >= 200 && [STATUS] < 405"
         hostnames:
-          - garage-ha-api.00o.sh
+          - garage-api.00o.sh
         parentRefs:
           - name: envoy-internal
             namespace: network
@@ -140,14 +140,14 @@ spec:
       s3:
         annotations:
           gatus.home-operations.com/endpoint: |-
-            name: Garage S3 (HA)
+            name: Garage S3
             group: storage
             interval: 1m
             urlPath: /health
             conditions:
               - "[STATUS] >= 200 && [STATUS] < 405"
         hostnames:
-          - garage-ha-s3.00o.sh
+          - garage-s3.00o.sh
         parentRefs:
           - name: envoy-internal
             namespace: network
@@ -159,14 +159,14 @@ spec:
       web:
         annotations:
           gatus.home-operations.com/endpoint: |-
-            name: Garage Bucket Web Access (HA)
+            name: Garage Bucket Web Access
             group: storage
             interval: 1m
             urlPath: /
             conditions:
               - "[STATUS] >= 200 && [STATUS] < 405"
         hostnames:
-          - garage-ha-web.00o.sh
+          - garage-web.00o.sh
         parentRefs:
           - name: envoy-internal
             namespace: network

--- a/kubernetes/apps/volsync-system/garage-ha/webui/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/garage-ha/webui/helmrelease.yaml
@@ -62,7 +62,7 @@ spec:
             name: Garage Portal
             group: storage
         hostnames:
-          - garage-ha.00o.sh
+          - garage.00o.sh
         parentRefs:
           - name: envoy-internal
             namespace: network


### PR DESCRIPTION
## Summary
Final step of the Garage 3-zone migration. Now that the old single-instance garage is gone (#1034), the \`garage-ha-*\` hostnames can shed their disambiguation prefix.

## Hostname changes
| Before | After |
|---|---|
| \`garage-ha-api.00o.sh\` | \`garage-api.00o.sh\` |
| \`garage-ha-s3.00o.sh\` | \`garage-s3.00o.sh\` |
| \`garage-ha-web.00o.sh\` | \`garage-web.00o.sh\` |
| \`garage-ha.00o.sh\` (webui) | \`garage.00o.sh\` |

The Garage config's \`root_domain\` values (\`.garage-s3.00o.sh\` / \`.garage-web.00o.sh\`) already point at the canonical names — this PR brings HTTPRoutes in line with the config. Gatus endpoint names also drop the "(HA)" suffix.

## What's NOT changed
- In-cluster service name remains \`garage-ha-app.volsync-system.svc.cluster.local\` — that's the bjw-s app-template chart's naming and renaming would require a redeploy. Backup consumers (CNPG/MariaDB/Kanidm) use the in-cluster name, so no consumer-side changes needed.

## After merge
- external-dns flips the Cloudflare records for the 4 hostnames
- \`garage-ha-*\` hostnames stop resolving
- \`garage{,-api,-s3,-web}.00o.sh\` resolve to garage-ha pods through envoy-internal

## Test plan
- [ ] CI / flux-local validates
- [ ] After merge + reconcile: \`https://garage.00o.sh\` loads the bucket browser
- [ ] \`https://garage-api.00o.sh/health\` returns 200
- [ ] CNPG / MariaDB / Kanidm backups continue (they use the internal SVC, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)