### PR TITLE
feat(mise): register soupglasses/mise-krew backend

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,6 +2,12 @@
 # Run `mise trust && mise install` to install all tools.
 # Versions are pinned for reproducibility; Renovate updates them automatically.
 
+[plugins]
+# Backend for installing krew kubectl plugins via mise. Pinned to a commit
+# SHA (not the tag) because mise can't fetch annotated tags via `#ref`.
+# renovate: datasource=github-tags depName=soupglasses/mise-krew
+krew = "https://github.com/soupglasses/mise-krew#49c405114856112d2d4cc1eb55eddee0249f5f51" # 2.1.0
+
 [env]
 _.python.venv = { path = "{{config_root}}/.venv", create = true }
 KUBECONFIG = "{{config_root}}/kubeconfig"


### PR DESCRIPTION
## Summary
Adds [\`soupglasses/mise-krew\`](https://github.com/soupglasses/mise-krew) as a mise backend so kubectl plugins can be installed and version-pinned in \`.mise.toml\` alongside the existing aqua / pipx tools.

## Usage after merge
\`\`\`toml
[tools]
"krew:tree"        = "v0.4.6"
"krew:view-secret" = "v1.5.0"
\`\`\`
Then \`mise install\` will install krew itself and the pinned plugins.

No specific plugins added in this PR — pin them as you go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)