### PR TITLE
feat(analytics): PostHog with Strimzi + Altinity ClickHouse + CNPG + Dragonfly + garage-ha

### DIFF
--- a/kubernetes/apps/analytics/kustomization.yaml
+++ b/kubernetes/apps/analytics/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: analytics
+
+components:
+  - ../../components/alerts
+  - ../../components/cluster-secrets
+
+resources:
+  - ./namespace.yaml
+  - ./posthog/ks.yaml

--- a/kubernetes/apps/analytics/namespace.yaml
+++ b/kubernetes/apps/analytics/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: analytics
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/analytics/posthog/app/externalsecret.yaml
+++ b/kubernetes/apps/analytics/posthog/app/externalsecret.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: posthog
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: posthog-secret
+    template:
+      engineVersion: v2
+      data:
+        # Django app secret + recordings encryption keys
+        SECRET_KEY: "{{ .POSTHOG_SECRET }}"
+        ENCRYPTION_SALT_KEYS: "{{ .ENCRYPTION_SALT_KEYS }}"
+        # Postgres connection (CNPG, db + user created by posthog-db-init Job)
+        DATABASE_URL: "postgres://{{ .POSTHOG_POSTGRES_USER }}:{{ urlquery .POSTHOG_POSTGRES_PASSWORD }}@postgres-rw.database.svc.cluster.local:5432/{{ .POSTHOG_POSTGRES_DB }}"
+        # Redis-compatible: cluster Dragonfly
+        REDIS_URL: "redis://dragonfly.database.svc.cluster.local:6379"
+        # Kafka brokers (Strimzi cluster in database namespace)
+        KAFKA_HOSTS: "kafka-kafka-bootstrap.database.svc.cluster.local:9092"
+        # ClickHouse (Altinity installation in database namespace)
+        CLICKHOUSE_HOST: "chi-posthog-posthog-0-0.database.svc.cluster.local"
+        CLICKHOUSE_USER: "posthog"
+        CLICKHOUSE_PASSWORD: "{{ .CLICKHOUSE_PASSWORD }}"
+        CLICKHOUSE_DATABASE: "posthog"
+        # Garage S3 for session recordings + plugin archive
+        OBJECT_STORAGE_ENABLED: "True"
+        OBJECT_STORAGE_ENDPOINT: "http://garage-ha-app.volsync-system.svc.cluster.local:3900"
+        OBJECT_STORAGE_REGION: "USTX01"
+        OBJECT_STORAGE_BUCKET: "posthog"
+        OBJECT_STORAGE_ACCESS_KEY_ID: "{{ .S3_ACCESS_KEY_ID }}"
+        OBJECT_STORAGE_SECRET_ACCESS_KEY: "{{ .S3_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: posthog

--- a/kubernetes/apps/analytics/posthog/app/helmrelease.yaml
+++ b/kubernetes/apps/analytics/posthog/app/helmrelease.yaml
@@ -1,0 +1,177 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app posthog
+spec:
+  interval: 2h
+  chartRef:
+    kind: OCIRepository
+    name: posthog
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+
+    # ── Shared image config across all controllers ───────────────────────
+    # PostHog publishes only SHA-tagged images. Track via Renovate digest
+    # hint below; bump SHA when a release we want to pin to ships.
+    # renovate: datasource=docker depName=posthog/posthog
+    _shared_image: &image
+      # renovate: ignore
+      repository: posthog/posthog
+      # The tag here is a known stable as of writing; update during PRs.
+      tag: "release-1.43.0"
+
+    controllers:
+      # ── Migrations Job — runs once on install/upgrade, blocks rollout ──
+      migrate:
+        type: job
+        annotations:
+          # Run before the long-running pods come up; rerun on chart upgrade.
+          helm.sh/hook: post-install,post-upgrade
+          helm.sh/hook-weight: "-5"
+          helm.sh/hook-delete-policy: before-hook-creation
+        job:
+          backoffLimit: 3
+          ttlSecondsAfterFinished: 86400
+        containers:
+          app:
+            image: *image
+            command: [/bin/bash, -c]
+            args:
+              - |
+                set -e
+                python manage.py migrate
+                python manage.py migrate_clickhouse
+            envFrom: &envFrom
+              - secretRef:
+                  name: posthog-secret
+            env: &env
+              SITE_URL: "https://posthog.${SECRET_DOMAIN}"
+              IS_BEHIND_PROXY: "True"
+              DISABLE_SECURE_SSL_REDIRECT: "False"
+              # PostHog auto-creates Kafka topics on startup if allowed.
+              KAFKA_AUTO_CREATE_TOPICS_ENABLE: "True"
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: [ALL]
+            resources:
+              requests: { cpu: 200m, memory: 512Mi }
+              limits:   { memory: 1Gi }
+
+      # ── Web (capture + UI + admin) ───────────────────────────────────
+      web:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image: *image
+            command: [/bin/bash, -c]
+            args: ["./bin/docker-server"]
+            envFrom: *envFrom
+            env: *env
+            probes:
+              liveness:  &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet: { path: /_health, port: 8000 }
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: [ALL]
+            resources:
+              requests: { cpu: 200m, memory: 512Mi }
+              limits:   { memory: 1Gi }
+
+      # ── Celery worker (background tasks) ──────────────────────────────
+      worker:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image: *image
+            command: [/bin/bash, -c]
+            args: ["./bin/docker-worker"]
+            envFrom: *envFrom
+            env: *env
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: [ALL]
+            resources:
+              requests: { cpu: 200m, memory: 512Mi }
+              limits:   { memory: 1Gi }
+
+      # ── Plugin server (event ingest pipeline; Kafka → CH) ─────────────
+      plugins:
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image: *image
+            command: [/bin/bash, -c]
+            args: ["./bin/plugin-server"]
+            envFrom: *envFrom
+            env: *env
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop: [ALL]
+            resources:
+              requests: { cpu: 200m, memory: 512Mi }
+              limits:   { memory: 1Gi }
+
+    service:
+      web:
+        controller: web
+        ports:
+          http:
+            port: &port 8000
+
+    route:
+      web:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            name: PostHog
+            group: analytics
+            interval: 1m
+            urlPath: /_health
+            conditions:
+              - "[STATUS] == 200"
+        hostnames:
+          - posthog.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: web
+                port: *port

--- a/kubernetes/apps/analytics/posthog/app/kustomization.yaml
+++ b/kubernetes/apps/analytics/posthog/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/analytics/posthog/app/ocirepository.yaml
+++ b/kubernetes/apps/analytics/posthog/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: posthog
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/analytics/posthog/bucket-init/bucket-init.yaml
+++ b/kubernetes/apps/analytics/posthog/bucket-init/bucket-init.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: posthog-bucket-init
+  labels:
+    app.kubernetes.io/name: posthog-bucket-init
+spec:
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: posthog-bucket-init
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: init
+          # renovate: datasource=docker depName=amazon/aws-cli
+          image: amazon/aws-cli:2.34.53@sha256:cf53765c0de54ad3a8ea21818f1c4c845a8cf7ca87831c078a00fef244031493
+          envFrom:
+            - secretRef:
+                name: posthog-s3
+          env:
+            - name: AWS_REGION
+              value: USTX01
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          command: [/bin/sh, -c]
+          args:
+            - |
+              aws --endpoint-url http://garage-ha-app.volsync-system.svc.cluster.local:3900 \
+                s3api head-bucket --bucket posthog 2>/dev/null && \
+                echo "Bucket posthog already exists" && exit 0
+              aws --endpoint-url http://garage-ha-app.volsync-system.svc.cluster.local:3900 \
+                s3 mb s3://posthog && \
+                echo "Bucket posthog created successfully"

--- a/kubernetes/apps/analytics/posthog/bucket-init/externalsecret.yaml
+++ b/kubernetes/apps/analytics/posthog/bucket-init/externalsecret.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: posthog-s3
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: posthog-s3
+    template:
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .S3_ACCESS_KEY_ID }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .S3_SECRET_ACCESS_KEY }}"
+  dataFrom:
+    - extract:
+        key: posthog

--- a/kubernetes/apps/analytics/posthog/bucket-init/kustomization.yaml
+++ b/kubernetes/apps/analytics/posthog/bucket-init/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./bucket-init.yaml

--- a/kubernetes/apps/analytics/posthog/db-init/db-init.yaml
+++ b/kubernetes/apps/analytics/posthog/db-init/db-init.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: posthog-db-init
+  labels:
+    app.kubernetes.io/name: posthog-db-init
+spec:
+  backoffLimit: 5
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: posthog-db-init
+    spec:
+      restartPolicy: OnFailure
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: init-db
+          image: ghcr.io/home-operations/postgres-init:18@sha256:5086f94abc783f1147d7c2a32c01db00ab594820026e4f6a82ac2af3dbde7fc7
+          envFrom:
+            - secretRef:
+                name: posthog-db-init
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]

--- a/kubernetes/apps/analytics/posthog/db-init/externalsecret.yaml
+++ b/kubernetes/apps/analytics/posthog/db-init/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: posthog-db-init
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: posthog-db-init
+    template:
+      data:
+        INIT_POSTGRES_HOST: postgres-rw.database.svc.cluster.local
+        INIT_POSTGRES_PORT: "5432"
+        INIT_POSTGRES_DBNAME: "{{ .POSTHOG_POSTGRES_DB }}"
+        INIT_POSTGRES_USER: "{{ .POSTHOG_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .POSTHOG_POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: posthog

--- a/kubernetes/apps/analytics/posthog/db-init/kustomization.yaml
+++ b/kubernetes/apps/analytics/posthog/db-init/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./db-init.yaml

--- a/kubernetes/apps/analytics/posthog/ks.yaml
+++ b/kubernetes/apps/analytics/posthog/ks.yaml
@@ -1,0 +1,89 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: posthog-bucket-init
+  namespace: analytics
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: posthog-bucket-init
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+    - name: garage-ha
+      namespace: volsync-system
+  interval: 1h
+  path: ./kubernetes/apps/analytics/posthog/bucket-init
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: analytics
+  timeout: 5m
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: posthog-db-init
+  namespace: analytics
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: posthog-db-init
+  dependsOn:
+    - name: onepassword
+      namespace: external-secrets
+    - name: postgres-cluster
+      namespace: database
+  interval: 1h
+  path: ./kubernetes/apps/analytics/posthog/db-init
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: analytics
+  timeout: 5m
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: posthog
+  namespace: analytics
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: posthog
+  dependsOn:
+    - name: posthog-bucket-init
+    - name: posthog-db-init
+    - name: kafka
+      namespace: database
+    - name: clickhouse-cluster
+      namespace: database
+    - name: dragonfly
+      namespace: database
+  interval: 1h
+  path: ./kubernetes/apps/analytics/posthog/app
+  postBuild:
+    substituteFrom:
+      - kind: Secret
+        name: cluster-secrets
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: analytics
+  timeout: 15m
+  wait: false

--- a/kubernetes/apps/database/clickhouse/app/helmrelease.yaml
+++ b/kubernetes/apps/database/clickhouse/app/helmrelease.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: altinity-clickhouse-operator
+spec:
+  interval: 1h
+  chart:
+    spec:
+      # renovate: datasource=helm depName=altinity-clickhouse-operator
+      chart: altinity-clickhouse-operator
+      version: 0.27.0
+      sourceRef:
+        kind: HelmRepository
+        name: altinity-clickhouse-operator
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    crdHook:
+      enabled: true
+    operator:
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 256Mi
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true

--- a/kubernetes/apps/database/clickhouse/app/helmrepository.yaml
+++ b/kubernetes/apps/database/clickhouse/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: altinity-clickhouse-operator
+spec:
+  interval: 1h
+  url: https://docs.altinity.com/clickhouse-operator

--- a/kubernetes/apps/database/clickhouse/app/kustomization.yaml
+++ b/kubernetes/apps/database/clickhouse/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/database/clickhouse/cluster/externalsecret.yaml
+++ b/kubernetes/apps/database/clickhouse/cluster/externalsecret.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: clickhouse-posthog
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: clickhouse-posthog
+    template:
+      data:
+        password: "{{ .CLICKHOUSE_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: clickhouse-posthog

--- a/kubernetes/apps/database/clickhouse/cluster/installation.yaml
+++ b/kubernetes/apps/database/clickhouse/cluster/installation.yaml
@@ -1,0 +1,65 @@
+---
+# Single-replica ClickHouse for PostHog OLAP backend. Backed by openebs-hostpath
+# on whichever node it lands. Can scale to a sharded/replicated cluster later
+# when event volume warrants it; the operator supports online reshape.
+apiVersion: clickhouse.altinity.com/v1
+kind: ClickHouseInstallation
+metadata:
+  name: posthog
+spec:
+  configuration:
+    users:
+      # Plaintext-from-secret pattern — operator hashes before persisting to ZK.
+      posthog/password:
+        valueFrom:
+          secretKeyRef:
+            name: clickhouse-posthog
+            key: password
+      posthog/networks/ip: "::/0"
+      posthog/profile: default
+      posthog/quota: default
+    clusters:
+      - name: posthog
+        layout:
+          shardsCount: 1
+          replicasCount: 1
+        templates:
+          podTemplate: clickhouse
+          dataVolumeClaimTemplate: data
+  defaults:
+    templates:
+      podTemplate: clickhouse
+      dataVolumeClaimTemplate: data
+  templates:
+    podTemplates:
+      - name: clickhouse
+        spec:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
+            fsGroup: 101
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: clickhouse
+              image: clickhouse/clickhouse-server:25.3
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: false
+                capabilities:
+                  drop: [ALL]
+              resources:
+                requests:
+                  cpu: 500m
+                  memory: 1Gi
+                limits:
+                  memory: 3Gi
+    volumeClaimTemplates:
+      - name: data
+        spec:
+          accessModes: [ReadWriteOnce]
+          storageClassName: openebs-hostpath
+          resources:
+            requests:
+              storage: 50Gi

--- a/kubernetes/apps/database/clickhouse/cluster/kustomization.yaml
+++ b/kubernetes/apps/database/clickhouse/cluster/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./installation.yaml

--- a/kubernetes/apps/database/clickhouse/ks.yaml
+++ b/kubernetes/apps/database/clickhouse/ks.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: clickhouse-operator
+  namespace: database
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: clickhouse-operator
+  interval: 1h
+  path: ./kubernetes/apps/database/clickhouse/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  timeout: 5m
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: clickhouse-cluster
+  namespace: database
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: clickhouse-cluster
+  dependsOn:
+    - name: clickhouse-operator
+  interval: 1h
+  path: ./kubernetes/apps/database/clickhouse/cluster
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  timeout: 10m
+  wait: false

--- a/kubernetes/apps/database/kafka/app/kafka.yaml
+++ b/kubernetes/apps/database/kafka/app/kafka.yaml
@@ -1,0 +1,74 @@
+---
+# Strimzi Kafka cluster running in KRaft mode (no ZooKeeper). Single
+# controller+broker pool, 3 nodes, one per cluster node via anti-affinity.
+# Topics created on demand by consumers; defaults RF=3 / minISR=2 so
+# losing one node doesn't break writes.
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: dual
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  replicas: 3
+  roles:
+    - controller
+    - broker
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 20Gi
+        class: openebs-hostpath
+        deleteClaim: false
+  resources:
+    requests:
+      cpu: 200m
+      memory: 768Mi
+    limits:
+      memory: 1500Mi
+  template:
+    pod:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  strimzi.io/cluster: kafka
+              topologyKey: kubernetes.io/hostname
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: Kafka
+metadata:
+  name: kafka
+  annotations:
+    strimzi.io/node-pools: enabled
+    strimzi.io/kraft: enabled
+spec:
+  kafka:
+    version: 4.0.0
+    metadataVersion: 4.0-IV3
+    listeners:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+    config:
+      offsets.topic.replication.factor: 3
+      transaction.state.log.replication.factor: 3
+      transaction.state.log.min.isr: 2
+      default.replication.factor: 3
+      min.insync.replicas: 2
+      auto.create.topics.enable: "true"
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: kafka-metrics
+          key: kafka-metrics-config.yml
+  # entityOperator: handles KafkaTopic / KafkaUser CRDs if anything
+  # wants to manage topics declaratively later.
+  entityOperator:
+    topicOperator: {}
+    userOperator: {}

--- a/kubernetes/apps/database/kafka/app/kustomization.yaml
+++ b/kubernetes/apps/database/kafka/app/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./kafka.yaml
+configMapGenerator:
+  - name: kafka-metrics
+    files:
+      - kafka-metrics-config.yml=./resources/kafka-metrics-config.yml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kubernetes/apps/database/kafka/app/resources/kafka-metrics-config.yml
+++ b/kubernetes/apps/database/kafka/app/resources/kafka-metrics-config.yml
@@ -1,0 +1,20 @@
+# JMX Prometheus exporter config — Strimzi default-ish set
+lowercaseOutputName: true
+rules:
+  - pattern: kafka.server<type=(.+), name=(.+)PerSec\w*, topic=(.+)><>Count
+    name: kafka_server_$1_$2_total
+    type: COUNTER
+    labels:
+      topic: "$3"
+  - pattern: kafka.server<type=(.+), name=(.+)PerSec\w*><>Count
+    name: kafka_server_$1_$2_total
+    type: COUNTER
+  - pattern: kafka.controller<type=(.+), name=(.+)><>(Count|Value)
+    name: kafka_controller_$1_$2
+    type: GAUGE
+  - pattern: kafka.network<type=(.+), name=(.+)><>Count
+    name: kafka_network_$1_$2_total
+    type: COUNTER
+  - pattern: kafka.network<type=(.+), name=(.+)><>Value
+    name: kafka_network_$1_$2
+    type: GAUGE

--- a/kubernetes/apps/database/kafka/ks.yaml
+++ b/kubernetes/apps/database/kafka/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kafka
+  namespace: database
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: kafka
+  dependsOn:
+    - name: strimzi-kafka-operator
+  interval: 1h
+  path: ./kubernetes/apps/database/kafka/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  timeout: 10m
+  wait: false

--- a/kubernetes/apps/database/kustomization.yaml
+++ b/kubernetes/apps/database/kustomization.yaml
@@ -13,3 +13,6 @@ resources:
   - ./dbgate/ks.yaml
   - ./dragonfly/ks.yaml
   - ./mariadb-operator/ks.yaml
+  - ./strimzi-kafka-operator/ks.yaml
+  - ./kafka/ks.yaml
+  - ./clickhouse/ks.yaml

--- a/kubernetes/apps/database/strimzi-kafka-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/database/strimzi-kafka-operator/app/helmrelease.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: strimzi-kafka-operator
+spec:
+  interval: 1h
+  chart:
+    spec:
+      # renovate: datasource=helm depName=strimzi-kafka-operator
+      chart: strimzi-kafka-operator
+      version: 1.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: strimzi
+  install:
+    remediation:
+      retries: 3
+    crds: CreateReplace
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+    crds: CreateReplace
+  values:
+    # Watch Kafka custom resources across all namespaces so consumers
+    # (e.g., analytics/posthog) can reference Kafka clusters living here.
+    watchAnyNamespace: true
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        memory: 512Mi
+    nodeSelector: {}

--- a/kubernetes/apps/database/strimzi-kafka-operator/app/helmrepository.yaml
+++ b/kubernetes/apps/database/strimzi-kafka-operator/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: strimzi
+spec:
+  interval: 1h
+  url: https://strimzi.io/charts

--- a/kubernetes/apps/database/strimzi-kafka-operator/app/kustomization.yaml
+++ b/kubernetes/apps/database/strimzi-kafka-operator/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/database/strimzi-kafka-operator/ks.yaml
+++ b/kubernetes/apps/database/strimzi-kafka-operator/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: strimzi-kafka-operator
+  namespace: database
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: strimzi-kafka-operator
+  interval: 1h
+  path: ./kubernetes/apps/database/strimzi-kafka-operator/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: database
+  timeout: 5m
+  wait: true


### PR DESCRIPTION
## Summary
Self-hosted PostHog (product analytics + session replay), wired to cluster shared infra instead of the stale official chart.

## What lands in this PR

### Shared infrastructure (`database/`)

| | What |
|---|---|
| `strimzi-kafka-operator/` | Strimzi 1.0.0, watches all namespaces |
| `kafka/` | Strimzi Kafka 4.0, **KRaft mode** (no ZooKeeper), 3-node KafkaNodePool, anti-affinity, RF=3/minISR=2 |
| `clickhouse/app/` | Altinity clickhouse-operator 0.27.0 |
| `clickhouse/cluster/` | `ClickHouseInstallation` `posthog`: single replica, CH 25.3, 50 GiB hostpath |

### Application (`analytics/`)

| | What |
|---|---|
| `namespace.yaml` | new `analytics` namespace |
| `posthog/bucket-init/` | Job creates `posthog` bucket on garage-ha |
| `posthog/db-init/` | Job runs `postgres-init` against CNPG to create posthog db + user |
| `posthog/app/` | bjw-s app-template HelmRelease — `web` + `worker` + `plugins` controllers + post-install migrations Job, all from `posthog/posthog` image. Web at `posthog.${SECRET_DOMAIN}` |

### Connections (no per-app duplicate infrastructure)

- Postgres → cluster CNPG (`postgres-rw.database.svc`)
- Redis → cluster Dragonfly (`dragonfly.database.svc`, Redis-compatible)
- Kafka → in-cluster Strimzi (`kafka-kafka-bootstrap.database.svc`)
- ClickHouse → in-cluster Altinity (`chi-posthog-posthog-0-0.database.svc`)
- S3 → garage-ha (`garage-ha-app.volsync-system.svc`, bucket `posthog`)

## Required 1Password items (before merge)

- **`posthog`**: `POSTHOG_SECRET`, `ENCRYPTION_SALT_KEYS`, `POSTGRES_SUPER_PASS`, `POSTHOG_POSTGRES_{DB,USER,PASSWORD}`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, `CLICKHOUSE_PASSWORD`
- **`clickhouse-posthog`**: `CLICKHOUSE_PASSWORD` (same value)

## Notes / known follow-ups

- PostHog image tag in `helmrelease.yaml` is `release-1.43.0` — PostHog only publishes SHA-tagged images otherwise. Bumping is manual; Renovate hint marked `ignore`. Worth revisiting once PostHog adopts semver.
- ClickHouse is single-replica for now. The Altinity operator supports online reshape to sharded/replicated when event volume warrants.
- Anti-affinity puts the 3 Kafka brokers on 3 distinct nodes — same pattern as garage-ha. Survives single-node loss with no write impact.
- `auto.create.topics.enable: true` lets PostHog create topics on first start. Can tighten later by pre-creating `KafkaTopic` resources.

## Test plan

- [ ] CI / flux-local validates the full tree
- [ ] After merge + 1Password items exist: Strimzi operator + Kafka pods Ready
- [ ] ClickHouseInstallation reports Ready, `chi-posthog-posthog-0-0` pod 1/1
- [ ] posthog-bucket-init + posthog-db-init Jobs both Complete
- [ ] PostHog migrate Job completes, web/worker/plugins pods 1/1
- [ ] `https://posthog.${SECRET_DOMAIN}/_health` returns 200
- [ ] Generate a test event from a browser SDK; verify it lands in ClickHouse via the PostHog UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)