### PR TITLE
fix(database): bucket-init Kustomizations depend on garage-ha (not garage)

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -43,7 +43,7 @@ spec:
     - name: cloudnative-pg
     - name: onepassword
       namespace: external-secrets
-    - name: garage
+    - name: garage-ha
       namespace: volsync-system
   interval: 1h
   path: ./kubernetes/apps/database/cloudnative-pg/bucket-init

--- a/kubernetes/apps/database/mariadb-operator/ks.yaml
+++ b/kubernetes/apps/database/mariadb-operator/ks.yaml
@@ -25,7 +25,7 @@ spec:
     - name: mariadb-operator
     - name: onepassword
       namespace: external-secrets
-    - name: garage
+    - name: garage-ha
       namespace: volsync-system
   interval: 1h
   path: ./kubernetes/apps/database/mariadb-operator/bucket-init


### PR DESCRIPTION
## Problem
After #1034 deleted the old single-instance \`garage\` Flux Kustomization in volsync-system, two stale references survived in dependsOn lists:

\`\`\`
database/cnpg-bucket-init     dependency 'volsync-system/garage' not found
database/mariadb-bucket-init  dependency 'volsync-system/garage' not found
\`\`\`

These bucket-init Jobs are blocked from reconciling until the dependency exists. The buckets themselves are fine (they already exist on garage-ha), but Flux thinks the Kustomization is not Ready.

## Fix
Repoint both dependsOn entries from \`garage\` → \`garage-ha\`.

## Test plan
- [ ] CI / flux-local validates
- [ ] After merge, both \`cnpg-bucket-init\` and \`mariadb-bucket-init\` go from Failed to True
- [ ] Downstream Kustomizations (\`postgres-cluster\`, \`mariadb-cluster\`) unblock if they were waiting

🤖 Generated with [Claude Code](https://claude.com/claude-code)